### PR TITLE
feat(repo): add admin ops foundation [#75]

### DIFF
--- a/docs/Tech_Spec/Admin_Ops_Foundation_Plan.md
+++ b/docs/Tech_Spec/Admin_Ops_Foundation_Plan.md
@@ -1,0 +1,404 @@
+# Admin Ops Foundation PLAN
+
+> `docs/Tech_Spec/feedback_loop_&_admin_ops` 아래 컴포넌트 구현을 시작하기 전에 공유 DB schema, 상태값, 메시지 계약, API 골격을 먼저 고정하기 위한 실행 문서.
+> 이 문서는 각 컴포넌트의 전체 구현 계획이 아니라 후속 브랜치가 재정의하지 않아야 하는 foundation 작업만 다룬다.
+
+**메타 정보**
+- Component ID: `admin-ops-foundation`
+- SOT: `docs/system-design.md`
+- Target SPEC:
+  - `docs/Tech_Spec/feedback_loop_&_admin_ops/Feedback_Ingestion_Pipeline_Spec.md`
+  - `docs/Tech_Spec/feedback_loop_&_admin_ops/Admin_Control_Plane_Spec.md`
+  - `docs/Tech_Spec/feedback_loop_&_admin_ops/ML_Pipeline_Execution_Spec.md`
+  - `docs/Tech_Spec/feedback_loop_&_admin_ops/Model_Release_and_Reindex_Spec.md`
+- 관련 문서:
+  - `docs/Tech_Spec/upload_search_Service/Core_Api_Server_Spec.md`
+  - `docs/Tech_Spec/upload_search_Service/Search_Service_Spec.md`
+  - `docs/Tech_Spec/upload_search_Service/Pipeline_Worker_Spec.md`
+  - `docs/Tech_Spec/upload_search_Service/Managed_Embedding_Endpoint_Spec.md`
+- Plan 상태: Draft
+
+---
+
+## 1. 구현 의도
+
+### 1.1 전달 목표
+- 후속 구현 브랜치들이 같은 Metadata DB schema와 상태값을 공유한다.
+- Feedback, Admin, ML Pipeline, Model Release 구현이 같은 message contract를 사용한다.
+- Core API, Search Service, Pipeline Worker가 새 shared contract를 읽거나 발행할 수 있는 최소 골격을 가진다.
+- 실제 feedback ingestion, ML training, release/cutover, rollback 실행은 후속 브랜치에서 구현한다.
+
+### 1.2 이번 구현의 범위
+
+이번 plan에 포함:
+- Core API Alembic migration 추가
+  - `Project.search_serving_state`
+  - `SearchResponseSnapshot`
+  - `MLPipelineRun`
+  - `ModelEvaluation`
+  - `ModelRelease`
+- Core API ORM/read-write model 추가 또는 확장
+- Search Service와 Pipeline Worker의 read model 정렬
+- video-processing envelope와 분리된 control-message schema 추가
+- feedback event schema 추가
+- Core API `feedbacks` / `admin` router wiring 골격 추가
+- feedback/admin/model-release repository 및 service 골격 추가
+- foundation contract를 검증하는 최소 자동화 테스트 추가
+
+명시적 제외 / 후속 phase:
+- `POST /api/v1/feedbacks`의 전체 validation/publish flow 완성
+- Feedback Ingestion Pipeline consumer와 raw log Object Storage sink 구현
+- 학습 dataset generation, training, evaluation 실행 구현
+- candidate reindex, cutover, rollback restore 구현
+- Managed Embedding Endpoint readiness 연동 구현
+- Admin API action의 전체 비즈니스 로직 구현
+
+### 1.3 전제조건과 blocker
+- 이미 고정된 spec contract:
+  - `SearchResponseSnapshot`은 Search Service가 생성하고 Metadata DB에 TTL 기반으로 저장한다.
+  - Feedback raw event는 Object Storage append-only log가 최종 원본이다.
+  - `TRAINING_REQUEST`와 `ROLLBACK_REQUEST`는 `video_id` 없는 control-message schema를 사용한다.
+  - Search serving gate는 `Project.search_serving_state=SERVABLE`이고 프로젝트 내부 모든 영상이 `READY`인 프로젝트만 검색 가능 대상으로 본다.
+  - `ModelRelease`는 active/previous/candidate/rollback snapshot serving 상태의 SOT다.
+- 필요한 upstream work / dependency:
+  - 기존 Core API migration chain `0003_pgvector_vector_index_entry` 이후 새 migration을 추가한다.
+  - 각 서비스의 SQLAlchemy model은 동일 테이블 계약을 서로 다르게 해석하지 않아야 한다.
+- 구현을 막는 open question:
+  - `ModelRelease`의 최초 row bootstrap을 migration seed로 둘지, service startup에서 lazy initialize할지 후속 구현 전에 결정해야 한다.
+  - `SearchResponseSnapshot` TTL cleanup을 DB job, application cleanup, 운영 task 중 어디에 둘지는 후속 Search Service 구현에서 확정한다.
+  - shared Python package가 없는 현재 구조에서 enum/message schema 중복을 어디까지 허용할지 결정이 필요하다. foundation에서는 서비스별 최소 중복을 작게 유지하고 이름/값을 테스트로 고정한다.
+
+### 1.4 구현 전략
+- 전체 접근:
+  - 먼저 DB와 message contract를 고정하고, 그 다음 서비스별 read/write model과 router/service 골격을 맞춘다.
+- 핵심 기술 작업 단위:
+  - Core API가 Metadata DB schema owner 역할을 하므로 Alembic migration은 Core API에 둔다.
+  - Search Service와 Pipeline Worker는 같은 DB table을 읽는 모델을 추가하되, schema 생성 책임은 갖지 않는다.
+  - `TRAINING_REQUEST` / `ROLLBACK_REQUEST`는 기존 `BrokerMessage` 또는 `MessageEnvelope`에 억지로 끼우지 않고 별도 control message 타입으로 분리한다.
+- 리스크 감소 전략:
+  - 후속 구현 전에 migration, enum 값, message payload shape, router wiring을 작은 테스트로 먼저 잠근다.
+  - 실제 domain transition은 skeleton에서 수행하지 않는다.
+- 병합 전략:
+  - 단일 foundation PR로 merge한다.
+  - 후속 PR은 feedback ingestion, ML lifecycle/release, admin control 순서로 foundation 위에서 분기한다.
+- Spec 추적 기준:
+  - `docs/system-design.md` §3.1, §3.6, §3.7, §3.8, §3.11, §3.12, §3.13
+  - Feedback Ingestion Pipeline Spec §2.1-2.3
+  - Admin Control Plane Spec §2.1-2.3
+  - ML Pipeline Execution Spec §2.1-2.3
+  - Model Release and Reindex Spec §2.1-2.3
+
+---
+
+## 2. Workstream과 순서
+
+### 2.1 권장 순서
+
+| 순서 | Workstream | 연결 SPEC | 지금 먼저 하는 이유 | 의존성 |
+| --- | --- | --- | --- | --- |
+| 1 | Shared DB schema | system-design §3, all feedback/admin/ML specs §2.2 | 후속 구현의 SOT를 먼저 고정한다 | 기존 Core API migration chain |
+| 2 | Shared constants and message schemas | system-design §3.13, Admin §2.1, ML §2.1, Release §2.1 | consumer/producer가 같은 payload shape를 보게 한다 | Workstream 1 naming decisions |
+| 3 | Service read/write models | Search / Pipeline / Core API related specs | 각 서비스가 새 schema를 같은 의미로 읽게 한다 | Workstream 1 |
+| 4 | Core API router and service skeletons | Feedback §2.1, Admin §2.1 | 후속 브랜치의 endpoint ownership과 wiring을 고정한다 | Workstream 2-3 |
+| 5 | Contract verification | all acceptance criteria anchors | foundation이 후속 브랜치의 계약으로 쓸 수 있음을 증명한다 | Workstream 1-4 |
+
+### 2.2 Workstream 상세
+
+#### Workstream: Shared DB Schema
+- 목표:
+  - Feedback/Admin/ML 운영에 필요한 Metadata DB 구조를 Core API migration으로 추가한다.
+- 연결 SPEC:
+  - system-design §3.1, §3.7, §3.8, §3.11, §3.12
+  - Admin Control Plane Spec §2.2
+  - ML Pipeline Execution Spec §2.2
+  - Model Release and Reindex Spec §2.2
+- 주요 변경:
+  - `project.search_serving_state` column 추가 또는 기존 `Project` schema와 정렬
+  - `search_response_snapshot` table 추가
+  - `ml_pipeline_run` table 추가
+  - `model_evaluation` table 추가
+  - `model_release` table 추가
+  - 상태값 check constraint와 조회용 index 추가
+- 영향 가능성이 높은 파일 / 영역:
+  - `services/core-api/alembic/versions/0004_admin_ops_foundation.py`
+  - `services/core-api/src/models/video.py`
+  - `services/core-api/src/models/admin_ops.py`
+- 의존성 / 연동 지점:
+  - Search Service read-only models
+  - Pipeline Worker DB models
+  - Admin repository query paths
+- 완료 조건:
+  - 기존 schema에서 upgrade가 가능하다.
+  - downgrade가 foundation schema를 제거하거나 원복할 수 있다.
+  - `Project.search_serving_state` 기본값은 `SERVABLE`이다.
+- 검증:
+  - Alembic upgrade test 또는 schema integration test
+  - SQLAlchemy model metadata smoke test
+
+#### Workstream: Shared Constants and Message Schemas
+- 목표:
+  - 서비스들이 같은 상태값과 message payload shape를 사용하도록 최소 계약을 고정한다.
+- 연결 SPEC:
+  - system-design §3.13
+  - Feedback Ingestion Pipeline Spec §2.1
+  - Admin Control Plane Spec §2.1
+  - ML Pipeline Execution Spec §2.1
+  - Model Release and Reindex Spec §2.1
+- 주요 변경:
+  - Project serving state 값 정의: `SERVABLE`, `ROLLBACK_EXCLUDED`
+  - Release status 값 정의: `STABLE`, `CANDIDATE_REINDEXING`, `ROLLBACK_PREPARING`
+  - ML run status 값 정의: `PENDING`, `RUNNING`, `READY_FOR_RELEASE`, `FAILED`, `SUPERSEDED`
+  - Control message schema 추가: `TRAINING_REQUEST`, `ROLLBACK_REQUEST`
+  - Feedback event schema 추가: `schema_version=1`
+- 영향 가능성이 높은 파일 / 영역:
+  - `services/core-api/src/infra/broker.py`
+  - `services/core-api/src/schemas/feedback_dto.py`
+  - `services/core-api/src/schemas/admin_ops.py`
+  - `services/pipeline-worker/src/schemas/messages.py`
+- 의존성 / 연동 지점:
+  - PGMQ publish path
+  - In-memory broker test double
+  - Pipeline Worker consumer dispatch
+- 완료 조건:
+  - Video-processing message는 계속 `video_id`를 요구한다.
+  - Control message는 `video_id` 없이 직렬화/검증된다.
+  - Feedback event는 spec의 필수 문맥 필드를 표현한다.
+- 검증:
+  - broker/message unit tests
+  - Pydantic validation tests
+
+#### Workstream: Service Read and Write Models
+- 목표:
+  - Core API, Search Service, Pipeline Worker가 새 shared schema를 같은 의미로 읽고 쓸 수 있게 한다.
+- 연결 SPEC:
+  - Search Service serving gate: Model Release and Reindex Spec §2.2-2.3
+  - Pipeline Worker dual-write/rollback hooks: Model Release and Reindex Spec §2.1-2.3
+  - Admin state read: Admin Control Plane Spec §2.1-2.2
+- 주요 변경:
+  - Search Service `ProjectModel.search_serving_state` 추가
+  - Search Service `SearchResponseSnapshot` model 또는 repository skeleton 추가
+  - Pipeline Worker `VideoModel.project_id`와 release 관련 read model 정렬
+  - Pipeline Worker `MLPipelineRun`, `ModelEvaluation`, `ModelRelease` model 추가
+  - Core API repository에서 admin 조회용 projection을 읽을 수 있게 준비
+- 영향 가능성이 높은 파일 / 영역:
+  - `services/search-service/src/infra/db/models.py`
+  - `services/search-service/src/infra/db/search_repository.py`
+  - `services/pipeline-worker/src/infra/db/models.py`
+  - `services/core-api/src/infra/db/admin_repository.py`
+  - `services/core-api/src/infra/db/model_release_repository.py`
+- 의존성 / 연동 지점:
+  - Existing `video`, `chunk`, `vector_index_entry` model fields
+  - Search result snapshot write timing
+  - Pipeline Worker process/delete flows
+- 완료 조건:
+  - Search Service query가 `Project.search_serving_state=SERVABLE`과 프로젝트 내부 all-or-nothing readiness를 기준으로 gate를 적용할 수 있다.
+  - Pipeline Worker can parse control messages without requiring `video_id`.
+  - Admin repository skeleton can query `Video`, `MLPipelineRun`, `ModelRelease`.
+- 검증:
+  - Search repository integration test for project-level `ROLLBACK_EXCLUDED` exclusion
+  - Pipeline Worker message schema unit test
+  - Core API repository smoke test
+
+#### Workstream: Core API Router and Service Skeletons
+- 목표:
+  - Feedback/Admin endpoint ownership과 DI wiring을 고정한다.
+- 연결 SPEC:
+  - Feedback Ingestion Pipeline Spec §2.1
+  - Admin Control Plane Spec §2.1-2.3
+- 주요 변경:
+  - `feedbacks` router 추가
+  - `admin` router 추가
+  - `api/v1/router.py` include wiring 추가
+  - `FeedbackService`, `AdminService` skeleton 추가
+  - `FeedbackRepository`, `AdminRepository`, `ModelReleaseRepository` skeleton 추가
+- 영향 가능성이 높은 파일 / 영역:
+  - `services/core-api/src/api/v1/routers/feedbacks.py`
+  - `services/core-api/src/api/v1/routers/admin.py`
+  - `services/core-api/src/api/v1/router.py`
+  - `services/core-api/src/services/feedback_service.py`
+  - `services/core-api/src/services/admin_service.py`
+- 의존성 / 연동 지점:
+  - `get_current_user`
+  - admin role dependency to be completed in admin branch
+  - broker client for control message publish
+- 완료 조건:
+  - API router wiring imports cleanly.
+  - Skeletons do not claim unimplemented business behavior.
+  - FastAPI dependencies use `Annotated[..., Depends(...)]`.
+- 검증:
+  - Core API route import/unit smoke test
+  - Existing Core API tests still pass
+
+#### Workstream: Contract Verification
+- 목표:
+  - foundation이 후속 브랜치의 stable base로 쓸 수 있음을 자동화된 최소 증거로 남긴다.
+- 연결 SPEC:
+  - All target specs §4 acceptance criteria에서 foundation이 선행해야 하는 contract pieces
+- 주요 변경:
+  - Migration/schema smoke tests
+  - Message schema tests
+  - Search gate readiness test
+  - Router wiring test
+- 영향 가능성이 높은 파일 / 영역:
+  - `services/core-api/tests/integration/test_admin_ops_foundation_schema.py`
+  - `services/core-api/tests/unit/test_broker.py`
+  - `services/pipeline-worker/tests/unit/test_message_schemas.py`
+  - `services/search-service/tests/integration/test_search_repository.py`
+- 의존성 / 연동 지점:
+  - Existing service `.venv` / Poetry setup
+  - Test DB support in existing test fixtures
+- 완료 조건:
+  - Foundation-specific tests pass.
+  - Existing affected service tests pass or documented blocker is recorded.
+- 검증:
+  - Service-level pytest commands listed in §3.5
+
+### 2.3 병렬화와 병합 지점
+- 안전하게 병렬화 가능한 작업:
+  - Message schema tests can proceed in parallel with DB migration after enum names are fixed.
+  - Core API router skeleton can proceed after repository interface names are fixed.
+- 공유 연동 지점 / 충돌 가능 영역:
+  - `services/core-api/src/infra/broker.py`
+  - `services/pipeline-worker/src/schemas/messages.py`
+  - `services/search-service/src/infra/db/search_repository.py`
+  - `services/core-api/src/api/v1/router.py`
+- 최종 통합 checkpoint:
+  - Run migration/schema tests first.
+  - Then run message schema tests.
+  - Then run service route/repository tests.
+  - Finally review all changed Python files against `AGENTS.md` Sonar rules.
+
+---
+
+## 3. 검증 및 테스트 전략
+
+### 3.1 리스크 기반 테스트 초점
+
+| Spec ref | 리스크 / 비즈니스 규칙 | 중요한 이유 | 권장 test level | 계획된 증명 |
+| --- | --- | --- | --- | --- |
+| system-design §3.1, Release §2.2 | `Project.search_serving_state` default/check constraint drift | Rollback 중 검색 제외 계약이 깨진다 | Integration | 새 column 기본값과 허용값을 schema test로 확인 |
+| system-design §3.13 | control message가 `video_id` 필수 envelope에 섞임 | ML/rollback 요청이 spec과 다른 payload가 된다 | Unit | `TRAINING_REQUEST` / `ROLLBACK_REQUEST` validation에 `video_id`가 없음을 확인 |
+| Release §2.3 | Search Service가 `ROLLBACK_EXCLUDED` 프로젝트를 검색 가능하게 취급 | rollback 복구 중 문제 데이터가 노출된다 | Integration | search repository gate가 project-level serving state와 project readiness를 적용함을 확인 |
+| Admin §2.2 | Admin read path가 필요한 SOT fields를 조회하지 못함 | 대시보드와 후속 admin action precondition이 불가능하다 | Unit/Integration | repository projection에 required nullable fields가 존재함을 확인 |
+| ML §2.3 | `MLPipelineRun` 상태값 drift | 활성 실행/대기 실행 규칙 구현이 흔들린다 | Integration | status check constraint 또는 model enum test로 허용값 고정 |
+
+### 3.2 계획된 자동화 테스트
+
+| Spec ref / acceptance criterion | 시나리오 / 규칙 | Test level | 이 level을 쓰는 이유 | 관찰 가능한 증명 |
+| --- | --- | --- | --- | --- |
+| system-design §3.1 | new `Project` row has `search_serving_state=SERVABLE` | Integration | DB default와 ORM mapping이 모두 관여한다 | inserted row의 field 값 확인 |
+| system-design §3.13 | control messages serialize without `video_id` | Unit | 순수 schema 계약이다 | payload keys가 정확히 일치 |
+| Release §2.3 | Search gate excludes `ROLLBACK_EXCLUDED` project | Integration | repository SQL이 계약을 강제해야 한다 | excluded project의 chunk가 반환되지 않음 |
+| Feedback §2.1-2.2 | feedback event schema preserves snapshot context fields | Unit | Pydantic schema shape 검증이면 충분하다 | required fields validation |
+| Admin §2.1 | admin router is included under `/api/v1/admin` | Unit/API smoke | FastAPI wiring 회귀를 막는다 | route list 또는 test client smoke |
+
+### 3.3 자동화 테스트로 다루지 않는 항목
+
+| Spec ref / rule | 자동화하지 않는 이유 | 수동 / 운영 증명 |
+| --- | --- | --- |
+| FIP raw Object Storage sink | foundation 범위가 아니며 consumer 구현 브랜치 소유 | 후속 FIP PR에서 Vector/Object Storage 설정과 함께 검증 |
+| ML training/evaluation execution | foundation 범위가 아니며 ML lifecycle 브랜치 소유 | 후속 ML PR에서 artifact와 run transition 테스트 |
+| ModelRelease cutover/rollback restore | foundation은 schema/contract만 제공 | 후속 release/reindex PR에서 transition integration test |
+| Managed Embedding readiness | foundation에서 endpoint 연동을 추가하지 않음 | 후속 release/reindex PR에서 readiness gate test |
+
+### 3.4 테스트 환경과 double
+- DB / storage / broker 설정:
+  - Core API migration/schema test는 기존 DB fixture 또는 Alembic test pattern을 재사용한다.
+  - Broker publish는 existing in-memory broker 또는 unit-level payload builder test로 제한한다.
+  - Object Storage는 foundation 테스트에서 double을 쓰지 않는다.
+- 외부 의존성 격리 방식:
+  - Search Service integration test는 DB repository boundary까지만 검증한다.
+  - Managed Embedding Endpoint, Vector Store external runtime은 foundation 검증에서 제외한다.
+- Time / async / retry 제어 방식:
+  - Message schema tests는 explicit `issued_at` 값을 사용한다.
+  - Retry/backoff behavior는 후속 구현에서 검증한다.
+- 필요한 fixture 또는 seed data:
+  - `SERVABLE` project와 그 하위 `READY` video
+  - `ROLLBACK_EXCLUDED` project와 그 하위 `READY` video
+  - minimal chunk/vector rows
+  - minimal `ModelRelease` row
+
+### 3.5 검증 명령과 quality gate
+- 필수 명령:
+  - `cd services/core-api && poetry run pytest tests/unit tests/integration`
+  - `cd services/search-service && poetry run pytest tests/unit tests/integration`
+  - `cd services/pipeline-worker && poetry run pytest tests/unit`
+- 병합 전 최소 meaningful check:
+  - New migration upgrade path succeeds.
+  - Message schema tests prove control messages do not require `video_id`.
+  - Search repository test proves project-level `ROLLBACK_EXCLUDED` is not served.
+  - Core API router import/wiring test passes.
+- 첨부할 증거:
+  - pytest output for affected services
+  - migration upgrade proof if run separately
+  - short note for any skipped command with blocker reason
+
+---
+
+## 4. 전달 리스크와 안전장치
+
+| 리스크 | 영향 | 완화책 | 검증 |
+| --- | --- | --- | --- |
+| Schema 또는 enum drift across services | 후속 브랜치가 서로 다른 상태값을 구현한다 | DB check constraint와 schema tests로 값 고정 | Migration/schema tests |
+| Control message가 video envelope와 섞임 | `TRAINING_REQUEST` / `ROLLBACK_REQUEST`가 consumer에서 파싱 실패한다 | 별도 control schema와 unit test 추가 | Message schema tests |
+| Search gate가 rollback exclusion을 누락 | 복구 중 데이터가 사용자 검색에 노출된다 | repository SQL을 project-level `SERVABLE`과 project readiness 기준으로 변경 | Search repository integration test |
+| Foundation에서 domain behavior를 과하게 구현 | 후속 브랜치 책임 경계가 흐려진다 | skeleton은 계약과 wiring만 제공하고 side effect는 최소화 | Code review against this plan |
+| Shared Python package 부재로 중복 증가 | 서비스별 enum/message 값이 나중에 갈라진다 | 중복은 작게 유지하고 테스트로 값 고정, 필요 시 후속 shared package ADR | Cross-service schema tests / review |
+| Migration rollback ambiguity | 배포 중 partial failure 복구가 어려워진다 | downgrade 또는 safe-forward 절차를 migration에 명확히 둔다 | Alembic downgrade smoke where feasible |
+
+---
+
+## 5. Rollout and Rollback
+
+### 5.1 Rollout 계획
+- Migration / schema 단계:
+  - Core API Alembic migration을 배포한다.
+  - `Project.search_serving_state`는 기존 row에 `SERVABLE` 기본값을 부여한다.
+  - 신규 tables는 비어 있는 상태로 배포 가능해야 한다.
+- Config / secret / infra 변경:
+  - foundation 단계에서는 새 secret을 추가하지 않는다.
+  - 새 queue 이름이 필요하면 config placeholder만 추가하고 실제 consumer rollout은 후속 브랜치에서 수행한다.
+- Backward / forward compatibility 고려사항:
+  - 기존 video upload/search/delete flow는 새 column 추가 후에도 기존 behavior를 유지해야 한다.
+  - `Project.search_serving_state` default가 있으므로 기존 project write path는 즉시 수정되지 않아도 row 생성이 가능해야 한다.
+  - Control message schema 추가는 기존 `PREPROCESS_REQUEST` / `DELETE_REQUEST` payload를 변경하지 않는다.
+- Rollout 중 볼 monitoring signal:
+  - Core API DB migration failure
+  - Search Service query failure
+  - Pipeline Worker message validation failure
+  - unexpected `ROLLBACK_EXCLUDED` row count greater than zero before rollback implementation
+- 배포 후 점검:
+  - Existing video creation still succeeds.
+  - Existing search flow still returns expected results.
+  - Existing pipeline worker video messages still parse.
+
+### 5.2 Rollback 계획
+- App rollback:
+  - App code can roll back while additive DB columns/tables remain unused.
+- Data rollback 또는 safe-forward plan:
+  - Prefer safe-forward for additive schema if no bad data was written.
+  - If rollback is required before use, downgrade can drop foundation-only tables and remove `Project.search_serving_state`.
+- Async / message compatibility fallback:
+  - Existing video-processing messages are unchanged.
+  - If control-message publish skeleton causes issues, disable new admin/feedback routes or leave them uncalled until fixed.
+- Partial deployment recovery:
+  - If one service deploys before another, additive schema and default values should keep existing flows working.
+  - If Search Service is not yet deployed with project-level `SERVABLE` filter, no `ROLLBACK_EXCLUDED` writes should occur before release/rollback implementation.
+
+---
+
+## 6. 완료 체크리스트
+
+- [ ] Core API migration adds all foundation tables/columns and constraints.
+- [ ] Core API ORM models match migration names and nullable/default rules.
+- [ ] Search Service read model includes `Project.search_serving_state`.
+- [ ] Pipeline Worker DB model includes `Video.project_id`, `MLPipelineRun`, `ModelEvaluation`, `ModelRelease`.
+- [ ] Video-processing messages still require `video_id`.
+- [ ] `TRAINING_REQUEST` and `ROLLBACK_REQUEST` use control-message schema without `video_id`.
+- [ ] Feedback event schema preserves the required snapshot context fields.
+- [ ] Core API includes `feedbacks` and `admin` router skeletons.
+- [ ] Repository/service skeletons do not implement full downstream behavior prematurely.
+- [ ] Foundation-specific tests are added and pass.
+- [ ] Affected existing tests pass or blockers are documented.
+- [ ] Remaining open questions are recorded before moving to implementation branches.
+

--- a/services/core-api/alembic/env.py
+++ b/services/core-api/alembic/env.py
@@ -6,6 +6,7 @@ from alembic import context
 from sqlalchemy import pool
 from sqlalchemy.ext.asyncio import async_engine_from_config
 
+from src.models import admin_ops  # noqa: F401
 from src.models.video import Base
 
 config = context.config

--- a/services/core-api/alembic/versions/0004_admin_ops_foundation.py
+++ b/services/core-api/alembic/versions/0004_admin_ops_foundation.py
@@ -1,0 +1,261 @@
+"""add admin ops foundation schema
+
+Revision ID: 0004_admin_ops_foundation
+Revises: 0003_pgvector_vector_index_entry
+Create Date: 2026-04-21
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0004_admin_ops_foundation"
+down_revision = "0003_pgvector_vector_index_entry"
+branch_labels = None
+depends_on = None
+
+
+PROJECT_SERVING_STATES = ("SERVABLE", "ROLLBACK_EXCLUDED")
+ML_RUN_STATUSES = ("PENDING", "RUNNING", "READY_FOR_RELEASE", "FAILED", "SUPERSEDED")
+ML_FAILURE_TYPES = ("FAIL", "ERROR")
+EVALUATION_STATUSES = ("RUNNING", "COMPLETED", "FAILED")
+EVALUATION_DECISIONS = ("PASS", "FAIL")
+RELEASE_STATUSES = ("STABLE", "CANDIDATE_REINDEXING", "ROLLBACK_PREPARING")
+
+
+def _check_values(column_name: str, values: tuple[str, ...]) -> str:
+    quoted_values = ", ".join(f"'{value}'" for value in values)
+    return f"{column_name} IN ({quoted_values})"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "project",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("title", sa.String(length=255), nullable=False),
+        sa.Column("description", sa.Text(), nullable=True),
+        sa.Column("search_serving_state", sa.Text(), nullable=False, server_default=sa.text("'SERVABLE'")),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint(
+            _check_values("search_serving_state", PROJECT_SERVING_STATES),
+            name="ck_project_search_serving_state",
+        ),
+    )
+    op.execute("CREATE INDEX idx_project_user_created ON project(user_id, created_at DESC, id DESC)")
+    op.create_index("idx_project_search_serving_state", "project", ["search_serving_state"])
+
+    op.create_table(
+        "search_response_snapshot",
+        sa.Column("req_id", postgresql.UUID(as_uuid=True), primary_key=True, nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("project.id"), nullable=False),
+        sa.Column("query_text", sa.Text(), nullable=False),
+        sa.Column("topk_chunk_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("used_chunk_ids", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("active_model_version", sa.String(length=128), nullable=False),
+        sa.Column("active_index_name", sa.String(length=128), nullable=False),
+        sa.Column("served_vector_paths", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("project_serving_state", sa.Text(), nullable=False),
+        sa.Column("scope_notice", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint(
+            _check_values("project_serving_state", PROJECT_SERVING_STATES),
+            name="ck_search_response_snapshot_project_serving_state",
+        ),
+    )
+    op.create_index("idx_search_response_snapshot_user_req", "search_response_snapshot", ["user_id", "req_id"])
+    op.create_index("idx_search_response_snapshot_expires_at", "search_response_snapshot", ["expires_at"])
+
+    op.create_table(
+        "model_evaluation",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("candidate_model_version", sa.String(length=128), nullable=False),
+        sa.Column("baseline_model_version", sa.String(length=128), nullable=False),
+        sa.Column("evaluation_dataset_ref", sa.Text(), nullable=False),
+        sa.Column("sample_count", sa.Integer(), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("quality_metrics", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("pass_criteria", postgresql.JSONB(astext_type=sa.Text()), nullable=False),
+        sa.Column("overall_decision", sa.Text(), nullable=True),
+        sa.Column("fail_reason", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint(_check_values("status", EVALUATION_STATUSES), name="ck_model_evaluation_status"),
+        sa.CheckConstraint(
+            "overall_decision IS NULL OR " + _check_values("overall_decision", EVALUATION_DECISIONS),
+            name="ck_model_evaluation_overall_decision",
+        ),
+        sa.CheckConstraint("sample_count >= 0", name="ck_model_evaluation_sample_count"),
+    )
+
+    op.create_table(
+        "ml_pipeline_run",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("status", sa.Text(), nullable=False),
+        sa.Column("failed_stage", sa.Text(), nullable=True),
+        sa.Column("failure_type", sa.Text(), nullable=True),
+        sa.Column("failure_reason", sa.Text(), nullable=True),
+        sa.Column("candidate_model_version", sa.String(length=128), nullable=True),
+        sa.Column("candidate_index_name", sa.String(length=128), nullable=True),
+        sa.Column("dataset_version", sa.String(length=128), nullable=False),
+        sa.Column("evaluation_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("model_evaluation.id"), nullable=True),
+        sa.Column("cutover_time", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("superseded_by_run_id", postgresql.UUID(as_uuid=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint(_check_values("status", ML_RUN_STATUSES), name="ck_ml_pipeline_run_status"),
+        sa.CheckConstraint(
+            "failure_type IS NULL OR " + _check_values("failure_type", ML_FAILURE_TYPES),
+            name="ck_ml_pipeline_run_failure_type",
+        ),
+    )
+    op.create_foreign_key(
+        "fk_ml_pipeline_run_superseded_by_run_id",
+        "ml_pipeline_run",
+        "ml_pipeline_run",
+        ["superseded_by_run_id"],
+        ["id"],
+    )
+    op.create_index("idx_ml_pipeline_run_status_created", "ml_pipeline_run", ["status", "created_at"])
+    op.create_index("uq_ml_pipeline_run_running", "ml_pipeline_run", ["status"], unique=True, postgresql_where=sa.text("status = 'RUNNING'"))
+    op.create_index("uq_ml_pipeline_run_pending", "ml_pipeline_run", ["status"], unique=True, postgresql_where=sa.text("status = 'PENDING'"))
+
+    op.create_table(
+        "model_release",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column(
+            "singleton_key",
+            sa.SmallInteger(),
+            nullable=False,
+            server_default=sa.text("1"),
+        ),
+        sa.Column("release_status", sa.Text(), nullable=False, server_default=sa.text("'STABLE'")),
+        sa.Column("active_model_version", sa.String(length=128), nullable=False),
+        sa.Column("active_index_name", sa.String(length=128), nullable=False),
+        sa.Column("previous_model_version", sa.String(length=128), nullable=True),
+        sa.Column("previous_index_name", sa.String(length=128), nullable=True),
+        sa.Column("candidate_model_version", sa.String(length=128), nullable=True),
+        sa.Column("candidate_index_name", sa.String(length=128), nullable=True),
+        sa.Column("rollback_snapshot_active_model_version", sa.String(length=128), nullable=True),
+        sa.Column("rollback_snapshot_active_index_name", sa.String(length=128), nullable=True),
+        sa.Column("rollback_snapshot_captured_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("candidate_ready_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("switched_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint("singleton_key = 1", name="ck_model_release_singleton_key"),
+        sa.CheckConstraint(_check_values("release_status", RELEASE_STATUSES), name="ck_model_release_status"),
+        sa.UniqueConstraint("singleton_key", name="uq_model_release_singleton_key"),
+    )
+    op.create_index("idx_model_release_status", "model_release", ["release_status"])
+
+    op.add_column(
+        "video",
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.create_foreign_key(
+        "fk_video_project_id",
+        "video",
+        "project",
+        ["project_id"],
+        ["id"],
+    )
+    op.create_index("idx_video_project_id", "video", ["project_id"])
+    op.add_column(
+        "vector_index_entry",
+        sa.Column(
+            "index_name",
+            sa.String(length=128),
+            nullable=False,
+            server_default=sa.text("'default-index'"),
+        ),
+    )
+    op.add_column(
+        "vector_index_entry",
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), nullable=True),
+    )
+    op.execute(
+        """
+        UPDATE vector_index_entry AS vie
+        SET project_id = v.project_id
+        FROM video AS v
+        WHERE vie.video_id = v.id
+        """
+    )
+    op.create_foreign_key(
+        "fk_vector_index_entry_project_id",
+        "vector_index_entry",
+        "project",
+        ["project_id"],
+        ["id"],
+    )
+    op.drop_constraint("vector_index_entry_pkey", "vector_index_entry", type_="primary")
+    op.create_primary_key(
+        "vector_index_entry_pkey",
+        "vector_index_entry",
+        ["index_name", "chunk_id"],
+    )
+    op.create_index(
+        "idx_vector_index_entry_project_index",
+        "vector_index_entry",
+        ["project_id", "index_name"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_vector_index_entry_project_index", table_name="vector_index_entry")
+    op.drop_constraint("vector_index_entry_pkey", "vector_index_entry", type_="primary")
+    op.execute("DELETE FROM vector_index_entry WHERE index_name != 'default-index'")
+    op.create_primary_key("vector_index_entry_pkey", "vector_index_entry", ["chunk_id"])
+    op.drop_constraint(
+        "fk_vector_index_entry_project_id",
+        "vector_index_entry",
+        type_="foreignkey",
+    )
+    op.drop_column("vector_index_entry", "project_id")
+    op.drop_column("vector_index_entry", "index_name")
+    op.drop_index("idx_video_project_id", table_name="video")
+    op.drop_constraint("fk_video_project_id", "video", type_="foreignkey")
+    op.drop_column("video", "project_id")
+    op.drop_index("idx_model_release_status", table_name="model_release")
+    op.drop_table("model_release")
+    op.drop_index("uq_ml_pipeline_run_pending", table_name="ml_pipeline_run")
+    op.drop_index("uq_ml_pipeline_run_running", table_name="ml_pipeline_run")
+    op.drop_index("idx_ml_pipeline_run_status_created", table_name="ml_pipeline_run")
+    op.drop_table("ml_pipeline_run")
+    op.drop_table("model_evaluation")
+    op.drop_index("idx_search_response_snapshot_expires_at", table_name="search_response_snapshot")
+    op.drop_index("idx_search_response_snapshot_user_req", table_name="search_response_snapshot")
+    op.drop_table("search_response_snapshot")
+    op.drop_index("idx_project_search_serving_state", table_name="project")
+    op.execute("DROP INDEX IF EXISTS idx_project_user_created")
+    op.drop_table("project")

--- a/services/core-api/src/api/v1/router.py
+++ b/services/core-api/src/api/v1/router.py
@@ -1,8 +1,12 @@
 from fastapi import APIRouter
 
+from src.api.v1.routers.admin import admin_router
+from src.api.v1.routers.feedbacks import feedbacks_router
 from src.api.v1.routers.videos import videos_router
 
 api_v1_router = APIRouter(tags=["system"])
 
 
 api_v1_router.include_router(videos_router)
+api_v1_router.include_router(feedbacks_router)
+api_v1_router.include_router(admin_router)

--- a/services/core-api/src/api/v1/routers/admin.py
+++ b/services/core-api/src/api/v1/routers/admin.py
@@ -1,0 +1,90 @@
+"""Admin router skeleton.
+
+Fixes endpoint ownership and DI wiring. Full admin-control behavior (training
+trigger, rollback orchestration, role-based auth, dashboard queries) lands in
+the Admin Control Plane branch.
+"""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from src.core.dependencies import get_broker_client, get_db_session_factory
+from src.infra.broker import BrokerClient
+from src.middlewares.auth import AuthenticatedUser, get_current_user
+from src.schemas.video_dto import ErrorResponse
+from src.services.admin_service import AdminService
+
+CurrentUser = Annotated[AuthenticatedUser, Depends(get_current_user)]
+DbSessionFactoryDependency = Annotated[Any, Depends(get_db_session_factory)]
+BrokerClientDependency = Annotated[BrokerClient, Depends(get_broker_client)]
+
+
+admin_router = APIRouter(
+    prefix="/admin",
+    tags=["admin"],
+    responses={
+        400: {"model": ErrorResponse},
+        401: {"model": ErrorResponse},
+        403: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+        501: {"model": ErrorResponse},
+    },
+)
+
+
+@admin_router.post(
+    "/ml-pipeline-runs/retrigger",
+    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+)
+def retrigger_ml_pipeline(
+    user: CurrentUser,
+    db_session_factory: DbSessionFactoryDependency,
+    broker_client: BrokerClientDependency,
+) -> None:
+    """Skeleton endpoint for triggering a training run.
+
+    The admin-control branch owns the full business rules (role check,
+    precondition gate, control-message publish). Foundation only reserves
+    the path.
+    """
+    _ = user
+    service = AdminService(
+        db_session_factory=db_session_factory,
+        broker_client=broker_client,
+    )
+    try:
+        service.trigger_training()
+    except NotImplementedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=str(exc),
+        ) from exc
+
+
+@admin_router.post(
+    "/model-release/rollback",
+    status_code=status.HTTP_501_NOT_IMPLEMENTED,
+)
+def rollback_model_release(
+    user: CurrentUser,
+    db_session_factory: DbSessionFactoryDependency,
+    broker_client: BrokerClientDependency,
+) -> None:
+    """Skeleton endpoint for triggering a model-release rollback.
+
+    The admin-control branch owns the full rollback orchestration.
+    """
+    _ = user
+    service = AdminService(
+        db_session_factory=db_session_factory,
+        broker_client=broker_client,
+    )
+    try:
+        service.trigger_rollback()
+    except NotImplementedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=str(exc),
+        ) from exc

--- a/services/core-api/src/api/v1/routers/feedbacks.py
+++ b/services/core-api/src/api/v1/routers/feedbacks.py
@@ -1,0 +1,60 @@
+"""Feedback router skeleton.
+
+Fixes endpoint ownership and DI wiring. Full validation/publish flow lands in
+the Feedback Ingestion Pipeline branch.
+"""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from src.core.dependencies import get_broker_client, get_db_session_factory
+from src.infra.broker import BrokerClient
+from src.middlewares.auth import AuthenticatedUser, get_current_user
+from src.schemas.feedback_dto import FeedbackRequest
+from src.schemas.video_dto import ErrorResponse
+from src.services.feedback_service import FeedbackService
+
+CurrentUser = Annotated[AuthenticatedUser, Depends(get_current_user)]
+DbSessionFactoryDependency = Annotated[Any, Depends(get_db_session_factory)]
+BrokerClientDependency = Annotated[BrokerClient, Depends(get_broker_client)]
+
+
+feedbacks_router = APIRouter(
+    prefix="/feedbacks",
+    tags=["feedbacks"],
+    responses={
+        400: {"model": ErrorResponse},
+        401: {"model": ErrorResponse},
+        404: {"model": ErrorResponse},
+        500: {"model": ErrorResponse},
+        501: {"model": ErrorResponse},
+    },
+)
+
+
+@feedbacks_router.post("", status_code=status.HTTP_501_NOT_IMPLEMENTED)
+def create_feedback(
+    payload: FeedbackRequest,
+    user: CurrentUser,
+    db_session_factory: DbSessionFactoryDependency,
+    broker_client: BrokerClientDependency,
+) -> None:
+    """Skeleton endpoint.
+
+    Validation/publish flow lands in the Feedback Ingestion Pipeline branch.
+    The skeleton enforces auth + payload shape and then rejects with 501 so
+    callers do not assume the behavior exists yet.
+    """
+    _ = user
+    service = FeedbackService(
+        db_session_factory=db_session_factory,
+        broker_client=broker_client,
+    )
+    try:
+        service.record_request(payload)
+    except NotImplementedError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_501_NOT_IMPLEMENTED,
+            detail=str(exc),
+        ) from exc

--- a/services/core-api/src/infra/broker.py
+++ b/services/core-api/src/infra/broker.py
@@ -2,10 +2,12 @@ import asyncio
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Literal
+from typing import Literal, Protocol
 from uuid import UUID
 
-MessageType = Literal["PREPROCESS_REQUEST", "DELETE_REQUEST"]
+VideoMessageType = Literal["PREPROCESS_REQUEST", "DELETE_REQUEST"]
+ControlMessageType = Literal["TRAINING_REQUEST", "ROLLBACK_REQUEST"]
+MessageType = VideoMessageType | ControlMessageType
 
 
 class BrokerPublishError(RuntimeError):
@@ -14,7 +16,7 @@ class BrokerPublishError(RuntimeError):
 
 @dataclass(frozen=True, slots=True)
 class BrokerMessage:
-    message_type: MessageType
+    message_type: VideoMessageType
     video_id: UUID
     trace_id: UUID
     attempt: int = 1
@@ -33,8 +35,33 @@ class BrokerMessage:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class ControlBrokerMessage:
+    message_type: ControlMessageType
+    trace_id: UUID
+    attempt: int = 1
+    payload_version: str = "v1"
+    issued_at: datetime | None = None
+
+    def to_payload(self) -> dict[str, object]:
+        issued_at = self.issued_at or datetime.now(timezone.utc)
+        return {
+            "message_type": self.message_type,
+            "payload_version": self.payload_version,
+            "trace_id": str(self.trace_id),
+            "attempt": self.attempt,
+            "issued_at": issued_at.isoformat(),
+        }
+
+
+class PublishableMessage(Protocol):
+    message_type: MessageType
+
+    def to_payload(self) -> dict[str, object]: ...
+
+
 def build_message(
-    message_type: MessageType,
+    message_type: VideoMessageType,
     *,
     video_id: UUID,
     trace_id: UUID,
@@ -50,14 +77,29 @@ def build_message(
     )
 
 
+def build_control_message(
+    message_type: ControlMessageType,
+    *,
+    trace_id: UUID,
+    attempt: int = 1,
+    issued_at: datetime | None = None,
+) -> ControlBrokerMessage:
+    return ControlBrokerMessage(
+        message_type=message_type,
+        trace_id=trace_id,
+        attempt=attempt,
+        issued_at=issued_at,
+    )
+
+
 class BrokerClient(ABC):
     @abstractmethod
-    async def publish(self, message: BrokerMessage) -> int | None:
+    async def publish(self, message: PublishableMessage) -> int | None:
         raise NotImplementedError
 
     async def publish_with_retry(
         self,
-        message: BrokerMessage,
+        message: PublishableMessage,
         *,
         max_attempts: int = 3,
         retry_delay_seconds: float = 0.0,

--- a/services/core-api/src/infra/db/admin_repository.py
+++ b/services/core-api/src/infra/db/admin_repository.py
@@ -1,0 +1,75 @@
+"""Skeleton admin repository for projection reads.
+
+Full business logic is implemented in the admin-control branch. This file only
+pins the query entry points so router/service skeletons can wire to a stable
+shape.
+"""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.admin_ops import MLPipelineRun, Project
+from src.models.video import Video
+
+
+@dataclass(slots=True)
+class ProjectProjection:
+    id: UUID
+    user_id: UUID
+    search_serving_state: str
+
+
+@dataclass(slots=True)
+class MLPipelineRunProjection:
+    id: UUID
+    status: str
+    candidate_model_version: str | None
+    dataset_version: str
+
+
+class AdminRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_project(self, project_id: UUID) -> ProjectProjection | None:
+        result = await self.session.execute(
+            select(Project.id, Project.user_id, Project.search_serving_state).where(
+                Project.id == project_id
+            )
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return ProjectProjection(
+            id=row.id,
+            user_id=row.user_id,
+            search_serving_state=row.search_serving_state,
+        )
+
+    async def get_video(self, video_id: UUID) -> Video | None:
+        result = await self.session.execute(
+            select(Video).where(Video.id == video_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_ml_pipeline_run(self, run_id: UUID) -> MLPipelineRunProjection | None:
+        result = await self.session.execute(
+            select(
+                MLPipelineRun.id,
+                MLPipelineRun.status,
+                MLPipelineRun.candidate_model_version,
+                MLPipelineRun.dataset_version,
+            ).where(MLPipelineRun.id == run_id)
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return MLPipelineRunProjection(
+            id=row.id,
+            status=row.status,
+            candidate_model_version=row.candidate_model_version,
+            dataset_version=row.dataset_version,
+        )

--- a/services/core-api/src/infra/db/feedback_repository.py
+++ b/services/core-api/src/infra/db/feedback_repository.py
@@ -1,0 +1,50 @@
+"""Skeleton feedback repository.
+
+Only provides the read projection used by the feedback-router skeleton to
+locate the `SearchResponseSnapshot` that a feedback event refers to. Publish
+and raw-log sink responsibilities belong to the Feedback Ingestion Pipeline
+branch.
+"""
+
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.admin_ops import SearchResponseSnapshot
+
+
+@dataclass(slots=True)
+class SnapshotProjection:
+    req_id: UUID
+    user_id: UUID
+    project_id: UUID
+    active_model_version: str
+    active_index_name: str
+
+
+class FeedbackRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_snapshot(self, req_id: UUID) -> SnapshotProjection | None:
+        result = await self.session.execute(
+            select(
+                SearchResponseSnapshot.req_id,
+                SearchResponseSnapshot.user_id,
+                SearchResponseSnapshot.project_id,
+                SearchResponseSnapshot.active_model_version,
+                SearchResponseSnapshot.active_index_name,
+            ).where(SearchResponseSnapshot.req_id == req_id)
+        )
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return SnapshotProjection(
+            req_id=row.req_id,
+            user_id=row.user_id,
+            project_id=row.project_id,
+            active_model_version=row.active_model_version,
+            active_index_name=row.active_index_name,
+        )

--- a/services/core-api/src/infra/db/model_release_repository.py
+++ b/services/core-api/src/infra/db/model_release_repository.py
@@ -1,0 +1,35 @@
+"""Skeleton model release repository.
+
+Full transition logic is implemented in the release/reindex branch. This file
+only fixes the read/load entry point so admin service skeletons can wire to a
+stable shape.
+"""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.admin_ops import ModelRelease
+
+
+class ModelReleaseRepository:
+    def __init__(self, session: AsyncSession) -> None:
+        self.session = session
+
+    async def get_by_id(self, release_id: UUID) -> ModelRelease | None:
+        result = await self.session.execute(
+            select(ModelRelease).where(ModelRelease.id == release_id)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_current(self) -> ModelRelease | None:
+        """Return the single `ModelRelease` row that is the SOT for serving state.
+
+        Bootstrap timing (migration seed vs. service startup lazy init) is an
+        open foundation question and resolved in the release/reindex branch.
+        """
+        result = await self.session.execute(
+            select(ModelRelease).where(ModelRelease.singleton_key == 1)
+        )
+        return result.scalar_one_or_none()

--- a/services/core-api/src/infra/inmemory_broker.py
+++ b/services/core-api/src/infra/inmemory_broker.py
@@ -1,4 +1,4 @@
-from src.infra.broker import BrokerClient, BrokerMessage, BrokerPublishError
+from src.infra.broker import BrokerClient, BrokerPublishError, PublishableMessage
 
 
 class InMemoryBrokerClient(BrokerClient):
@@ -7,7 +7,7 @@ class InMemoryBrokerClient(BrokerClient):
         self.publish_attempts = 0
         self.published_messages: list[dict[str, object]] = []
 
-    async def publish(self, message: BrokerMessage) -> int | None:
+    async def publish(self, message: PublishableMessage) -> int | None:
         self.publish_attempts += 1
         if self._failures_before_success > 0:
             self._failures_before_success -= 1

--- a/services/core-api/src/infra/pgmq_client.py
+++ b/services/core-api/src/infra/pgmq_client.py
@@ -3,7 +3,7 @@ from typing import Any
 
 import asyncpg
 
-from src.infra.broker import BrokerClient, BrokerMessage, BrokerPublishError
+from src.infra.broker import BrokerClient, BrokerPublishError, PublishableMessage
 
 
 class PGMQBrokerClient(BrokerClient):
@@ -13,7 +13,7 @@ class PGMQBrokerClient(BrokerClient):
         self._connection = connection
         self._dsn = dsn
 
-    async def publish(self, message: BrokerMessage) -> int | None:
+    async def publish(self, message: PublishableMessage) -> int | None:
         payload = message.to_payload()
         try:
             message_id = await self._publish_payload(

--- a/services/core-api/src/models/admin_ops.py
+++ b/services/core-api/src/models/admin_ops.py
@@ -1,0 +1,241 @@
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    SmallInteger,
+    String,
+    Text,
+    UniqueConstraint,
+    desc,
+    func,
+    text,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.models.video import Base
+
+
+PROJECT_SERVING_STATES = ("SERVABLE", "ROLLBACK_EXCLUDED")
+RELEASE_STATUSES = ("STABLE", "CANDIDATE_REINDEXING", "ROLLBACK_PREPARING")
+ML_RUN_STATUSES = ("PENDING", "RUNNING", "READY_FOR_RELEASE", "FAILED", "SUPERSEDED")
+ML_FAILURE_TYPES = ("FAIL", "ERROR")
+EVALUATION_STATUSES = ("RUNNING", "COMPLETED", "FAILED")
+EVALUATION_DECISIONS = ("PASS", "FAIL")
+
+
+def _check_values(column_name: str, values: tuple[str, ...]) -> str:
+    quoted_values = ", ".join(f"'{value}'" for value in values)
+    return f"{column_name} IN ({quoted_values})"
+
+
+class Project(Base):
+    __tablename__ = "project"
+    __table_args__ = (
+        CheckConstraint(
+            _check_values("search_serving_state", PROJECT_SERVING_STATES),
+            name="ck_project_search_serving_state",
+        ),
+        Index("idx_project_user_created", "user_id", desc("created_at"), desc("id")),
+        Index("idx_project_search_serving_state", "search_serving_state"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    description: Mapped[str | None] = mapped_column(Text, nullable=True)
+    search_serving_state: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="SERVABLE",
+        server_default=text("'SERVABLE'"),
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class SearchResponseSnapshot(Base):
+    __tablename__ = "search_response_snapshot"
+    __table_args__ = (
+        CheckConstraint(
+            _check_values("project_serving_state", PROJECT_SERVING_STATES),
+            name="ck_search_response_snapshot_project_serving_state",
+        ),
+        Index("idx_search_response_snapshot_user_req", "user_id", "req_id"),
+        Index("idx_search_response_snapshot_expires_at", "expires_at"),
+    )
+
+    req_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    project_id: Mapped[UUID] = mapped_column(ForeignKey("project.id"), nullable=False)
+    query_text: Mapped[str] = mapped_column(Text, nullable=False)
+    topk_chunk_ids: Mapped[list[str]] = mapped_column(JSONB, nullable=False)
+    used_chunk_ids: Mapped[list[str]] = mapped_column(JSONB, nullable=False)
+    active_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    active_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    served_vector_paths: Mapped[list[dict[str, str]]] = mapped_column(JSONB, nullable=False)
+    project_serving_state: Mapped[str] = mapped_column(Text, nullable=False)
+    scope_notice: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class ModelEvaluation(Base):
+    __tablename__ = "model_evaluation"
+    __table_args__ = (
+        CheckConstraint(_check_values("status", EVALUATION_STATUSES), name="ck_model_evaluation_status"),
+        CheckConstraint(
+            "overall_decision IS NULL OR " + _check_values("overall_decision", EVALUATION_DECISIONS),
+            name="ck_model_evaluation_overall_decision",
+        ),
+        CheckConstraint("sample_count >= 0", name="ck_model_evaluation_sample_count"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    candidate_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    baseline_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    evaluation_dataset_ref: Mapped[str] = mapped_column(Text, nullable=False)
+    sample_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    quality_metrics: Mapped[dict[str, float]] = mapped_column(JSONB, nullable=False)
+    pass_criteria: Mapped[dict[str, object]] = mapped_column(JSONB, nullable=False)
+    overall_decision: Mapped[str | None] = mapped_column(Text, nullable=True)
+    fail_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+
+
+class MLPipelineRun(Base):
+    __tablename__ = "ml_pipeline_run"
+    __table_args__ = (
+        CheckConstraint(_check_values("status", ML_RUN_STATUSES), name="ck_ml_pipeline_run_status"),
+        CheckConstraint(
+            "failure_type IS NULL OR " + _check_values("failure_type", ML_FAILURE_TYPES),
+            name="ck_ml_pipeline_run_failure_type",
+        ),
+        Index("idx_ml_pipeline_run_status_created", "status", "created_at"),
+        Index("uq_ml_pipeline_run_running", "status", unique=True, postgresql_where=text("status = 'RUNNING'")),
+        Index("uq_ml_pipeline_run_pending", "status", unique=True, postgresql_where=text("status = 'PENDING'")),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    status: Mapped[str] = mapped_column(Text, nullable=False)
+    failed_stage: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    candidate_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    dataset_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    evaluation_id: Mapped[UUID | None] = mapped_column(ForeignKey("model_evaluation.id"), nullable=True)
+    cutover_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    superseded_by_run_id: Mapped[UUID | None] = mapped_column(ForeignKey("ml_pipeline_run.id"), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class ModelRelease(Base):
+    __tablename__ = "model_release"
+    __table_args__ = (
+        CheckConstraint("singleton_key = 1", name="ck_model_release_singleton_key"),
+        CheckConstraint(
+            _check_values("release_status", RELEASE_STATUSES),
+            name="ck_model_release_status",
+        ),
+        UniqueConstraint("singleton_key", name="uq_model_release_singleton_key"),
+        Index("idx_model_release_status", "release_status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    singleton_key: Mapped[int] = mapped_column(
+        SmallInteger,
+        nullable=False,
+        default=1,
+        server_default=text("1"),
+    )
+    release_status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="STABLE",
+        server_default=text("'STABLE'"),
+    )
+    active_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    active_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    previous_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    previous_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    rollback_snapshot_active_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    rollback_snapshot_active_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    rollback_snapshot_captured_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    candidate_ready_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    switched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )

--- a/services/core-api/src/models/video.py
+++ b/services/core-api/src/models/video.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
-from sqlalchemy import CheckConstraint, DateTime, Index, String, Text, desc, func, text
+from sqlalchemy import CheckConstraint, DateTime, ForeignKey, Index, String, Text, desc, func, text
 from sqlalchemy.dialects.postgresql import UUID as PGUUID
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -31,6 +31,7 @@ class Video(Base):
         ),
         Index("idx_video_user_created", "user_id", desc("created_at"), desc("id")),
         Index("idx_video_user_status", "user_id", "status"),
+        Index("idx_video_project_id", "project_id"),
     )
 
     id: Mapped[UUID] = mapped_column(
@@ -40,6 +41,10 @@ class Video(Base):
         server_default=text("gen_random_uuid()"),
     )
     user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    project_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("project.id"),
+        nullable=True,
+    )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     category: Mapped[str] = mapped_column(Text, nullable=False)
     input_type: Mapped[str] = mapped_column(Text, nullable=False)

--- a/services/core-api/src/schemas/admin_ops.py
+++ b/services/core-api/src/schemas/admin_ops.py
@@ -1,0 +1,39 @@
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ProjectSearchServingState(str, Enum):
+    SERVABLE = "SERVABLE"
+    ROLLBACK_EXCLUDED = "ROLLBACK_EXCLUDED"
+
+
+class ReleaseStatus(str, Enum):
+    STABLE = "STABLE"
+    CANDIDATE_REINDEXING = "CANDIDATE_REINDEXING"
+    ROLLBACK_PREPARING = "ROLLBACK_PREPARING"
+
+
+class MLPipelineRunStatus(str, Enum):
+    PENDING = "PENDING"
+    RUNNING = "RUNNING"
+    READY_FOR_RELEASE = "READY_FOR_RELEASE"
+    FAILED = "FAILED"
+    SUPERSEDED = "SUPERSEDED"
+
+
+class ControlMessageType(str, Enum):
+    TRAINING_REQUEST = "TRAINING_REQUEST"
+    ROLLBACK_REQUEST = "ROLLBACK_REQUEST"
+
+
+class ControlMessage(BaseModel):
+    model_config = ConfigDict(use_enum_values=False, extra="forbid")
+
+    message_type: ControlMessageType
+    payload_version: str = Field(..., pattern=r"^v\d+$")
+    trace_id: UUID
+    attempt: int = Field(..., ge=1)
+    issued_at: datetime

--- a/services/core-api/src/schemas/feedback_dto.py
+++ b/services/core-api/src/schemas/feedback_dto.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from enum import Enum
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class FeedbackRating(str, Enum):
+    LIKE = "LIKE"
+    DISLIKE = "DISLIKE"
+
+
+class ServedVectorPath(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    model_version: str = Field(..., min_length=1)
+    index_name: str = Field(..., min_length=1)
+
+
+class FeedbackRequest(BaseModel):
+    model_config = ConfigDict(use_enum_values=False, extra="forbid")
+
+    req_id: UUID
+    rating: FeedbackRating
+
+
+class FeedbackEvent(BaseModel):
+    model_config = ConfigDict(use_enum_values=False, extra="forbid")
+
+    schema_version: int = Field(1, ge=1)
+    event_id: UUID
+    user_id: UUID
+    project_id: UUID
+    req_id: UUID
+    query_text: str = Field(..., min_length=1)
+    rating: FeedbackRating
+    topk_ids: list[UUID]
+    used_ids: list[UUID]
+    active_model_version: str = Field(..., min_length=1)
+    active_index_name: str = Field(..., min_length=1)
+    response_snapshot_ref: str = Field(..., min_length=1)
+    created_at: datetime
+    trace_id: UUID | None = None
+    served_vector_paths: list[ServedVectorPath] = Field(default_factory=list)

--- a/services/core-api/src/services/admin_service.py
+++ b/services/core-api/src/services/admin_service.py
@@ -1,0 +1,33 @@
+"""Admin service skeleton.
+
+Scope (foundation): Hold the seam between admin router wiring and the full
+admin-control flow owned by the Admin Control Plane branch.
+
+Out of scope: training trigger, rollback orchestration, readiness checks,
+role-based authorization. Those land in the admin-control branch.
+"""
+
+from typing import Any
+
+from src.infra.broker import BrokerClient
+
+
+class AdminService:
+    def __init__(
+        self,
+        *,
+        db_session_factory: Any,
+        broker_client: BrokerClient | None,
+    ) -> None:
+        self._db_session_factory = db_session_factory
+        self._broker_client = broker_client
+
+    def trigger_training(self) -> None:
+        raise NotImplementedError(
+            "AdminService.trigger_training is implemented in the admin-control branch."
+        )
+
+    def trigger_rollback(self) -> None:
+        raise NotImplementedError(
+            "AdminService.trigger_rollback is implemented in the admin-control branch."
+        )

--- a/services/core-api/src/services/feedback_service.py
+++ b/services/core-api/src/services/feedback_service.py
@@ -1,0 +1,35 @@
+"""Feedback service skeleton.
+
+Scope (foundation): Hold the seam between feedback router wiring and the full
+ingestion/publish flow owned by the Feedback Ingestion Pipeline branch.
+
+Out of scope: raw Object Storage sink, broker publish, validation against
+`SearchResponseSnapshot`. Those land in the FIP branch.
+"""
+
+from typing import Any
+
+from src.infra.broker import BrokerClient
+from src.schemas.feedback_dto import FeedbackRequest
+
+
+class FeedbackService:
+    def __init__(
+        self,
+        *,
+        db_session_factory: Any,
+        broker_client: BrokerClient | None,
+    ) -> None:
+        self._db_session_factory = db_session_factory
+        self._broker_client = broker_client
+
+    def record_request(self, request: FeedbackRequest) -> None:
+        """Record a feedback request.
+
+        Placeholder for the full ingestion/publish flow implemented in the
+        Feedback Ingestion Pipeline branch.
+        """
+        _ = request
+        raise NotImplementedError(
+            "FeedbackService.record_request is implemented in the feedback-ingestion branch."
+        )

--- a/services/core-api/tests/api/v1/test_admin_ops_router_wiring.py
+++ b/services/core-api/tests/api/v1/test_admin_ops_router_wiring.py
@@ -1,0 +1,99 @@
+"""Router wiring smoke tests for the admin-ops foundation routers.
+
+Goal: prove that `feedbacks` and `admin` routers are included under the
+existing `/api/v1` prefix and that their skeleton endpoints reject anonymous
+callers as expected. Business behavior lives in the follow-up branches.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from httpx import AsyncClient
+
+from tests.support import AppContext, auth_headers, create_token
+
+
+def _route_paths(app_context: AppContext) -> set[str]:
+    return {route.path for route in app_context.app.routes if hasattr(route, "path")}
+
+
+@pytest.mark.asyncio
+async def test_feedbacks_and_admin_routes_are_wired(app_context: AppContext) -> None:
+    paths = _route_paths(app_context)
+    assert "/api/v1/feedbacks" in paths
+    assert "/api/v1/admin/ml-pipeline-runs/retrigger" in paths
+    assert "/api/v1/admin/model-release/rollback" in paths
+
+
+@pytest.mark.asyncio
+async def test_feedbacks_endpoint_requires_auth(api_client: AsyncClient) -> None:
+    response = await api_client.post("/api/v1/feedbacks", json={})
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_admin_endpoints_require_auth(api_client: AsyncClient) -> None:
+    training_response = await api_client.post("/api/v1/admin/ml-pipeline-runs/retrigger")
+    rollback_response = await api_client.post("/api/v1/admin/model-release/rollback")
+    assert training_response.status_code == 401
+    assert rollback_response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_feedback_endpoint_returns_not_implemented_for_skeleton(
+    app_context: AppContext,
+    api_client: AsyncClient,
+) -> None:
+    requester_user_id = UUID(str(uuid4()))
+    token = create_token(app_context.settings.jwt_secret_key, str(requester_user_id))
+    payload = {
+        "req_id": str(uuid4()),
+        "rating": "LIKE",
+    }
+
+    response = await api_client.post(
+        "/api/v1/feedbacks",
+        json=payload,
+        headers=auth_headers(token),
+    )
+
+    assert response.status_code == 501
+
+
+@pytest.mark.asyncio
+async def test_feedback_endpoint_rejects_internal_event_fields(
+    app_context: AppContext,
+    api_client: AsyncClient,
+) -> None:
+    requester_user_id = UUID(str(uuid4()))
+    token = create_token(app_context.settings.jwt_secret_key, str(requester_user_id))
+    payload = {
+        "req_id": str(uuid4()),
+        "rating": "LIKE",
+        "user_id": str(requester_user_id),
+        "project_id": str(uuid4()),
+    }
+
+    response = await api_client.post(
+        "/api/v1/feedbacks",
+        json=payload,
+        headers=auth_headers(token),
+    )
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_admin_training_returns_not_implemented_for_skeleton(
+    app_context: AppContext,
+    api_client: AsyncClient,
+) -> None:
+    requester_user_id = UUID(str(uuid4()))
+    token = create_token(app_context.settings.jwt_secret_key, str(requester_user_id))
+
+    response = await api_client.post(
+        "/api/v1/admin/ml-pipeline-runs/retrigger",
+        headers=auth_headers(token),
+    )
+
+    assert response.status_code == 501

--- a/services/core-api/tests/api/v1/test_admin_ops_router_wiring.py
+++ b/services/core-api/tests/api/v1/test_admin_ops_router_wiring.py
@@ -80,7 +80,7 @@ async def test_feedback_endpoint_rejects_internal_event_fields(
         headers=auth_headers(token),
     )
 
-    assert response.status_code == 422
+    assert response.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/services/core-api/tests/conftest.py
+++ b/services/core-api/tests/conftest.py
@@ -68,7 +68,22 @@ async def session_factory(
 
     async with engine.begin() as connection:
         await connection.execute(
-            text("TRUNCATE TABLE vector_index_entry, chunk, transcript_segment, asset, video CASCADE")
+            text(
+                """
+                TRUNCATE TABLE
+                    model_release,
+                    ml_pipeline_run,
+                    model_evaluation,
+                    search_response_snapshot,
+                    vector_index_entry,
+                    chunk,
+                    transcript_segment,
+                    asset,
+                    video,
+                    project
+                CASCADE
+                """
+            )
         )
 
     factory: SessionFactory = async_sessionmaker(engine, expire_on_commit=False)
@@ -105,4 +120,3 @@ async def api_client(app_context: AppContext) -> AsyncGenerator[AsyncClient, Non
         base_url="https://testserver",
     ) as client:
         yield client
-

--- a/services/core-api/tests/integration/test_admin_ops_foundation_schema.py
+++ b/services/core-api/tests/integration/test_admin_ops_foundation_schema.py
@@ -1,0 +1,137 @@
+import pytest
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from tests.support import SessionFactory
+
+
+@pytest.mark.asyncio
+async def test_admin_ops_foundation_schema_contract(session_factory: SessionFactory) -> None:
+    async with session_factory() as session:
+        project_columns = await _columns_for(session, "project")
+        video_columns = await _columns_for(session, "video")
+        snapshot_columns = await _columns_for(session, "search_response_snapshot")
+        run_columns = await _columns_for(session, "ml_pipeline_run")
+        evaluation_columns = await _columns_for(session, "model_evaluation")
+        release_columns = await _columns_for(session, "model_release")
+        project_state_default = await session.scalar(
+            text(
+                """
+                SELECT column_default
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'project'
+                  AND column_name = 'search_serving_state'
+                """
+            )
+        )
+        project_state_check = await _constraint_definition(session, "ck_project_search_serving_state")
+        ml_run_status_check = await _constraint_definition(session, "ck_ml_pipeline_run_status")
+        release_status_check = await _constraint_definition(session, "ck_model_release_status")
+        release_singleton_check = await _constraint_definition(
+            session, "ck_model_release_singleton_key"
+        )
+
+    assert project_columns["search_serving_state"][1] == "text"
+    assert video_columns["project_id"][1] == "uuid"
+    assert project_state_default == "'SERVABLE'::text"
+    assert "SERVABLE" in project_state_check
+    assert "ROLLBACK_EXCLUDED" in project_state_check
+    assert snapshot_columns["req_id"][1] == "uuid"
+    assert snapshot_columns["served_vector_paths"][0] == "jsonb"
+    assert evaluation_columns["quality_metrics"][0] == "jsonb"
+    assert run_columns["status"][1] == "text"
+    assert "READY_FOR_RELEASE" in ml_run_status_check
+    assert release_columns["singleton_key"][1] == "int2"
+    assert release_columns["release_status"][1] == "text"
+    assert "ROLLBACK_PREPARING" in release_status_check
+    assert "singleton_key = 1" in release_singleton_check
+
+
+@pytest.mark.asyncio
+async def test_sqlalchemy_models_include_admin_ops_foundation_tables() -> None:
+    from src.models import admin_ops  # noqa: F401
+    from src.models.video import Base
+
+    table_names = set(Base.metadata.tables)
+
+    assert {
+        "project",
+        "search_response_snapshot",
+        "ml_pipeline_run",
+        "model_evaluation",
+        "model_release",
+    }.issubset(table_names)
+    assert "project_id" in Base.metadata.tables["video"].columns
+    model_release_table = Base.metadata.tables["model_release"]
+    model_release_constraints = {
+        constraint.name for constraint in model_release_table.constraints
+    }
+    assert "singleton_key" in model_release_table.columns
+    assert "ck_model_release_singleton_key" in model_release_constraints
+    assert "uq_model_release_singleton_key" in model_release_constraints
+
+
+@pytest.mark.asyncio
+async def test_model_release_schema_rejects_duplicate_singleton_rows(
+    session_factory: SessionFactory,
+) -> None:
+    async with session_factory() as session:
+        await session.execute(
+            text(
+                """
+                INSERT INTO model_release (
+                    active_model_version,
+                    active_index_name
+                )
+                VALUES ('model-v1', 'index-v1')
+                """
+            )
+        )
+        await session.commit()
+
+        with pytest.raises(IntegrityError):
+            await session.execute(
+                text(
+                    """
+                    INSERT INTO model_release (
+                        active_model_version,
+                        active_index_name
+                    )
+                    VALUES ('model-v2', 'index-v2')
+                    """
+                )
+            )
+            await session.commit()
+        await session.rollback()
+
+
+async def _columns_for(session, table_name: str) -> dict[str, tuple[str, str]]:
+    result = await session.execute(
+        text(
+            """
+            SELECT column_name, data_type, udt_name
+            FROM information_schema.columns
+            WHERE table_schema = 'public'
+              AND table_name = :table_name
+            ORDER BY ordinal_position
+            """
+        ),
+        {"table_name": table_name},
+    )
+    return {row.column_name: (row.data_type, row.udt_name) for row in result}
+
+
+async def _constraint_definition(session, constraint_name: str) -> str:
+    definition = await session.scalar(
+        text(
+            """
+            SELECT pg_get_constraintdef(oid)
+            FROM pg_constraint
+            WHERE conname = :constraint_name
+            """
+        ),
+        {"constraint_name": constraint_name},
+    )
+    assert definition is not None
+    return definition

--- a/services/core-api/tests/integration/test_admin_repository.py
+++ b/services/core-api/tests/integration/test_admin_repository.py
@@ -1,0 +1,49 @@
+"""Smoke test for AdminRepository projection reads.
+
+Ensures the foundation repository skeleton can query the admin-ops tables
+through SQLAlchemy without schema drift.
+"""
+
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import text
+
+from src.infra.db.admin_repository import AdminRepository
+from tests.support import SessionFactory
+
+
+@pytest.mark.asyncio
+async def test_admin_repository_returns_project_projection(
+    session_factory: SessionFactory,
+) -> None:
+    project_id = uuid4()
+    user_id = uuid4()
+    async with session_factory() as session:
+        await session.execute(
+            text(
+                "INSERT INTO project (id, user_id, title, search_serving_state) "
+                "VALUES (:id, :user_id, 'Test', 'ROLLBACK_EXCLUDED')"
+            ),
+            {"id": project_id, "user_id": user_id},
+        )
+        await session.commit()
+
+        repo = AdminRepository(session)
+        projection = await repo.get_project(project_id)
+
+    assert projection is not None
+    assert projection.id == project_id
+    assert projection.user_id == user_id
+    assert projection.search_serving_state == "ROLLBACK_EXCLUDED"
+
+
+@pytest.mark.asyncio
+async def test_admin_repository_returns_none_for_missing_run(
+    session_factory: SessionFactory,
+) -> None:
+    async with session_factory() as session:
+        repo = AdminRepository(session)
+        result = await repo.get_ml_pipeline_run(uuid4())
+
+    assert result is None

--- a/services/core-api/tests/integration/test_pipeline_artifact_schema.py
+++ b/services/core-api/tests/integration/test_pipeline_artifact_schema.py
@@ -34,12 +34,14 @@ async def test_alembic_creates_pgvector_vector_index_entry_contract(
                     SELECT a.attname
                     FROM pg_index i
                     JOIN pg_class t ON t.oid = i.indrelid
+                    JOIN unnest(i.indkey) WITH ORDINALITY AS pk(attnum, ord)
+                      ON TRUE
                     JOIN pg_attribute a
                       ON a.attrelid = i.indrelid
-                     AND a.attnum = ANY(i.indkey)
+                     AND a.attnum = pk.attnum
                     WHERE t.relname = 'vector_index_entry'
                       AND i.indisprimary
-                    ORDER BY a.attnum
+                    ORDER BY pk.ord
                     """
                 )
             )
@@ -49,9 +51,11 @@ async def test_alembic_creates_pgvector_vector_index_entry_contract(
     assert "id" not in columns
     assert "embedding" not in columns
     assert columns["chunk_id"][1] == "uuid"
+    assert columns["index_name"][1] == "varchar"
     assert columns["user_id"][1] == "uuid"
+    assert columns["project_id"][1] == "uuid"
     assert columns["video_id"][1] == "uuid"
     assert columns["embedding_vector"][1] == "vector"
     assert columns["embedding_model_version"][1] == "varchar"
     assert columns["created_at"][1] == "timestamptz"
-    assert primary_key_columns == ["chunk_id"]
+    assert primary_key_columns == ["index_name", "chunk_id"]

--- a/services/core-api/tests/unit/test_admin_ops_schemas.py
+++ b/services/core-api/tests/unit/test_admin_ops_schemas.py
@@ -1,0 +1,98 @@
+from datetime import UTC, datetime
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.schemas.admin_ops import ControlMessage, ControlMessageType, MLPipelineRunStatus
+from src.schemas.feedback_dto import FeedbackEvent, FeedbackRating, FeedbackRequest
+
+
+def test_control_message_accepts_training_request_without_video_id() -> None:
+    payload = {
+        "message_type": ControlMessageType.TRAINING_REQUEST.value,
+        "payload_version": "v1",
+        "trace_id": str(uuid4()),
+        "attempt": 1,
+        "issued_at": datetime(2026, 4, 21, 12, 0, tzinfo=UTC).isoformat(),
+    }
+
+    message = ControlMessage.model_validate(payload)
+
+    assert message.message_type is ControlMessageType.TRAINING_REQUEST
+    assert "video_id" not in message.model_dump()
+
+
+def test_control_message_rejects_video_id_field() -> None:
+    payload = {
+        "message_type": ControlMessageType.ROLLBACK_REQUEST.value,
+        "payload_version": "v1",
+        "trace_id": str(uuid4()),
+        "attempt": 1,
+        "issued_at": datetime(2026, 4, 21, 12, 0, tzinfo=UTC).isoformat(),
+        "video_id": str(uuid4()),
+    }
+
+    with pytest.raises(ValidationError):
+        ControlMessage.model_validate(payload)
+
+
+def test_feedback_event_preserves_snapshot_context_fields() -> None:
+    chunk_id = uuid4()
+    payload = {
+        "schema_version": 1,
+        "event_id": str(uuid4()),
+        "user_id": str(uuid4()),
+        "project_id": str(uuid4()),
+        "req_id": str(uuid4()),
+        "query_text": "find key point",
+        "rating": FeedbackRating.LIKE.value,
+        "topk_ids": [str(chunk_id)],
+        "used_ids": [str(chunk_id)],
+        "active_model_version": "embedding-v1",
+        "active_index_name": "active-index",
+        "response_snapshot_ref": "snapshot/ref",
+        "created_at": datetime(2026, 4, 21, 12, 0, tzinfo=UTC).isoformat(),
+        "trace_id": str(uuid4()),
+    }
+
+    event = FeedbackEvent.model_validate(payload)
+
+    assert event.schema_version == 1
+    assert event.rating is FeedbackRating.LIKE
+    assert event.topk_ids == [chunk_id]
+    assert event.used_ids == [chunk_id]
+
+
+def test_feedback_request_accepts_only_public_fields() -> None:
+    req_id = uuid4()
+    request = FeedbackRequest.model_validate(
+        {
+            "req_id": str(req_id),
+            "rating": FeedbackRating.DISLIKE.value,
+        }
+    )
+
+    assert request.req_id == req_id
+    assert request.rating is FeedbackRating.DISLIKE
+
+
+def test_feedback_request_rejects_internal_event_fields() -> None:
+    with pytest.raises(ValidationError):
+        FeedbackRequest.model_validate(
+            {
+                "req_id": str(uuid4()),
+                "rating": FeedbackRating.LIKE.value,
+                "user_id": str(uuid4()),
+            }
+        )
+
+
+def test_ml_run_status_values_match_foundation_contract() -> None:
+    assert {status.value for status in MLPipelineRunStatus} == {
+        "PENDING",
+        "RUNNING",
+        "READY_FOR_RELEASE",
+        "FAILED",
+        "SUPERSEDED",
+    }

--- a/services/core-api/tests/unit/test_broker.py
+++ b/services/core-api/tests/unit/test_broker.py
@@ -6,7 +6,7 @@ import pytest
 
 from src.core.config import Settings
 from src.core.dependencies import _build_broker_client
-from src.infra.broker import BrokerPublishError, build_message
+from src.infra.broker import BrokerPublishError, build_control_message, build_message
 from src.infra.inmemory_broker import InMemoryBrokerClient
 from src.infra.pgmq_client import PGMQBrokerClient
 
@@ -49,6 +49,38 @@ async def test_pgmq_broker_publishes_spec_payload_to_matching_queue() -> None:
                     "trace_id": str(trace_id),
                     "attempt": 1,
                     "video_id": str(video_id),
+                    "issued_at": issued_at.isoformat(),
+                }
+            ),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_pgmq_broker_publishes_control_message_without_video_id() -> None:
+    trace_id = uuid4()
+    issued_at = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    message = build_control_message(
+        "TRAINING_REQUEST",
+        trace_id=trace_id,
+        issued_at=issued_at,
+    )
+    connection = FakePGMQConnection(message_id=8)
+    client = PGMQBrokerClient(connection)
+
+    message_id = await client.publish(message)
+
+    assert message_id == 8
+    assert connection.calls == [
+        (
+            "SELECT pgmq.send(queue_name => $1, msg => $2::jsonb)",
+            "TRAINING_REQUEST",
+            json.dumps(
+                {
+                    "message_type": "TRAINING_REQUEST",
+                    "payload_version": "v1",
+                    "trace_id": str(trace_id),
+                    "attempt": 1,
                     "issued_at": issued_at.isoformat(),
                 }
             ),

--- a/services/pipeline-worker/src/infra/db/artifact_repository.py
+++ b/services/pipeline-worker/src/infra/db/artifact_repository.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from src.infra.db.models import AssetModel, ChunkModel, TranscriptSegmentModel, VectorIndexEntryModel, VideoModel
 
+DEFAULT_VECTOR_INDEX_NAME = "default-index"
+
 
 @dataclass(slots=True)
 class AssetRecord:
@@ -41,6 +43,12 @@ class ChunkRecord:
     scene_tags: str = ""
     keyframe_asset_id: UUID | str | None = None
     id: UUID | str | None = None
+
+
+@dataclass(slots=True)
+class VectorScope:
+    user_id: UUID
+    project_id: UUID | None
 
 
 class ArtifactRepository:
@@ -198,7 +206,7 @@ class ArtifactRepository:
         embedding_model_version = chunks[0].embedding_model_version
 
         async with self._session_factory() as session:
-            owner_id = await self._load_video_owner_id(session, normalized_video_id)
+            vector_scope = await self._load_vector_scope(session, normalized_video_id)
             existing_chunk_ids = (
                 await session.execute(
                     select(ChunkModel.id).where(
@@ -242,8 +250,10 @@ class ArtifactRepository:
                 )
                 session.add(
                     VectorIndexEntryModel(
+                        index_name=DEFAULT_VECTOR_INDEX_NAME,
                         chunk_id=chunk_id,
-                        user_id=owner_id,
+                        user_id=vector_scope.user_id,
+                        project_id=vector_scope.project_id,
                         video_id=normalized_video_id,
                         embedding_vector=embedding,
                         embedding_model_version=chunk.embedding_model_version,
@@ -312,13 +322,20 @@ class ArtifactRepository:
             return list(result.scalars().all())
 
     @staticmethod
-    async def _load_video_owner_id(session: AsyncSession, video_id: UUID) -> UUID:
-        owner_id = await session.scalar(
-            select(VideoModel.user_id).where(VideoModel.id == video_id)
-        )
-        if owner_id is None:
+    async def _load_vector_scope(session: AsyncSession, video_id: UUID) -> VectorScope:
+        row = (
+            await session.execute(
+                select(VideoModel.user_id, VideoModel.project_id).where(
+                    VideoModel.id == video_id
+                )
+            )
+        ).one_or_none()
+        if row is None:
             raise ValueError(f"Video not found for vector persistence: {video_id}")
-        return owner_id
+        return VectorScope(
+            user_id=row.user_id,
+            project_id=row.project_id,
+        )
 
     @staticmethod
     def _normalize_uuid(value: UUID | str) -> UUID:

--- a/services/pipeline-worker/src/infra/db/models.py
+++ b/services/pipeline-worker/src/infra/db/models.py
@@ -3,6 +3,7 @@ from uuid import UUID
 
 from pgvector.sqlalchemy import Vector
 from sqlalchemy import JSON, DateTime, ForeignKey, Integer, String, Text, Uuid, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -11,6 +12,31 @@ class Base(DeclarativeBase):
 
 
 VECTOR_COLUMN_TYPE = Vector().with_variant(JSON(), "sqlite")
+METADATA_JSON_TYPE = JSON().with_variant(JSONB(), "postgresql")
+
+
+class ProjectModel(Base):
+    __tablename__ = "project"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    search_serving_state: Mapped[str] = mapped_column(
+        Text(), nullable=False, default="SERVABLE"
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
 
 
 class VideoModel(Base):
@@ -18,6 +44,9 @@ class VideoModel(Base):
 
     id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
     user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    project_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("project.id"), nullable=True
+    )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     category: Mapped[str] = mapped_column(Text(), nullable=False)
     input_type: Mapped[str] = mapped_column(Text(), nullable=False)
@@ -85,8 +114,16 @@ class ChunkModel(Base):
 class VectorIndexEntryModel(Base):
     __tablename__ = "vector_index_entry"
 
+    index_name: Mapped[str] = mapped_column(
+        String(128),
+        primary_key=True,
+        default="default-index",
+    )
     chunk_id: Mapped[UUID] = mapped_column(ForeignKey("chunk.id"), primary_key=True)
     user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    project_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("project.id"), nullable=True
+    )
     video_id: Mapped[UUID] = mapped_column(ForeignKey("video.id"))
     embedding_vector: Mapped[list[float]] = mapped_column(VECTOR_COLUMN_TYPE, nullable=False)
     embedding_model_version: Mapped[str] = mapped_column(String(64))
@@ -94,5 +131,85 @@ class VectorIndexEntryModel(Base):
         DateTime(timezone=True),
         nullable=False,
         default=func.now(),
+        server_default=func.now(),
+    )
+
+
+class ModelEvaluationModel(Base):
+    __tablename__ = "model_evaluation"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    candidate_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    baseline_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    evaluation_dataset_ref: Mapped[str] = mapped_column(Text(), nullable=False)
+    sample_count: Mapped[int] = mapped_column(Integer(), nullable=False)
+    status: Mapped[str] = mapped_column(Text(), nullable=False)
+    quality_metrics: Mapped[dict[str, float]] = mapped_column(
+        METADATA_JSON_TYPE, nullable=False
+    )
+    pass_criteria: Mapped[dict[str, object]] = mapped_column(
+        METADATA_JSON_TYPE, nullable=False
+    )
+    overall_decision: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    fail_reason: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class MLPipelineRunModel(Base):
+    __tablename__ = "ml_pipeline_run"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    status: Mapped[str] = mapped_column(Text(), nullable=False)
+    failed_stage: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    failure_type: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    failure_reason: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    candidate_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    dataset_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    evaluation_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("model_evaluation.id"), nullable=True
+    )
+    cutover_time: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    superseded_by_run_id: Mapped[UUID | None] = mapped_column(Uuid(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class ModelReleaseModel(Base):
+    __tablename__ = "model_release"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    release_status: Mapped[str] = mapped_column(Text(), nullable=False, default="STABLE")
+    active_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    active_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    previous_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    previous_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    rollback_snapshot_active_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    rollback_snapshot_active_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    rollback_snapshot_captured_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    candidate_ready_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    switched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
         server_default=func.now(),
     )

--- a/services/pipeline-worker/src/infra/db/video_repository.py
+++ b/services/pipeline-worker/src/infra/db/video_repository.py
@@ -14,6 +14,7 @@ VideoStatus = Literal["PENDING", "UPLOADED", "PROCESSING", "READY", "FAILED", "D
 class VideoRecord:
     id: UUID | str
     user_id: UUID | str
+    project_id: UUID | str | None = None
     title: str = ""
     category: str = "GENERAL"
     input_type: str = "LOCAL_FILE"
@@ -38,11 +39,17 @@ class VideoRepository:
     async def create_video(self, video: VideoRecord) -> None:
         video_id = self._normalize_uuid(video.id)
         user_id = self._normalize_uuid(video.user_id)
+        project_id = (
+            self._normalize_uuid(video.project_id)
+            if video.project_id is not None
+            else None
+        )
         async with self._session_factory() as session:
             session.add(
                 VideoModel(
                     id=video_id,
                     user_id=user_id,
+                    project_id=project_id,
                     title=video.title,
                     category=video.category,
                     input_type=video.input_type,
@@ -184,6 +191,7 @@ class VideoRepository:
         return VideoRecord(
             id=model.id,
             user_id=model.user_id,
+            project_id=model.project_id,
             title=model.title,
             category=model.category,
             input_type=model.input_type,

--- a/services/pipeline-worker/src/schemas/__init__.py
+++ b/services/pipeline-worker/src/schemas/__init__.py
@@ -1,5 +1,5 @@
 """Message schema package."""
 
-from src.schemas.messages import MessageEnvelope, MessageType
+from src.schemas.messages import ControlMessage, ControlMessageType, MessageEnvelope, MessageType
 
-__all__ = ["MessageEnvelope", "MessageType"]
+__all__ = ["ControlMessage", "ControlMessageType", "MessageEnvelope", "MessageType"]

--- a/services/pipeline-worker/src/schemas/messages.py
+++ b/services/pipeline-worker/src/schemas/messages.py
@@ -10,8 +10,13 @@ class MessageType(str, Enum):
     DELETE_REQUEST = "DELETE_REQUEST"
 
 
+class ControlMessageType(str, Enum):
+    TRAINING_REQUEST = "TRAINING_REQUEST"
+    ROLLBACK_REQUEST = "ROLLBACK_REQUEST"
+
+
 class MessageEnvelope(BaseModel):
-    model_config = ConfigDict(use_enum_values=False)
+    model_config = ConfigDict(use_enum_values=False, extra="forbid")
 
     message_type: MessageType
     payload_version: str = Field(..., pattern=r"^v\d+$")
@@ -27,3 +32,13 @@ class MessageEnvelope(BaseModel):
     @property
     def is_delete(self) -> bool:
         return self.message_type == MessageType.DELETE_REQUEST
+
+
+class ControlMessage(BaseModel):
+    model_config = ConfigDict(use_enum_values=False, extra="forbid")
+
+    message_type: ControlMessageType
+    payload_version: str = Field(..., pattern=r"^v\d+$")
+    trace_id: UUID
+    attempt: int = Field(..., ge=1)
+    issued_at: datetime

--- a/services/pipeline-worker/tests/integration/test_repositories.py
+++ b/services/pipeline-worker/tests/integration/test_repositories.py
@@ -92,5 +92,7 @@ async def test_persist_chunks_and_vectors_stores_vector_entries_with_video_owner
     assert stored_chunks[0].id == vector_entry.chunk_id
     assert vector_entry.user_id == stored_video.user_id
     assert vector_entry.video_id == stored_video.id
+    assert vector_entry.project_id == stored_video.project_id
+    assert vector_entry.index_name == "default-index"
     assert stored_vectors[0] == pytest.approx([1.0, 2.0])
     assert vector_entry.embedding_vector == pytest.approx([1.0, 2.0])

--- a/services/pipeline-worker/tests/unit/test_db_models.py
+++ b/services/pipeline-worker/tests/unit/test_db_models.py
@@ -1,0 +1,12 @@
+from src.infra.db.models import Base
+
+
+def test_vector_index_entry_model_matches_release_serving_contract() -> None:
+    table = Base.metadata.tables["vector_index_entry"]
+
+    assert "index_name" in table.columns
+    assert "project_id" in table.columns
+    assert [column.name for column in table.primary_key.columns] == [
+        "index_name",
+        "chunk_id",
+    ]

--- a/services/pipeline-worker/tests/unit/test_message_schemas.py
+++ b/services/pipeline-worker/tests/unit/test_message_schemas.py
@@ -4,7 +4,8 @@ from uuid import uuid4
 import pytest
 from pydantic import ValidationError
 
-from src.schemas import MessageEnvelope, MessageType
+from src.schemas import ControlMessage, ControlMessageType, MessageEnvelope, MessageType
+from src.infra.db.models import Base
 
 
 def _base_payload(message_type: str) -> dict:
@@ -37,3 +38,41 @@ def test_envelope_requires_fields() -> None:
     payload.pop("video_id")
     with pytest.raises(ValidationError):
         MessageEnvelope.model_validate(payload)
+
+
+def test_control_message_parses_training_request_without_video_id() -> None:
+    payload = {
+        "message_type": ControlMessageType.TRAINING_REQUEST.value,
+        "payload_version": "v1",
+        "trace_id": str(uuid4()),
+        "attempt": 1,
+        "issued_at": datetime.now(UTC).isoformat(),
+    }
+
+    message = ControlMessage.model_validate(payload)
+
+    assert message.message_type is ControlMessageType.TRAINING_REQUEST
+    assert "video_id" not in message.model_dump()
+
+
+def test_control_message_rejects_video_id_field() -> None:
+    payload = {
+        "message_type": ControlMessageType.ROLLBACK_REQUEST.value,
+        "payload_version": "v1",
+        "trace_id": str(uuid4()),
+        "attempt": 1,
+        "issued_at": datetime.now(UTC).isoformat(),
+        "video_id": str(uuid4()),
+    }
+
+    with pytest.raises(ValidationError):
+        ControlMessage.model_validate(payload)
+
+
+def test_admin_ops_foundation_models_match_shared_columns() -> None:
+    tables = Base.metadata.tables
+
+    assert "project_id" in tables["video"].columns
+    assert "quality_metrics" in tables["model_evaluation"].columns
+    assert "pass_criteria" in tables["model_evaluation"].columns
+    assert "release_status" in tables["model_release"].columns

--- a/services/search-service/src/api/v1/routers/search.py
+++ b/services/search-service/src/api/v1/routers/search.py
@@ -42,6 +42,7 @@ async def search(
 
     result = await orchestrator.execute(
         user_id=user.requester_user_id,
+        project_id=body.project_id,
         query=normalized,
         trace_id=trace_id,
     )

--- a/services/search-service/src/infra/db/models.py
+++ b/services/search-service/src/infra/db/models.py
@@ -8,7 +8,8 @@ from datetime import datetime
 from uuid import UUID
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, Uuid, func
+from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text, Uuid, func
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
 
@@ -16,11 +17,32 @@ class Base(DeclarativeBase):
     pass
 
 
+SNAPSHOT_JSON_TYPE = JSON().with_variant(JSONB(), "postgresql")
+
+
+class ProjectModel(Base):
+    __tablename__ = "project"
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    search_serving_state: Mapped[str] = mapped_column(Text(), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
 class VideoModel(Base):
     __tablename__ = "video"
 
     id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
     user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    project_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("project.id"), nullable=True
+    )
     title: Mapped[str] = mapped_column(String(255), nullable=False)
     status: Mapped[str] = mapped_column(Text(), nullable=False)
     created_at: Mapped[datetime] = mapped_column(
@@ -43,13 +65,39 @@ class ChunkModel(Base):
     end_ms: Mapped[int] = mapped_column(Integer(), nullable=False)
 
 
+class SearchResponseSnapshotModel(Base):
+    __tablename__ = "search_response_snapshot"
+
+    req_id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True)
+    user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    project_id: Mapped[UUID] = mapped_column(ForeignKey("project.id"), nullable=False)
+    query_text: Mapped[str] = mapped_column(Text(), nullable=False)
+    topk_chunk_ids: Mapped[list[str]] = mapped_column(SNAPSHOT_JSON_TYPE, nullable=False)
+    used_chunk_ids: Mapped[list[str]] = mapped_column(SNAPSHOT_JSON_TYPE, nullable=False)
+    active_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    active_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    served_vector_paths: Mapped[list[dict[str, str]]] = mapped_column(
+        SNAPSHOT_JSON_TYPE, nullable=False
+    )
+    project_serving_state: Mapped[str] = mapped_column(Text(), nullable=False)
+    scope_notice: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
 class VectorIndexEntryModel(Base):
     __tablename__ = "vector_index_entry"
 
+    index_name: Mapped[str] = mapped_column(String(128), primary_key=True)
     chunk_id: Mapped[UUID] = mapped_column(
         ForeignKey("chunk.id"), primary_key=True
     )
     user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    project_id: Mapped[UUID | None] = mapped_column(
+        ForeignKey("project.id"), nullable=True
+    )
     video_id: Mapped[UUID] = mapped_column(ForeignKey("video.id"), nullable=False)
     embedding_vector: Mapped[list[float]] = mapped_column(
         Vector(), nullable=False

--- a/services/search-service/src/infra/db/search_repository.py
+++ b/services/search-service/src/infra/db/search_repository.py
@@ -1,15 +1,32 @@
-"""Read-only repository for search queries.
+"""Repository for search queries and response snapshot writes.
 
-Provides: corpus readiness check, FTS, ANN, SOT gate.
+Provides: corpus readiness check, FTS, ANN, SOT gate, SearchResponseSnapshot sink.
 """
 
 from dataclasses import dataclass
+from datetime import datetime
 from uuid import UUID
 
-from sqlalchemy import select, text
+from sqlalchemy import exists, not_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+from sqlalchemy.orm import aliased
 
-from src.infra.db.models import ChunkModel, VectorIndexEntryModel, VideoModel
+from src.infra.db.models import ChunkModel, ProjectModel, SearchResponseSnapshotModel, VideoModel
+
+DEFAULT_VECTOR_INDEX_NAME = "default-index"
+
+
+PROJECT_SERVING_GATE_SQL = """
+(
+    p.search_serving_state = 'SERVABLE'
+    AND NOT EXISTS (
+        SELECT 1
+        FROM video project_video
+        WHERE project_video.project_id = p.id
+          AND project_video.status != 'READY'
+    )
+)
+"""
 
 
 @dataclass(slots=True)
@@ -45,20 +62,43 @@ class ANNCandidate:
     rank: int
 
 
+@dataclass(frozen=True, slots=True)
+class SearchResponseSnapshotWrite:
+    req_id: UUID
+    user_id: UUID
+    project_id: UUID
+    query_text: str
+    topk_chunk_ids: list[str]
+    used_chunk_ids: list[str]
+    active_model_version: str
+    active_index_name: str
+    served_vector_paths: list[dict[str, str]]
+    project_serving_state: str
+    expires_at: datetime
+    scope_notice: str | None = None
+
+
 class SearchRepository:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
 
-    async def check_corpus_readiness(self, user_id: UUID) -> CorpusReadiness:
-        """Single-query readiness check: total video count + non-ready count."""
+    async def check_corpus_readiness(
+        self, user_id: UUID, project_id: UUID
+    ) -> CorpusReadiness:
+        """Single-project readiness check: total video count + non-ready count."""
         async with self._session_factory() as session:
             stmt = text("""
                 SELECT COUNT(*) AS total,
-                       COUNT(*) FILTER (WHERE status != 'READY') AS non_ready
-                FROM video
-                WHERE user_id = :user_id
+                       COUNT(*) FILTER (WHERE v.status != 'READY') AS non_ready
+                FROM video v
+                JOIN project p ON v.project_id = p.id
+                WHERE v.user_id = :user_id
+                  AND p.user_id = :user_id
+                  AND v.project_id = :project_id
             """)
-            result = await session.execute(stmt, {"user_id": user_id})
+            result = await session.execute(
+                stmt, {"user_id": user_id, "project_id": project_id}
+            )
             row = result.one()
             return CorpusReadiness(
                 total_videos=row.total,
@@ -66,12 +106,14 @@ class SearchRepository:
             )
 
     async def fts_search(
-        self, user_id: UUID, query: str, *, top_k: int
+        self, user_id: UUID, project_id: UUID, query: str, *, top_k: int
     ) -> list[FTSCandidate]:
         """FTS keyword search on chunk text with user tenancy via video join.
 
         Uses PostgreSQL ts_rank + to_tsvector/to_tsquery for ranking.
         FTS target text is COALESCE(enriched_text, text) per SPEC §2.2.
+        Project-scoped chunks are served only when the project is `SERVABLE`
+        and every video in that project is `READY`.
         """
         async with self._session_factory() as session:
             stmt = text("""
@@ -84,15 +126,25 @@ class SearchRepository:
                        ) AS rank
                 FROM chunk c
                 JOIN video v ON c.video_id = v.id
+                JOIN project p ON v.project_id = p.id
                 WHERE v.user_id = :user_id
+                  AND v.project_id = :project_id
+                  AND p.user_id = :user_id
                   AND v.status = 'READY'
+                  AND """ + PROJECT_SERVING_GATE_SQL + """
                   AND to_tsvector('simple', COALESCE(c.enriched_text, c.text))
                       @@ plainto_tsquery('simple', :query)
                 ORDER BY rank
                 LIMIT :top_k
             """)
             result = await session.execute(
-                stmt, {"user_id": user_id, "query": query, "top_k": top_k}
+                stmt,
+                {
+                    "user_id": user_id,
+                    "project_id": project_id,
+                    "query": query,
+                    "top_k": top_k,
+                },
             )
             return [
                 FTSCandidate(chunk_id=row.chunk_id, rank=row.rank)
@@ -100,7 +152,12 @@ class SearchRepository:
             ]
 
     async def ann_search(
-        self, user_id: UUID, query_embedding: list[float], *, top_k: int
+        self,
+        user_id: UUID,
+        project_id: UUID,
+        query_embedding: list[float],
+        *,
+        top_k: int,
     ) -> list[ANNCandidate]:
         """ANN vector search on vector_index_entry with READY video filter.
 
@@ -115,8 +172,15 @@ class SearchRepository:
                        ) AS rank
                 FROM vector_index_entry vie
                 JOIN video v ON vie.video_id = v.id
+                JOIN project p ON v.project_id = p.id
                 WHERE vie.user_id = :user_id
+                  AND vie.project_id = :project_id
+                  AND v.project_id = :project_id
+                  AND p.user_id = :user_id
+                  AND vie.index_name = :index_name
+                  AND vie.project_id IS NOT DISTINCT FROM v.project_id
                   AND v.status = 'READY'
+                  AND """ + PROJECT_SERVING_GATE_SQL + """
                 ORDER BY vie.embedding_vector <=> CAST(:query_embedding AS vector)
                 LIMIT :top_k
             """)
@@ -124,6 +188,8 @@ class SearchRepository:
                 stmt,
                 {
                     "user_id": user_id,
+                    "project_id": project_id,
+                    "index_name": DEFAULT_VECTOR_INDEX_NAME,
                     "query_embedding": str(query_embedding),
                     "top_k": top_k,
                 },
@@ -134,9 +200,9 @@ class SearchRepository:
             ]
 
     async def sot_gate(
-        self, user_id: UUID, chunk_ids: list[UUID]
+        self, user_id: UUID, project_id: UUID, chunk_ids: list[UUID]
     ) -> list[ChunkRecord]:
-        """SOT serving gate: verify chunks belong to READY videos owned by user.
+        """SOT serving gate: verify chunks belong to a servable READY project.
 
         Returns only chunks that pass the gate, with full metadata for response.
         """
@@ -144,6 +210,7 @@ class SearchRepository:
             return []
 
         async with self._session_factory() as session:
+            project_video = aliased(VideoModel)
             stmt = (
                 select(
                     ChunkModel.id.label("chunk_id"),
@@ -155,10 +222,19 @@ class SearchRepository:
                     ChunkModel.end_ms,
                 )
                 .join(VideoModel, ChunkModel.video_id == VideoModel.id)
+                .join(ProjectModel, VideoModel.project_id == ProjectModel.id)
                 .where(
                     ChunkModel.id.in_(chunk_ids),
                     VideoModel.user_id == user_id,
+                    VideoModel.project_id == project_id,
                     VideoModel.status == "READY",
+                    ProjectModel.user_id == user_id,
+                    ProjectModel.search_serving_state == "SERVABLE",
+                    not_(
+                        exists()
+                        .where(project_video.project_id == ProjectModel.id)
+                        .where(project_video.status != "READY")
+                    ),
                 )
             )
             result = await session.execute(stmt)
@@ -174,3 +250,26 @@ class SearchRepository:
                 )
                 for row in result
             ]
+
+    async def save_search_response_snapshot(
+        self, snapshot: SearchResponseSnapshotWrite
+    ) -> None:
+        """Persist search response context for later feedback attribution."""
+        async with self._session_factory() as session:
+            session.add(
+                SearchResponseSnapshotModel(
+                    req_id=snapshot.req_id,
+                    user_id=snapshot.user_id,
+                    project_id=snapshot.project_id,
+                    query_text=snapshot.query_text,
+                    topk_chunk_ids=snapshot.topk_chunk_ids,
+                    used_chunk_ids=snapshot.used_chunk_ids,
+                    active_model_version=snapshot.active_model_version,
+                    active_index_name=snapshot.active_index_name,
+                    served_vector_paths=snapshot.served_vector_paths,
+                    project_serving_state=snapshot.project_serving_state,
+                    scope_notice=snapshot.scope_notice,
+                    expires_at=snapshot.expires_at,
+                )
+            )
+            await session.commit()

--- a/services/search-service/src/schemas/search_dto.py
+++ b/services/search-service/src/schemas/search_dto.py
@@ -24,6 +24,7 @@ def normalize_query(raw: str) -> str:
 class SearchRequest(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
+    project_id: UUID
     query: str = Field(min_length=1)
 
 

--- a/services/search-service/src/services/search_orchestrator.py
+++ b/services/search-service/src/services/search_orchestrator.py
@@ -82,13 +82,14 @@ class SearchOrchestrator:
         self,
         *,
         user_id: UUID,
+        project_id: UUID,
         query: str,
         trace_id: str,
     ) -> SearchResult:
         req_id = uuid4()
 
         # Steps 5-6: Single-query corpus readiness gate
-        readiness = await self._repo.check_corpus_readiness(user_id)
+        readiness = await self._repo.check_corpus_readiness(user_id, project_id)
         if readiness.total_videos == 0:
             raise NoVideosUploadedError()
         if readiness.non_ready_count > 0:
@@ -97,7 +98,7 @@ class SearchOrchestrator:
         # Steps 7-8
         query_embedding = await self._embed_query(query, trace_id)
         fts_results, ann_results = await self._retrieve(
-            user_id, query, query_embedding
+            user_id, project_id, query, query_embedding
         )
 
         # Steps 9-10
@@ -105,7 +106,7 @@ class SearchOrchestrator:
         if not merged:
             return _empty_result(req_id)
 
-        records = await self._sot_gate(user_id, merged)
+        records = await self._sot_gate(user_id, project_id, merged)
         if not records:
             return _empty_result(req_id)
 
@@ -135,14 +136,17 @@ class SearchOrchestrator:
     async def _retrieve(
         self,
         user_id: UUID,
+        project_id: UUID,
         query: str,
         query_embedding: list[float],
     ) -> tuple[list[FTSCandidate], list[ANNCandidate]]:
         """Step 7: FTS/ANN parallel retrieval."""
         return await asyncio.gather(
-            self._repo.fts_search(user_id, query, top_k=self._search_top_k),
+            self._repo.fts_search(
+                user_id, project_id, query, top_k=self._search_top_k
+            ),
             self._repo.ann_search(
-                user_id, query_embedding, top_k=self._search_top_k
+                user_id, project_id, query_embedding, top_k=self._search_top_k
             ),
         )
 
@@ -159,11 +163,12 @@ class SearchOrchestrator:
     async def _sot_gate(
         self,
         user_id: UUID,
+        project_id: UUID,
         merged: list[RRFCandidate],
     ) -> list[ChunkRecord]:
         """Step 9: SOT serving gate — verify ownership and READY status."""
         chunk_ids = [c.chunk_id for c in merged]
-        return await self._repo.sot_gate(user_id, chunk_ids)
+        return await self._repo.sot_gate(user_id, project_id, chunk_ids)
 
     @staticmethod
     def _order_records(

--- a/services/search-service/tests/api/test_search.py
+++ b/services/search-service/tests/api/test_search.py
@@ -34,6 +34,7 @@ from src.services.search_orchestrator import SearchOrchestrator
 
 TEST_SECRET = "test-secret-key-for-search-service-32b"
 TEST_USER_ID = uuid4()
+TEST_PROJECT_ID = uuid4()
 SEARCH_URL = "/api/v1/search"
 
 
@@ -166,7 +167,9 @@ async def _post(
     ) as client:
         return await client.post(
             SEARCH_URL,
-            json=json_body if json_body is not None else {"query": query},
+            json=json_body
+            if json_body is not None
+            else {"query": query, "project_id": str(TEST_PROJECT_ID)},
             headers=headers if headers is not None else _auth_headers(),
         )
 

--- a/services/search-service/tests/integration/test_search_repository.py
+++ b/services/search-service/tests/integration/test_search_repository.py
@@ -4,6 +4,7 @@ Uses testcontainers to spin up a real PostgreSQL instance with pgvector.
 Tests: readiness gate, searchable corpus check, FTS search, ANN search, SOT gate.
 """
 
+from datetime import UTC, datetime, timedelta
 from uuid import uuid4
 
 import pytest
@@ -11,8 +12,8 @@ import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from src.infra.db.models import Base, ChunkModel, VectorIndexEntryModel, VideoModel
-from src.infra.db.search_repository import SearchRepository
+from src.infra.db.models import Base, ChunkModel, ProjectModel, VectorIndexEntryModel, VideoModel
+from src.infra.db.search_repository import SearchRepository, SearchResponseSnapshotWrite
 
 # Testcontainers import is optional; skip all tests if unavailable
 try:
@@ -66,14 +67,45 @@ def repo(session_factory) -> SearchRepository:
 
 
 async def _seed_video(
-    session: AsyncSession, *, user_id, status="READY", title="Test Video"
+    session: AsyncSession,
+    *,
+    user_id,
+    status="READY",
+    title="Test Video",
+    project_id=None,
 ):
     vid = uuid4()
     session.add(
-        VideoModel(id=vid, user_id=user_id, title=title, status=status)
+        VideoModel(
+            id=vid,
+            user_id=user_id,
+            project_id=project_id,
+            title=title,
+            status=status,
+        )
     )
     await session.flush()
     return vid
+
+
+async def _seed_project(
+    session: AsyncSession,
+    *,
+    user_id,
+    search_serving_state="SERVABLE",
+    title="Test Project",
+):
+    pid = uuid4()
+    session.add(
+        ProjectModel(
+            id=pid,
+            user_id=user_id,
+            title=title,
+            search_serving_state=search_serving_state,
+        )
+    )
+    await session.flush()
+    return pid
 
 
 async def _seed_chunk(
@@ -104,10 +136,16 @@ async def _seed_chunk(
 async def _seed_vector(
     session: AsyncSession, *, chunk_id, user_id, video_id, embedding=None
 ):
+    project_id = await session.scalar(
+        text("SELECT project_id FROM video WHERE id = :video_id"),
+        {"video_id": video_id},
+    )
     session.add(
         VectorIndexEntryModel(
+            index_name="default-index",
             chunk_id=chunk_id,
             user_id=user_id,
+            project_id=project_id,
             video_id=video_id,
             embedding_vector=embedding or [0.1, 0.2, 0.3],
             embedding_model_version="test-v001",
@@ -118,27 +156,29 @@ async def _seed_vector(
 
 class TestCheckCorpusReadiness:
     async def test_user_with_no_videos(self, repo) -> None:
-        result = await repo.check_corpus_readiness(uuid4())
+        result = await repo.check_corpus_readiness(uuid4(), uuid4())
         assert result.total_videos == 0
         assert result.non_ready_count == 0
 
     async def test_user_with_only_ready_videos(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            await _seed_video(session, user_id=user, status="READY")
+            project_id = await _seed_project(session, user_id=user)
+            await _seed_video(session, user_id=user, project_id=project_id, status="READY")
             await session.commit()
 
-        result = await repo.check_corpus_readiness(user)
+        result = await repo.check_corpus_readiness(user, project_id)
         assert result.total_videos == 1
         assert result.non_ready_count == 0
 
     async def test_user_with_pending_video(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            await _seed_video(session, user_id=user, status="PENDING")
+            project_id = await _seed_project(session, user_id=user)
+            await _seed_video(session, user_id=user, project_id=project_id, status="PENDING")
             await session.commit()
 
-        result = await repo.check_corpus_readiness(user)
+        result = await repo.check_corpus_readiness(user, project_id)
         assert result.total_videos == 1
         assert result.non_ready_count == 1
 
@@ -147,11 +187,14 @@ class TestCheckCorpusReadiness:
     ) -> None:
         user = uuid4()
         async with session_factory() as session:
-            await _seed_video(session, user_id=user, status="READY")
-            await _seed_video(session, user_id=user, status="PROCESSING")
+            project_id = await _seed_project(session, user_id=user)
+            await _seed_video(session, user_id=user, project_id=project_id, status="READY")
+            await _seed_video(
+                session, user_id=user, project_id=project_id, status="PROCESSING"
+            )
             await session.commit()
 
-        result = await repo.check_corpus_readiness(user)
+        result = await repo.check_corpus_readiness(user, project_id)
         assert result.total_videos == 2
         assert result.non_ready_count == 1
 
@@ -161,10 +204,13 @@ class TestCheckCorpusReadiness:
         owner = uuid4()
         other = uuid4()
         async with session_factory() as session:
-            await _seed_video(session, user_id=owner, status="PROCESSING")
+            project_id = await _seed_project(session, user_id=owner)
+            await _seed_video(
+                session, user_id=owner, project_id=project_id, status="PROCESSING"
+            )
             await session.commit()
 
-        result = await repo.check_corpus_readiness(other)
+        result = await repo.check_corpus_readiness(other, project_id)
         assert result.total_videos == 0
         assert result.non_ready_count == 0
 
@@ -173,7 +219,8 @@ class TestFTSSearch:
     async def test_finds_matching_chunk(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user)
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(session, user_id=user, project_id=project_id)
             await _seed_chunk(
                 session,
                 video_id=vid,
@@ -182,38 +229,43 @@ class TestFTSSearch:
             )
             await session.commit()
 
-        results = await repo.fts_search(user, "machine learning", top_k=10)
+        results = await repo.fts_search(user, project_id, "machine learning", top_k=10)
         assert len(results) >= 1
 
     async def test_no_match_returns_empty(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user)
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(session, user_id=user, project_id=project_id)
             await _seed_chunk(session, video_id=vid, text_val="cooking recipe")
             await session.commit()
 
-        results = await repo.fts_search(user, "quantum physics", top_k=10)
+        results = await repo.fts_search(user, project_id, "quantum physics", top_k=10)
         assert len(results) == 0
 
     async def test_tenancy_enforced(self, session_factory, repo) -> None:
         owner = uuid4()
         other = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=owner)
+            project_id = await _seed_project(session, user_id=owner)
+            vid = await _seed_video(session, user_id=owner, project_id=project_id)
             await _seed_chunk(session, video_id=vid, text_val="secret data")
             await session.commit()
 
-        results = await repo.fts_search(other, "secret data", top_k=10)
+        results = await repo.fts_search(other, project_id, "secret data", top_k=10)
         assert len(results) == 0
 
     async def test_non_ready_video_excluded(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user, status="PROCESSING")
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(
+                session, user_id=user, project_id=project_id, status="PROCESSING"
+            )
             await _seed_chunk(session, video_id=vid, text_val="test data")
             await session.commit()
 
-        results = await repo.fts_search(user, "test data", top_k=10)
+        results = await repo.fts_search(user, project_id, "test data", top_k=10)
         assert len(results) == 0
 
 
@@ -221,7 +273,8 @@ class TestANNSearch:
     async def test_finds_nearest_chunk(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user)
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(session, user_id=user, project_id=project_id)
             cid = await _seed_chunk(session, video_id=vid, text_val="vector test")
             await _seed_vector(
                 session,
@@ -232,7 +285,7 @@ class TestANNSearch:
             )
             await session.commit()
 
-        results = await repo.ann_search(user, [1.0, 0.0, 0.0], top_k=10)
+        results = await repo.ann_search(user, project_id, [1.0, 0.0, 0.0], top_k=10)
         assert len(results) >= 1
         assert results[0].chunk_id == cid
 
@@ -240,7 +293,8 @@ class TestANNSearch:
         owner = uuid4()
         other = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=owner)
+            project_id = await _seed_project(session, user_id=owner)
+            vid = await _seed_video(session, user_id=owner, project_id=project_id)
             cid = await _seed_chunk(session, video_id=vid)
             await _seed_vector(
                 session,
@@ -251,13 +305,14 @@ class TestANNSearch:
             )
             await session.commit()
 
-        results = await repo.ann_search(other, [0.5, 0.5, 0.0], top_k=10)
+        results = await repo.ann_search(other, project_id, [0.5, 0.5, 0.0], top_k=10)
         assert len(results) == 0
 
     async def test_ranking_by_distance(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user)
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(session, user_id=user, project_id=project_id)
             close_cid = await _seed_chunk(
                 session, video_id=vid, text_val="close"
             )
@@ -280,7 +335,7 @@ class TestANNSearch:
             )
             await session.commit()
 
-        results = await repo.ann_search(user, [1.0, 0.0, 0.0], top_k=10)
+        results = await repo.ann_search(user, project_id, [1.0, 0.0, 0.0], top_k=10)
         assert len(results) == 2
         assert results[0].chunk_id == close_cid
         assert results[1].chunk_id == far_cid
@@ -288,7 +343,8 @@ class TestANNSearch:
     async def test_top_k_limits_results(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user)
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(session, user_id=user, project_id=project_id)
             for i in range(5):
                 cid = await _seed_chunk(
                     session, video_id=vid, text_val=f"chunk {i}"
@@ -302,7 +358,7 @@ class TestANNSearch:
                 )
             await session.commit()
 
-        results = await repo.ann_search(user, [0.0, 1.0, 0.0], top_k=3)
+        results = await repo.ann_search(user, project_id, [0.0, 1.0, 0.0], top_k=3)
         assert len(results) == 3
 
 
@@ -310,8 +366,9 @@ class TestSOTGate:
     async def test_passes_ready_owned_chunks(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
+            project_id = await _seed_project(session, user_id=user)
             vid = await _seed_video(
-                session, user_id=user, title="My Video"
+                session, user_id=user, project_id=project_id, title="My Video"
             )
             cid = await _seed_chunk(
                 session,
@@ -323,7 +380,7 @@ class TestSOTGate:
             )
             await session.commit()
 
-        records = await repo.sot_gate(user, [cid])
+        records = await repo.sot_gate(user, excluded_project, [cid])
         assert len(records) == 1
         assert records[0].chunk_id == cid
         assert records[0].title == "My Video"
@@ -335,42 +392,257 @@ class TestSOTGate:
     async def test_filters_non_ready_video(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user, status="DELETING")
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(
+                session, user_id=user, project_id=project_id, status="DELETING"
+            )
             cid = await _seed_chunk(session, video_id=vid)
             await session.commit()
 
-        records = await repo.sot_gate(user, [cid])
+        records = await repo.sot_gate(user, servable_project, [cid])
         assert len(records) == 0
 
     async def test_filters_other_user_chunks(self, session_factory, repo) -> None:
         owner = uuid4()
         other = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=owner)
+            project_id = await _seed_project(session, user_id=owner)
+            vid = await _seed_video(session, user_id=owner, project_id=project_id)
             cid = await _seed_chunk(session, video_id=vid)
             await session.commit()
 
-        records = await repo.sot_gate(other, [cid])
+        records = await repo.sot_gate(other, project_id, [cid])
         assert len(records) == 0
 
     async def test_filters_hard_deleted_chunk(self, session_factory, repo) -> None:
         user = uuid4()
         non_existent_chunk = uuid4()
-        records = await repo.sot_gate(user, [non_existent_chunk])
+        records = await repo.sot_gate(user, uuid4(), [non_existent_chunk])
         assert len(records) == 0
 
     async def test_empty_chunk_ids_returns_empty(self, repo) -> None:
-        records = await repo.sot_gate(uuid4(), [])
+        records = await repo.sot_gate(uuid4(), uuid4(), [])
         assert records == []
 
     async def test_mixed_valid_and_invalid(self, session_factory, repo) -> None:
         user = uuid4()
         async with session_factory() as session:
-            vid = await _seed_video(session, user_id=user)
+            project_id = await _seed_project(session, user_id=user)
+            vid = await _seed_video(session, user_id=user, project_id=project_id)
             valid_cid = await _seed_chunk(session, video_id=vid)
             await session.commit()
 
         invalid_cid = uuid4()
-        records = await repo.sot_gate(user, [valid_cid, invalid_cid])
+        records = await repo.sot_gate(user, project_id, [valid_cid, invalid_cid])
         assert len(records) == 1
         assert records[0].chunk_id == valid_cid
+
+
+class TestProjectServingGate:
+    """Foundation contract: a `ROLLBACK_EXCLUDED` project's chunks are not served.
+
+    The gate must apply to FTS, ANN, and the SOT projection so rollback
+    exclusion is enforced on every read path.
+    """
+
+    async def test_rollback_excluded_project_is_filtered_from_sot(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        async with session_factory() as session:
+            excluded_project = await _seed_project(
+                session, user_id=user, search_serving_state="ROLLBACK_EXCLUDED"
+            )
+            vid = await _seed_video(
+                session, user_id=user, project_id=excluded_project
+            )
+            cid = await _seed_chunk(session, video_id=vid)
+            await session.commit()
+
+        records = await repo.sot_gate(user, excluded_project, [cid])
+        assert records == []
+
+    async def test_servable_project_passes_sot_gate(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        async with session_factory() as session:
+            servable_project = await _seed_project(session, user_id=user)
+            vid = await _seed_video(
+                session, user_id=user, project_id=servable_project
+            )
+            cid = await _seed_chunk(session, video_id=vid)
+            await session.commit()
+
+        records = await repo.sot_gate(user, servable_project, [cid])
+        assert len(records) == 1
+        assert records[0].chunk_id == cid
+
+    async def test_rollback_excluded_project_is_filtered_from_fts(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        async with session_factory() as session:
+            excluded_project = await _seed_project(
+                session, user_id=user, search_serving_state="ROLLBACK_EXCLUDED"
+            )
+            vid = await _seed_video(
+                session, user_id=user, project_id=excluded_project
+            )
+            await _seed_chunk(
+                session,
+                video_id=vid,
+                text_val="rollback secret content",
+                enriched="rollback secret content",
+            )
+            await session.commit()
+
+        results = await repo.fts_search(
+            user, excluded_project, "rollback secret", top_k=10
+        )
+        assert results == []
+
+    async def test_rollback_excluded_project_is_filtered_from_ann(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        async with session_factory() as session:
+            excluded_project = await _seed_project(
+                session, user_id=user, search_serving_state="ROLLBACK_EXCLUDED"
+            )
+            vid = await _seed_video(
+                session, user_id=user, project_id=excluded_project
+            )
+            cid = await _seed_chunk(session, video_id=vid, text_val="excluded")
+            await _seed_vector(
+                session,
+                chunk_id=cid,
+                user_id=user,
+                video_id=vid,
+                embedding=[1.0, 0.0, 0.0],
+            )
+            await session.commit()
+
+        results = await repo.ann_search(
+            user, excluded_project, [1.0, 0.0, 0.0], top_k=10
+        )
+        assert results == []
+
+    async def test_project_with_non_ready_video_is_filtered_from_sot(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        async with session_factory() as session:
+            project_id = await _seed_project(session, user_id=user)
+            ready_vid = await _seed_video(session, user_id=user, project_id=project_id)
+            await _seed_video(
+                session,
+                user_id=user,
+                project_id=project_id,
+                status="PROCESSING",
+            )
+            cid = await _seed_chunk(session, video_id=ready_vid)
+            await session.commit()
+
+        records = await repo.sot_gate(user, project_id, [cid])
+        assert records == []
+
+    async def test_project_with_non_ready_video_is_filtered_from_fts(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        async with session_factory() as session:
+            project_id = await _seed_project(session, user_id=user)
+            ready_vid = await _seed_video(session, user_id=user, project_id=project_id)
+            await _seed_video(
+                session,
+                user_id=user,
+                project_id=project_id,
+                status="FAILED",
+            )
+            await _seed_chunk(
+                session,
+                video_id=ready_vid,
+                text_val="project readiness token",
+                enriched="project readiness token",
+            )
+            await session.commit()
+
+        results = await repo.fts_search(user, project_id, "project readiness", top_k=10)
+        assert results == []
+
+    async def test_project_with_non_ready_video_is_filtered_from_ann(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        async with session_factory() as session:
+            project_id = await _seed_project(session, user_id=user)
+            ready_vid = await _seed_video(session, user_id=user, project_id=project_id)
+            await _seed_video(
+                session,
+                user_id=user,
+                project_id=project_id,
+                status="PROCESSING",
+            )
+            cid = await _seed_chunk(session, video_id=ready_vid)
+            await _seed_vector(
+                session,
+                chunk_id=cid,
+                user_id=user,
+                video_id=ready_vid,
+                embedding=[1.0, 0.0, 0.0],
+            )
+            await session.commit()
+
+        results = await repo.ann_search(user, project_id, [1.0, 0.0, 0.0], top_k=10)
+        assert results == []
+
+
+class TestSearchResponseSnapshot:
+    async def test_repository_writes_snapshot_contract(
+        self, session_factory, repo
+    ) -> None:
+        user = uuid4()
+        req_id = uuid4()
+        async with session_factory() as session:
+            project_id = await _seed_project(session, user_id=user)
+            await session.commit()
+
+        expires_at = datetime.now(UTC) + timedelta(hours=1)
+        await repo.save_search_response_snapshot(
+            SearchResponseSnapshotWrite(
+                req_id=req_id,
+                user_id=user,
+                project_id=project_id,
+                query_text="needle",
+                topk_chunk_ids=[str(uuid4())],
+                used_chunk_ids=[str(uuid4())],
+                active_model_version="embedding-v1",
+                active_index_name="active-index",
+                served_vector_paths=[
+                    {
+                        "model_version": "embedding-v1",
+                        "index_name": "active-index",
+                    }
+                ],
+                project_serving_state="SERVABLE",
+                expires_at=expires_at,
+            )
+        )
+
+        async with session_factory() as session:
+            row = await session.execute(
+                text(
+                    """
+                    SELECT query_text, active_model_version, project_serving_state
+                    FROM search_response_snapshot
+                    WHERE req_id = :req_id
+                    """
+                ),
+                {"req_id": req_id},
+            )
+            snapshot = row.one()
+
+        assert snapshot.query_text == "needle"
+        assert snapshot.active_model_version == "embedding-v1"
+        assert snapshot.project_serving_state == "SERVABLE"

--- a/services/search-service/tests/integration/test_search_repository.py
+++ b/services/search-service/tests/integration/test_search_repository.py
@@ -380,7 +380,7 @@ class TestSOTGate:
             )
             await session.commit()
 
-        records = await repo.sot_gate(user, excluded_project, [cid])
+        records = await repo.sot_gate(user, project_id, [cid])
         assert len(records) == 1
         assert records[0].chunk_id == cid
         assert records[0].title == "My Video"
@@ -399,7 +399,7 @@ class TestSOTGate:
             cid = await _seed_chunk(session, video_id=vid)
             await session.commit()
 
-        records = await repo.sot_gate(user, servable_project, [cid])
+        records = await repo.sot_gate(user, project_id, [cid])
         assert len(records) == 0
 
     async def test_filters_other_user_chunks(self, session_factory, repo) -> None:

--- a/services/search-service/tests/unit/test_db_models.py
+++ b/services/search-service/tests/unit/test_db_models.py
@@ -1,0 +1,12 @@
+from src.infra.db.models import Base
+
+
+def test_vector_index_entry_model_matches_release_serving_contract() -> None:
+    table = Base.metadata.tables["vector_index_entry"]
+
+    assert "index_name" in table.columns
+    assert "project_id" in table.columns
+    assert [column.name for column in table.primary_key.columns] == [
+        "index_name",
+        "chunk_id",
+    ]

--- a/services/search-service/tests/unit/test_search_dto.py
+++ b/services/search-service/tests/unit/test_search_dto.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 import pytest
 from pydantic import ValidationError
 
@@ -18,8 +20,18 @@ class TestNormalizeQuery:
 class TestSearchRequest:
     def test_empty_query_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            SearchRequest(query="")
+            SearchRequest(project_id=uuid4(), query="")
+
+    def test_project_id_required(self) -> None:
+        with pytest.raises(ValidationError):
+            SearchRequest(query="hello")
 
     def test_unknown_field_rejected(self) -> None:
         with pytest.raises(ValidationError):
-            SearchRequest.model_validate({"query": "hello", "category": "IT"})
+            SearchRequest.model_validate(
+                {
+                    "project_id": str(uuid4()),
+                    "query": "hello",
+                    "category": "IT",
+                }
+            )

--- a/services/search-service/tests/unit/test_search_orchestrator_answer.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_answer.py
@@ -17,6 +17,7 @@ from src.middlewares.error_handler import ApiError, ServiceUnavailableError
 from src.services.search_orchestrator import SearchOrchestrator
 
 USER_ID = uuid4()
+PROJECT_ID = uuid4()
 TRACE_ID = str(uuid4())
 
 
@@ -84,6 +85,7 @@ class TestSearchOrchestratorAnswer:
 
         result = await orchestrator.execute(
             user_id=USER_ID,
+            project_id=PROJECT_ID,
             query="What happened?",
             trace_id=TRACE_ID,
         )
@@ -108,6 +110,7 @@ class TestSearchOrchestratorAnswer:
 
         result = await orchestrator.execute(
             user_id=USER_ID,
+            project_id=PROJECT_ID,
             query="What happened?",
             trace_id=TRACE_ID,
         )
@@ -125,6 +128,7 @@ class TestSearchOrchestratorAnswer:
         with pytest.raises(ApiError, match="ANSWER"):
             await orchestrator.execute(
                 user_id=USER_ID,
+                project_id=PROJECT_ID,
                 query="What happened?",
                 trace_id=TRACE_ID,
             )
@@ -143,6 +147,7 @@ class TestSearchOrchestratorAnswer:
         with pytest.raises(ServiceUnavailableError):
             await orchestrator.execute(
                 user_id=USER_ID,
+                project_id=PROJECT_ID,
                 query="What happened?",
                 trace_id=TRACE_ID,
             )
@@ -161,6 +166,7 @@ class TestSearchOrchestratorAnswer:
         with pytest.raises(ApiError, match="Gemini auth failed"):
             await orchestrator.execute(
                 user_id=USER_ID,
+                project_id=PROJECT_ID,
                 query="What happened?",
                 trace_id=TRACE_ID,
             )
@@ -175,6 +181,7 @@ class TestSearchOrchestratorAnswer:
         with patch("src.services.search_orchestrator.log_warning") as log_warning:
             result = await orchestrator.execute(
                 user_id=USER_ID,
+                project_id=PROJECT_ID,
                 query="What happened?",
                 trace_id=TRACE_ID,
             )

--- a/services/search-service/tests/unit/test_search_orchestrator_empty.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_empty.py
@@ -24,6 +24,7 @@ from src.schemas.search_dto import EMPTY_ANSWER
 from src.services.search_orchestrator import SearchOrchestrator
 
 USER_ID = uuid4()
+PROJECT_ID = uuid4()
 TRACE_ID = str(uuid4())
 
 
@@ -86,13 +87,13 @@ class TestReadinessGate:
         orch = _make_orchestrator(non_ready_count=1)
 
         with pytest.raises(SearchNotReadyError):
-            await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+            await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
     async def test_non_ready_skips_all_expensive_calls(self) -> None:
         orch = _make_orchestrator(non_ready_count=1)
 
         with pytest.raises(SearchNotReadyError):
-            await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+            await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         orch._embedding_client.embed_query.assert_not_called()
         orch._repo.fts_search.assert_not_called()
@@ -105,13 +106,13 @@ class TestCorpusEmpty:
         orch = _make_orchestrator(total_videos=0)
 
         with pytest.raises(NoVideosUploadedError):
-            await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+            await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
     async def test_no_videos_uploaded_skips_all_downstream_calls(self) -> None:
         orch = _make_orchestrator(total_videos=0)
 
         with pytest.raises(NoVideosUploadedError):
-            await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+            await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         orch._embedding_client.embed_query.assert_not_called()
         orch._repo.fts_search.assert_not_called()
@@ -128,7 +129,7 @@ class TestFinalEmpty:
             ann_results=[],
             sot_records=[],  # SOT gate rejects everything
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         assert result.answer == EMPTY_ANSWER
         assert result.chunks == []
@@ -138,7 +139,7 @@ class TestFinalEmpty:
             fts_results=[],
             ann_results=[],
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         assert result.answer == EMPTY_ANSWER
         assert result.chunks == []
@@ -148,27 +149,67 @@ class TestFinalEmpty:
             fts_results=[],
             ann_results=[],
         )
-        await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         orch._llm_adapter.generate.assert_not_called()
 
 
 class TestRetrievalFlow:
+    async def test_project_scope_is_passed_to_all_repository_reads(self) -> None:
+        chunk_id = uuid4()
+        orch = _make_orchestrator(
+            search_top_k=15,
+            fts_results=[FTSCandidate(chunk_id=chunk_id, rank=1)],
+            sot_records=[],
+        )
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="my query",
+            trace_id=TRACE_ID,
+        )
+
+        orch._repo.check_corpus_readiness.assert_called_once_with(
+            USER_ID, PROJECT_ID
+        )
+        orch._repo.fts_search.assert_called_once_with(
+            USER_ID, PROJECT_ID, "my query", top_k=15
+        )
+        orch._repo.ann_search.assert_called_once()
+        ann_args = orch._repo.ann_search.call_args
+        assert ann_args[0][0] == USER_ID
+        assert ann_args[0][1] == PROJECT_ID
+        orch._repo.sot_gate.assert_called_once()
+        sot_args = orch._repo.sot_gate.call_args
+        assert sot_args[0][0] == USER_ID
+        assert sot_args[0][1] == PROJECT_ID
+
     async def test_fts_ann_called_with_correct_args(self) -> None:
         orch = _make_orchestrator(search_top_k=15)
-        await orch.execute(user_id=USER_ID, query="my query", trace_id=TRACE_ID)
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="my query",
+            trace_id=TRACE_ID,
+        )
 
         orch._repo.fts_search.assert_called_once_with(
-            USER_ID, "my query", top_k=15
+            USER_ID, PROJECT_ID, "my query", top_k=15
         )
         orch._repo.ann_search.assert_called_once()
         call_args = orch._repo.ann_search.call_args
         assert call_args[0][0] == USER_ID
+        assert call_args[0][1] == PROJECT_ID
         assert call_args[1]["top_k"] == 15
 
     async def test_embedding_called_with_query(self) -> None:
         orch = _make_orchestrator()
-        await orch.execute(user_id=USER_ID, query="search term", trace_id=TRACE_ID)
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="search term",
+            trace_id=TRACE_ID,
+        )
 
         orch._embedding_client.embed_query.assert_called_once_with(
             "search term", trace_id=TRACE_ID
@@ -183,11 +224,17 @@ class TestRetrievalFlow:
             ann_results=[ANNCandidate(chunk_id=cid_ann, rank=1)],
             sot_records=[],
         )
-        await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="test",
+            trace_id=TRACE_ID,
+        )
 
         call_args = orch._repo.sot_gate.call_args
         assert call_args[0][0] == USER_ID
-        passed_ids = set(call_args[0][1])
+        assert call_args[0][1] == PROJECT_ID
+        passed_ids = set(call_args[0][2])
         assert cid_fts in passed_ids
         assert cid_ann in passed_ids
 
@@ -201,7 +248,7 @@ class TestChunksAssembly:
             fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
             sot_records=[record],
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         assert len(result.chunks) == 1
         assert result.chunks[0].ref == 1
@@ -231,7 +278,7 @@ class TestChunksAssembly:
                 _chunk_record(chunk_id=cid3, video_id=vid, title="V1"),
             ],
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         refs = [c.ref for c in result.chunks]
         assert refs == [1, 2, 3]
@@ -250,7 +297,7 @@ class TestChunksAssembly:
             fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
             sot_records=[record],
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         chunk = result.chunks[0]
         assert chunk.chunk_id == cid
@@ -268,7 +315,7 @@ class TestChunksAssembly:
             fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
             sot_records=[_chunk_record(chunk_id=cid)],
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         for chunk in result.chunks:
             assert chunk.used is False
@@ -287,7 +334,7 @@ class TestChunksAssembly:
             sot_records=records,
             final_top_k=3,
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         assert len(result.chunks) <= 3
 
@@ -302,7 +349,7 @@ class TestChunksAssembly:
             ],
             sot_records=[_chunk_record(chunk_id=cid_pass)],
         )
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
 
         assert len(result.chunks) == 1
         assert result.chunks[0].chunk_id == cid_pass
@@ -311,11 +358,11 @@ class TestChunksAssembly:
 class TestReqId:
     async def test_each_call_generates_unique_req_id(self) -> None:
         orch = _make_orchestrator()
-        r1 = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
-        r2 = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        r1 = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
+        r2 = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
         assert r1.req_id != r2.req_id
 
     async def test_empty_result_still_has_req_id(self) -> None:
         orch = _make_orchestrator()
-        result = await orch.execute(user_id=USER_ID, query="test", trace_id=TRACE_ID)
+        result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
         assert isinstance(result.req_id, UUID)


### PR DESCRIPTION
  ## Summary

  - Admin Ops Foundation 기반 스키마, API skeleton, service/repository seam을 추가했습니다.
  - `ModelRelease` current row를 singleton invariant로 고정했습니다.
  - `vector_index_entry`를 project/index scope 기반 계약으로 확장했습니다.
  - Search 요청부터 repository까지 `project_id` scope를 전달하도록 수정했습니다.
  - Feedback API의 public request DTO를 내부 event contract와 분리했습니다.
  - 관련 unit/integration schema 테스트를 추가했습니다.

  ## Why

  Admin Ops Foundation은 모델 릴리즈, 프로젝트 serving state, 피드백 수집, 검색 snapshot을 후속 운영 기능의 기준 계약으로 고정
  하는 작업입니다.

  기존 구현은 foundation skeleton 단계였지만, PR 리뷰 기준으로 보면 몇 가지 계약이 불명확했습니다.

  - `ModelRelease`는 current serving 상태의 SOT인데 여러 row가 생길 수 있었고, `.limit(1)` 조회는 어떤 row가 current인지 보장하
  지 못했습니다.
  - `vector_index_entry`는 `chunk_id` 단일 key라서 active/previous/candidate index나 project 단위 projection을 표현하기 어려웠
  습니다.
  - Search 경로는 `user_id`만 전달해 같은 user의 다른 project 데이터가 readiness, FTS, ANN, SOT gate에 섞일 수 있었습니다.
  - Feedback endpoint가 내부 `FeedbackEvent` 전체를 public API body로 노출해 client가 소유하면 안 되는 context 필드까지 요청 계
  약에 포함하고 있었습니다.

  이번 PR은 후속 기능 구현 전에 이 경계들을 먼저 고정해, 이후 Admin Ops / Feedback Ingestion / Search Serving 작업이 같은 DB/
  API 계약 위에서 진행되도록 만드는 목적입니다.

  ## Trade-offs

  - `ModelRelease`는 UUID primary key를 유지하고 `singleton_key` + unique/check 제약으로 단일 row를 보장했습니다.
    - 대안은 fixed primary key 또는 environment scope key였습니다.
    - 현재는 단일 serving environment 전제라 `singleton_key`가 가장 작고 명시적입니다.
    - 향후 multi-environment가 필요하면 `environment` column + unique scope로 확장해야 합니다.

  - `vector_index_entry`는 `(index_name, chunk_id)` composite primary key로 바꿨습니다.
    - 대안은 별도 surrogate key를 추가하고 `(index_name, chunk_id)` unique index를 두는 방식입니다.
    - 현재 쿼리와 계약은 index/chunk identity가 핵심이라 composite key가 더 직접적입니다.
    - 다만 ORM 사용처가 늘어나면 composite key 처리 비용이 생길 수 있습니다.

  - Search API에 `project_id`를 required field로 추가했습니다.
    - 대안은 server가 user의 default project를 암묵적으로 선택하는 방식입니다.
    - 하지만 검색 결과와 readiness 판단은 project scope가 명확해야 하므로 client가 project를 명시하게 했습니다.
    - 이 변경은 API contract 변경이므로 호출부도 함께 맞춰야 합니다.

  - Feedback public request는 `req_id`, `rating`만 받도록 제한했습니다.
    - 대안은 client가 검색 context 전체를 다시 보내는 방식입니다.
    - 하지만 query text, chunk ids, active model/index는 server snapshot에서 복원해야 신뢰 가능한 감사 trail이 됩니다.
    - full event construction은 후속 Feedback Ingestion Pipeline에서 snapshot lookup 이후 처리합니다.

 ## Review Scope

  변경 파일을 영향 범위 기준으로 분류했습니다.

  비즈니스 로직 또는 서비스 계약에 직접 영향을 주는 핵심 파일:

  - `services/core-api/alembic/versions/0004_admin_ops_foundation.py`
    - Admin Ops Foundation의 DB 계약을 정의합니다.
    - `ModelRelease` singleton current row, project serving state, search snapshot, vector projection 변경이 포함됩니다.

  - `services/search-service/src/infra/db/search_repository.py`
    - 검색 read path의 project scope 적용 지점입니다.
    - readiness, FTS, ANN, SOT gate가 `user_id + project_id` 기준으로 동작합니다.

  - `services/search-service/src/services/search_orchestrator.py`
    - API에서 받은 `project_id`를 검색 pipeline 전체에 전달하는 boundary입니다.

  - `services/core-api/src/schemas/feedback_dto.py`
    - public `FeedbackRequest`와 internal `FeedbackEvent`를 분리한 API 계약입니다.
    - client 입력을 `req_id`, `rating`으로 제한합니다.

  - `services/pipeline-worker/src/infra/db/artifact_repository.py`
    - vector projection write path입니다.
    - chunk vector 저장 시 `index_name`, `project_id`를 함께 기록합니다.

  계약 동기화 대상:

  - `services/core-api/src/models/admin_ops.py`
  - `services/core-api/src/infra/db/model_release_repository.py`
  - `services/search-service/src/schemas/search_dto.py`
  - `services/search-service/src/api/v1/routers/search.py`
  - `services/search-service/src/infra/db/models.py`
  - `services/pipeline-worker/src/infra/db/models.py`
  - `services/pipeline-worker/src/infra/db/video_repository.py`

  Admin/Feedback skeleton 대상:

  - `services/core-api/src/api/v1/routers/admin.py`
  - `services/core-api/src/api/v1/routers/feedbacks.py`
  - `services/core-api/src/infra/db/admin_repository.py`
  - `services/core-api/src/infra/db/feedback_repository.py`
  - `services/core-api/src/schemas/admin_ops.py`
  - `services/core-api/src/services/admin_service.py`
  - `services/core-api/src/services/feedback_service.py`

  지원/테스트 대상:

  - `services/core-api/src/infra/broker.py`
  - `services/pipeline-worker/src/schemas/messages.py`
  - `services/core-api/tests/**`
  - `services/search-service/tests/**`
  - `services/pipeline-worker/tests/**`

  ## Verification

  - `poetry run pytest tests/unit/test_admin_ops_schemas.py tests/api/v1/test_admin_ops_router_wiring.py tests/integration/
  test_admin_ops_foundation_schema.py tests/integration/test_pipeline_artifact_schema.py -q`
    - `7 passed, 9 skipped`
  - `poetry run pytest tests/unit/test_db_models.py -q`
    - pipeline-worker: `1 passed`
  - `poetry run pytest tests/unit/test_search_orchestrator_empty.py tests/unit/test_search_orchestrator_answer.py tests/unit/
  test_search_dto.py tests/unit/test_db_models.py -q`
    - search-service: `31 passed`
  - `python3 -m py_compile ...`
    - passed
  - `git diff --check`
    - passed

  ## Issue

  Closes #75