### PR TITLE
feat(search): 임베딩 모델 버전 전환 지원 [#88]

### DIFF
--- a/services/core-api/alembic/versions/0005_legacy_reindex_metadata.py
+++ b/services/core-api/alembic/versions/0005_legacy_reindex_metadata.py
@@ -1,0 +1,112 @@
+"""add legacy reindex metadata schema
+
+Revision ID: 0005_legacy_reindex_metadata
+Revises: 0004_admin_ops_foundation
+Create Date: 2026-05-27
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0005_legacy_reindex_metadata"
+down_revision = "0004_admin_ops_foundation"
+branch_labels = None
+depends_on = None
+
+
+LEGACY_REINDEX_STATUSES = ("PENDING", "RUNNING", "SUCCEEDED", "FAILED", "SKIPPED")
+LEGACY_REINDEX_FAILURE_TYPES = ("FAIL", "ERROR")
+LEGACY_REINDEX_FAILED_STAGES = (
+    "TARGET_LOOKUP",
+    "TEXT_LOAD",
+    "EMBEDDING",
+    "VECTOR_UPSERT",
+    "CONSISTENCY_CHECK",
+)
+
+
+def _check_values(column_name: str, values: tuple[str, ...]) -> str:
+    quoted_values = ", ".join(f"'{value}'" for value in values)
+    return f"{column_name} IN ({quoted_values})"
+
+
+def upgrade() -> None:
+    op.create_table(
+        "vector_index_catalog",
+        sa.Column("index_name", sa.String(length=128), primary_key=True, nullable=False),
+        sa.Column("model_version", sa.String(length=128), nullable=False),
+        sa.Column("embedding_dimension", sa.Integer(), nullable=False),
+        sa.Column("retired_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("delete_after", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("retire_reason", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+    )
+
+    op.create_table(
+        "legacy_reindex_item",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+            server_default=sa.text("gen_random_uuid()"),
+        ),
+        sa.Column("video_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("video.id"), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("project_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("project.id"), nullable=True),
+        sa.Column("source_index_name", sa.String(length=128), nullable=False),
+        sa.Column("source_model_version", sa.String(length=128), nullable=False),
+        sa.Column("target_index_name", sa.String(length=128), nullable=False),
+        sa.Column("target_model_version", sa.String(length=128), nullable=False),
+        sa.Column("status", sa.Text(), nullable=False, server_default=sa.text("'PENDING'")),
+        sa.Column("failed_stage", sa.Text(), nullable=True),
+        sa.Column("failure_type", sa.Text(), nullable=True),
+        sa.Column("last_error", sa.Text(), nullable=True),
+        sa.Column("retry_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("total_chunk_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("completed_chunk_count", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("NOW()")),
+        sa.CheckConstraint(
+            _check_values("status", LEGACY_REINDEX_STATUSES),
+            name="ck_legacy_reindex_item_status",
+        ),
+        sa.CheckConstraint(
+            "failure_type IS NULL OR " + _check_values("failure_type", LEGACY_REINDEX_FAILURE_TYPES),
+            name="ck_legacy_reindex_item_failure_type",
+        ),
+        sa.CheckConstraint(
+            "failed_stage IS NULL OR " + _check_values("failed_stage", LEGACY_REINDEX_FAILED_STAGES),
+            name="ck_legacy_reindex_item_failed_stage",
+        ),
+        sa.UniqueConstraint(
+            "video_id",
+            "source_index_name",
+            "target_index_name",
+            name="uq_legacy_reindex_item_video_source_target",
+        ),
+    )
+    op.create_index(
+        "idx_legacy_reindex_item_status_updated",
+        "legacy_reindex_item",
+        ["status", "updated_at"],
+    )
+    op.create_index(
+        "idx_legacy_reindex_item_target_status",
+        "legacy_reindex_item",
+        ["target_index_name", "status"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_legacy_reindex_item_target_status", table_name="legacy_reindex_item")
+    op.drop_index("idx_legacy_reindex_item_status_updated", table_name="legacy_reindex_item")
+    op.drop_table("legacy_reindex_item")
+    op.drop_table("vector_index_catalog")

--- a/services/core-api/src/models/admin_ops.py
+++ b/services/core-api/src/models/admin_ops.py
@@ -28,6 +28,15 @@ ML_RUN_STATUSES = ("PENDING", "RUNNING", "READY_FOR_RELEASE", "FAILED", "SUPERSE
 ML_FAILURE_TYPES = ("FAIL", "ERROR")
 EVALUATION_STATUSES = ("RUNNING", "COMPLETED", "FAILED")
 EVALUATION_DECISIONS = ("PASS", "FAIL")
+LEGACY_REINDEX_STATUSES = ("PENDING", "RUNNING", "SUCCEEDED", "FAILED", "SKIPPED")
+LEGACY_REINDEX_FAILURE_TYPES = ("FAIL", "ERROR")
+LEGACY_REINDEX_FAILED_STAGES = (
+    "TARGET_LOOKUP",
+    "TEXT_LOAD",
+    "EMBEDDING",
+    "VECTOR_UPSERT",
+    "CONSISTENCY_CHECK",
+)
 
 
 def _check_values(column_name: str, values: tuple[str, ...]) -> str:
@@ -228,6 +237,91 @@ class ModelRelease(Base):
     candidate_opened_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     candidate_ready_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     switched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+class VectorIndexCatalog(Base):
+    __tablename__ = "vector_index_catalog"
+
+    index_name: Mapped[str] = mapped_column(String(128), primary_key=True)
+    model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    embedding_dimension: Mapped[int] = mapped_column(Integer, nullable=False)
+    retired_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    delete_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    retire_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=func.now(),
+        server_default=func.now(),
+    )
+
+
+class LegacyReindexItem(Base):
+    __tablename__ = "legacy_reindex_item"
+    __table_args__ = (
+        CheckConstraint(
+            _check_values("status", LEGACY_REINDEX_STATUSES),
+            name="ck_legacy_reindex_item_status",
+        ),
+        CheckConstraint(
+            "failure_type IS NULL OR " + _check_values("failure_type", LEGACY_REINDEX_FAILURE_TYPES),
+            name="ck_legacy_reindex_item_failure_type",
+        ),
+        CheckConstraint(
+            "failed_stage IS NULL OR " + _check_values("failed_stage", LEGACY_REINDEX_FAILED_STAGES),
+            name="ck_legacy_reindex_item_failed_stage",
+        ),
+        UniqueConstraint(
+            "video_id",
+            "source_index_name",
+            "target_index_name",
+            name="uq_legacy_reindex_item_video_source_target",
+        ),
+        Index("idx_legacy_reindex_item_status_updated", "status", "updated_at"),
+        Index("idx_legacy_reindex_item_target_status", "target_index_name", "status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        primary_key=True,
+        default=uuid4,
+        server_default=text("gen_random_uuid()"),
+    )
+    video_id: Mapped[UUID] = mapped_column(ForeignKey("video.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    project_id: Mapped[UUID | None] = mapped_column(ForeignKey("project.id"), nullable=True)
+    source_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    source_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    target_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    target_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    status: Mapped[str] = mapped_column(
+        Text,
+        nullable=False,
+        default="PENDING",
+        server_default=text("'PENDING'"),
+    )
+    failed_stage: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_type: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retry_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
+    total_chunk_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
+    completed_chunk_count: Mapped[int] = mapped_column(Integer, nullable=False, default=0, server_default=text("0"))
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/services/core-api/tests/integration/test_admin_ops_foundation_schema.py
+++ b/services/core-api/tests/integration/test_admin_ops_foundation_schema.py
@@ -14,6 +14,8 @@ async def test_admin_ops_foundation_schema_contract(session_factory: SessionFact
         run_columns = await _columns_for(session, "ml_pipeline_run")
         evaluation_columns = await _columns_for(session, "model_evaluation")
         release_columns = await _columns_for(session, "model_release")
+        catalog_columns = await _columns_for(session, "vector_index_catalog")
+        reindex_columns = await _columns_for(session, "legacy_reindex_item")
         project_state_default = await session.scalar(
             text(
                 """
@@ -31,6 +33,7 @@ async def test_admin_ops_foundation_schema_contract(session_factory: SessionFact
         release_singleton_check = await _constraint_definition(
             session, "ck_model_release_singleton_key"
         )
+        reindex_status_check = await _constraint_definition(session, "ck_legacy_reindex_item_status")
 
     assert project_columns["search_serving_state"][1] == "text"
     assert video_columns["project_id"][1] == "uuid"
@@ -47,6 +50,11 @@ async def test_admin_ops_foundation_schema_contract(session_factory: SessionFact
     assert release_columns["release_status"][1] == "text"
     assert "ROLLBACK_PREPARING" in release_status_check
     assert "singleton_key = 1" in release_singleton_check
+    assert catalog_columns["index_name"][1] == "varchar"
+    assert catalog_columns["embedding_dimension"][1] == "int4"
+    assert reindex_columns["source_index_name"][1] == "varchar"
+    assert reindex_columns["target_index_name"][1] == "varchar"
+    assert "SKIPPED" in reindex_status_check
 
 
 @pytest.mark.asyncio
@@ -62,6 +70,8 @@ async def test_sqlalchemy_models_include_admin_ops_foundation_tables() -> None:
         "ml_pipeline_run",
         "model_evaluation",
         "model_release",
+        "vector_index_catalog",
+        "legacy_reindex_item",
     }.issubset(table_names)
     assert "project_id" in Base.metadata.tables["video"].columns
     model_release_table = Base.metadata.tables["model_release"]
@@ -71,6 +81,12 @@ async def test_sqlalchemy_models_include_admin_ops_foundation_tables() -> None:
     assert "singleton_key" in model_release_table.columns
     assert "ck_model_release_singleton_key" in model_release_constraints
     assert "uq_model_release_singleton_key" in model_release_constraints
+    legacy_reindex_table = Base.metadata.tables["legacy_reindex_item"]
+    legacy_reindex_constraints = {
+        constraint.name for constraint in legacy_reindex_table.constraints
+    }
+    assert "ck_legacy_reindex_item_status" in legacy_reindex_constraints
+    assert "uq_legacy_reindex_item_video_source_target" in legacy_reindex_constraints
 
 
 @pytest.mark.asyncio

--- a/services/feedback-loop-pipeline/poetry.lock
+++ b/services/feedback-loop-pipeline/poetry.lock
@@ -336,6 +336,88 @@ win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
 dev = ["Sphinx (==8.1.3) ; python_version >= \"3.11\"", "build (==1.2.2) ; python_version >= \"3.11\"", "colorama (==0.4.5) ; python_version < \"3.8\"", "colorama (==0.4.6) ; python_version >= \"3.8\"", "exceptiongroup (==1.1.3) ; python_version >= \"3.7\" and python_version < \"3.11\"", "freezegun (==1.1.0) ; python_version < \"3.8\"", "freezegun (==1.5.0) ; python_version >= \"3.8\"", "mypy (==0.910) ; python_version < \"3.6\"", "mypy (==0.971) ; python_version == \"3.6\"", "mypy (==1.13.0) ; python_version >= \"3.8\"", "mypy (==1.4.1) ; python_version == \"3.7\"", "myst-parser (==4.0.0) ; python_version >= \"3.11\"", "pre-commit (==4.0.1) ; python_version >= \"3.9\"", "pytest (==6.1.2) ; python_version < \"3.8\"", "pytest (==8.3.2) ; python_version >= \"3.8\"", "pytest-cov (==2.12.1) ; python_version < \"3.8\"", "pytest-cov (==5.0.0) ; python_version == \"3.8\"", "pytest-cov (==6.0.0) ; python_version >= \"3.9\"", "pytest-mypy-plugins (==1.9.3) ; python_version >= \"3.6\" and python_version < \"3.8\"", "pytest-mypy-plugins (==3.1.0) ; python_version >= \"3.8\"", "sphinx-rtd-theme (==3.0.2) ; python_version >= \"3.11\"", "tox (==3.27.1) ; python_version < \"3.8\"", "tox (==4.23.2) ; python_version >= \"3.8\"", "twine (==6.0.1) ; python_version >= \"3.11\""]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+description = "Fundamental package for array computing in Python"
+optional = false
+python-versions = ">=3.11"
+groups = ["main"]
+files = [
+    {file = "numpy-2.4.6-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0280e0356c0829a18d9de1cb7eee50ec22ca639878d7240307ca0943d73cd2c4"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:110f8b71aacb688ec69062bb7f6938a0f8acb01b7c1c4beb453c65b6d234584d"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:4cfe66903cc32a9921a6733d96b19bb6abf310397581bbad89c228f5abaf0ee8"},
+    {file = "numpy-2.4.6-cp311-cp311-macosx_14_0_x86_64.whl", hash = "sha256:8155154c7c691289fe18f510b5d4657c68c67989f293f0535a91360392ff6538"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ab0a9c4ffb1a6d95ef519fe4247dba8eb6b18ad93999f76b7f657039acabd47"},
+    {file = "numpy-2.4.6-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:89cd468399cfd2504718f0ba50e410dca55a170b61a02ad92bb18c8a65186e93"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c2d37ab77531417474168eb79d6d80b14f821a966818505d03013d0833edb7a8"},
+    {file = "numpy-2.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f407cb6b8e9d6d8c626bc73c945db1706035af8fd632295547bf1c9e46d092d6"},
+    {file = "numpy-2.4.6-cp311-cp311-win32.whl", hash = "sha256:ddea102b48f9e339f3948bf22040944184627a30fdf7f858667673b9c5f033c8"},
+    {file = "numpy-2.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:1e254a00cdf42b1e4d5b3d68d33af63268d41340d8885df2ab6470f2e1500147"},
+    {file = "numpy-2.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:ed9749eef4cbd126da3dc1d6bcb3a57f5eb7ac6a6484146bdbf743f552dfc577"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41"},
+    {file = "numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f"},
+    {file = "numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a"},
+    {file = "numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2"},
+    {file = "numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45"},
+    {file = "numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751"},
+    {file = "numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f"},
+    {file = "numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b"},
+    {file = "numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a"},
+    {file = "numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605"},
+    {file = "numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91"},
+    {file = "numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359"},
+    {file = "numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe"},
+    {file = "numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20"},
+    {file = "numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67"},
+    {file = "numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd"},
+    {file = "numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75"},
+    {file = "numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5"},
+    {file = "numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b"},
+    {file = "numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402"},
+    {file = "numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb"},
+    {file = "numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1"},
+    {file = "numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261"},
+    {file = "numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e"},
+    {file = "numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43"},
+    {file = "numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895"},
+    {file = "numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4"},
+    {file = "numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627"},
+    {file = "numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_10_15_x86_64.whl", hash = "sha256:55cced7c52e981362f708ad635198e97a752dfba412cc03c23bbf3bd8d5cd662"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:d6da64deb6b8ed903e7560180a92f2d804ee1ba5eeb849ac2748b8c1aba1f6d7"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_arm64.whl", hash = "sha256:68a5124b13fa6cc2086764a20005d30bc0548146f7f5322f02fce212ca14317f"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-macosx_14_0_x86_64.whl", hash = "sha256:948424b06129ce883307e8cff868c31396d8dc7630a59c61d70d98dbe70f222c"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5dbbdb29840ca3d91ee0fece42fc29278886d908280bfec0a5846c6f901a3eb0"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ad03c0965fb3c692200e74d458ca28c1dbb4ce96f9a479a8aa041ad5fabca02"},
+    {file = "numpy-2.4.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:2803abfebfc990042cd494d8ce2d5f82e9d847af6d35ec486923aa19dbad5e73"},
+    {file = "numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda"},
+]
+
+[[package]]
 name = "packaging"
 version = "26.2"
 description = "Core utilities for Python packages"
@@ -358,6 +440,21 @@ files = [
     {file = "pastel-0.2.1-py2.py3-none-any.whl", hash = "sha256:4349225fcdf6c2bb34d483e523475de5bb04a5c10ef711263452cb37d7dd4364"},
     {file = "pastel-0.2.1.tar.gz", hash = "sha256:e6581ac04e973cac858828c6202c1e1e81fee1dc7de7683f3e1ffe0bfd8a573d"},
 ]
+
+[[package]]
+name = "pgvector"
+version = "0.4.2"
+description = "pgvector support for Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08"},
+    {file = "pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a"},
+]
+
+[package.dependencies]
+numpy = "*"
 
 [[package]]
 name = "pluggy"
@@ -894,4 +991,4 @@ dev = ["black (>=19.3b0) ; python_version >= \"3.6\"", "pytest (>=4.6.2)"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "7e0fb9b66f868505fc0b22305ca85d935e2722f89379a0372a3f4264cbb20280"
+content-hash = "a4106bd1960d1a9ebc3a831f3b6bbc95ea5e4bf9ebbca1d275dfe9e0d3a794a9"

--- a/services/feedback-loop-pipeline/pyproject.toml
+++ b/services/feedback-loop-pipeline/pyproject.toml
@@ -10,6 +10,7 @@ python = "^3.11"
 aiosqlite = ">=0.20,<1.0"
 asyncpg = ">=0.29,<1.0"
 loguru = ">=0.7,<1.0"
+pgvector = ">=0.3,<1.0"
 pydantic = ">=2.7,<3.0"
 pydantic-settings = ">=2.3,<3.0"
 sqlalchemy = { version = ">=2.0,<3.0", extras = ["asyncio"] }

--- a/services/feedback-loop-pipeline/src/config/settings.py
+++ b/services/feedback-loop-pipeline/src/config/settings.py
@@ -25,6 +25,7 @@ class Settings(BaseSettings):
     evaluation_artifact_prefix: str = Field(alias="EVALUATION_ARTIFACT_PREFIX", min_length=1)
 
     managed_embedding_endpoint_url: str = Field(alias="MANAGED_EMBEDDING_ENDPOINT_URL", min_length=1)
+    search_service_url: str = Field(default="", alias="SEARCH_SERVICE_URL")
     local_training_model_name: str = Field(alias="LOCAL_TRAINING_MODEL_NAME", min_length=1)
     embedding_dimension: int = Field(alias="EMBEDDING_DIMENSION", ge=1)
     training_config_path: str = Field(alias="TRAINING_CONFIG_PATH", min_length=1)

--- a/services/feedback-loop-pipeline/src/config/settings.py
+++ b/services/feedback-loop-pipeline/src/config/settings.py
@@ -40,6 +40,10 @@ class Settings(BaseSettings):
     rollback_restore_timeout_sec: int = Field(default=300, alias="ROLLBACK_RESTORE_TIMEOUT_SEC", ge=1)
     stuck_run_timeout_sec: int = Field(default=3600, alias="STUCK_RUN_TIMEOUT_SEC", ge=1)
     reconciliation_interval_sec: int = Field(default=60, alias="RECONCILIATION_INTERVAL_SEC", ge=1)
+    legacy_reindex_scan_interval_sec: int = Field(default=60, alias="LEGACY_REINDEX_SCAN_INTERVAL_SEC", ge=1)
+    legacy_reindex_batch_size: int = Field(default=8, alias="LEGACY_REINDEX_BATCH_SIZE", ge=1)
+    legacy_reindex_per_run_video_limit: int = Field(default=100, alias="LEGACY_REINDEX_PER_RUN_VIDEO_LIMIT", ge=1)
+    legacy_reindex_throttle_sleep_ms: int = Field(default=0, alias="LEGACY_REINDEX_THROTTLE_SLEEP_MS", ge=0)
     max_retries: int = Field(default=3, alias="MAX_RETRIES", ge=0)
     retry_backoff_sec: float = Field(default=1.0, alias="RETRY_BACKOFF_SEC", ge=0.0)
 

--- a/services/feedback-loop-pipeline/src/infra/db/legacy_reindex_lock.py
+++ b/services/feedback-loop-pipeline/src/infra/db/legacy_reindex_lock.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class PostgresAdvisoryLegacyReindexLock:
+    def __init__(
+        self,
+        session: AsyncSession,
+        *,
+        lock_name: str = "legacy_reembedding_global_lock",
+    ) -> None:
+        self._session = session
+        self._lock_name = lock_name
+        self._acquired = False
+
+    async def try_acquire(self) -> bool:
+        if self._dialect_name() != "postgresql":
+            self._acquired = True
+            return True
+
+        result = await self._session.execute(
+            text("SELECT pg_try_advisory_lock(hashtext(:lock_name))"),
+            {"lock_name": self._lock_name},
+        )
+        self._acquired = bool(result.scalar())
+        return self._acquired
+
+    async def release(self) -> None:
+        if not self._acquired:
+            return
+        if self._dialect_name() == "postgresql":
+            await self._session.execute(
+                text("SELECT pg_advisory_unlock(hashtext(:lock_name))"),
+                {"lock_name": self._lock_name},
+            )
+        self._acquired = False
+
+    def _dialect_name(self) -> str:
+        return self._session.get_bind().dialect.name

--- a/services/feedback-loop-pipeline/src/infra/db/legacy_reindex_store.py
+++ b/services/feedback-loop-pipeline/src/infra/db/legacy_reindex_store.py
@@ -1,0 +1,455 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import and_, func, select
+from sqlalchemy.dialects.postgresql import insert as postgres_insert
+from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import aliased
+
+from src.infra.db.models import (
+    ChunkModel,
+    LegacyReindexItemModel,
+    ModelReleaseModel,
+    VectorIndexCatalogModel,
+    VectorIndexEntryModel,
+    VideoModel,
+)
+
+
+@dataclass(frozen=True)
+class LegacyCutoverGateResult:
+    blocked: bool
+    remaining_video_count: int
+
+
+@dataclass(frozen=True)
+class ReindexChunkRecord:
+    chunk_id: UUID
+    text: str | None
+    enriched_text: str | None
+    source_created_at: datetime
+
+
+@dataclass(frozen=True)
+class ReindexVideoRecord:
+    video_id: UUID
+    user_id: UUID
+    project_id: UUID | None
+    status: str
+    chunks: list[ReindexChunkRecord]
+
+
+@dataclass(frozen=True)
+class ReindexedVectorRecord:
+    index_name: str
+    chunk_id: UUID
+    user_id: UUID
+    project_id: UUID | None
+    video_id: UUID
+    embedding_vector: list[float]
+    embedding_model_version: str
+    created_at: datetime
+
+
+class VectorIndexCatalogStore:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def upsert_index(
+        self,
+        *,
+        index_name: str,
+        model_version: str,
+        embedding_dimension: int,
+        created_at: datetime,
+    ) -> None:
+        existing = await self._session.get(VectorIndexCatalogModel, index_name)
+        if existing is None:
+            self._session.add(
+                VectorIndexCatalogModel(
+                    index_name=index_name,
+                    model_version=model_version,
+                    embedding_dimension=embedding_dimension,
+                    created_at=created_at,
+                )
+            )
+            await self._session.flush()
+            return
+        existing.model_version = model_version
+        existing.embedding_dimension = embedding_dimension
+        await self._session.flush()
+
+    async def get(self, index_name: str) -> VectorIndexCatalogModel | None:
+        return await self._session.get(VectorIndexCatalogModel, index_name)
+
+# legacy reindex 작업용 DB 저장소 클래스
+#   1. cutover 전에 legacy reindex가 남았는지 확인
+#   2. 재색인해야 할 video를 legacy_reindex_item에 등록 (LegacyReindexItem.status == pending)
+#   3. PENDING인 item을 가져옴 
+#   4. item 상태를 RUNNING / SUCCEEDED / FAILED / SKIPPED로 변경
+#   5. item에 해당하는 video + chunk를 로드
+#   6. 새로 만든 embedding vector를 target index에 upsert
+#   7. target index에 vector가 다 들어갔는지 개수 확인
+class LegacyReindexStore:
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def ensure_cutover_ready(
+        self,
+        *,
+        active_index_name: str,
+        active_model_version: str,
+        candidate_index_name: str | None,
+        now: datetime,
+        limit: int = 100,
+    ) -> LegacyCutoverGateResult:
+        remaining_count = await self.count_old_only_videos(
+            target_index_name=active_index_name,
+            excluded_index_names={active_index_name, candidate_index_name} - {None},
+        )
+        if remaining_count == 0:
+            return LegacyCutoverGateResult(blocked=False, remaining_video_count=0)
+        await self.enqueue_old_only_items(
+            target_index_name=active_index_name,
+            target_model_version=active_model_version,
+            excluded_index_names={active_index_name, candidate_index_name} - {None},
+            now=now,
+            limit=limit,
+        )
+        return LegacyCutoverGateResult(blocked=True, remaining_video_count=remaining_count)
+
+    async def enqueue_old_only_items(
+        self,
+        *,
+        target_index_name: str,
+        target_model_version: str,
+        excluded_index_names: set[str],
+        now: datetime,
+        limit: int,
+    ) -> int:
+        enqueued_count = 0
+        for source_index in await self._source_indexes(excluded_index_names):
+            if enqueued_count >= limit:
+                break
+            remaining_limit = limit - enqueued_count
+            rows = await self._old_only_video_rows(
+                source_index_name=source_index.index_name,
+                target_index_name=target_index_name,
+                limit=remaining_limit,
+            )
+            for row in rows:
+                created = await self._ensure_item(
+                    video_id=row.video_id,
+                    user_id=row.user_id,
+                    project_id=row.project_id,
+                    source_index_name=source_index.index_name,
+                    source_model_version=source_index.model_version,
+                    target_index_name=target_index_name,
+                    target_model_version=target_model_version,
+                    now=now,
+                )
+                if created:
+                    enqueued_count += 1
+        await self._session.flush()
+        return enqueued_count
+
+    async def pending_items(self, *, limit: int) -> list[LegacyReindexItemModel]:
+        result = await self._session.execute(
+            select(LegacyReindexItemModel)
+            .where(LegacyReindexItemModel.status == "PENDING")
+            .order_by(LegacyReindexItemModel.updated_at.asc(), LegacyReindexItemModel.id.asc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def mark_running(self, item: LegacyReindexItemModel, *, started_at: datetime) -> None:
+        item.status = "RUNNING"
+        item.started_at = started_at
+        item.updated_at = started_at
+        item.failed_stage = None
+        item.failure_type = None
+        item.last_error = None
+        await self._session.flush()
+
+    async def mark_succeeded(
+        self,
+        item: LegacyReindexItemModel,
+        *,
+        total_chunk_count: int,
+        completed_at: datetime,
+    ) -> None:
+        item.status = "SUCCEEDED"
+        item.total_chunk_count = total_chunk_count
+        item.completed_chunk_count = total_chunk_count
+        item.completed_at = completed_at
+        item.updated_at = completed_at
+        item.failed_stage = None
+        item.failure_type = None
+        item.last_error = None
+        await self._session.flush()
+
+    async def mark_failed(
+        self,
+        item: LegacyReindexItemModel,
+        *,
+        failed_stage: str,
+        error_message: str,
+        failed_at: datetime,
+    ) -> None:
+        item.status = "FAILED"
+        item.failed_stage = failed_stage
+        item.failure_type = "ERROR"
+        item.last_error = error_message
+        item.retry_count += 1
+        item.updated_at = failed_at
+        await self._session.flush()
+
+    async def mark_skipped(
+        self,
+        item: LegacyReindexItemModel,
+        *,
+        reason: str,
+        skipped_at: datetime,
+    ) -> None:
+        item.status = "SKIPPED"
+        item.failed_stage = None
+        item.failure_type = None
+        item.last_error = reason
+        item.completed_at = skipped_at
+        item.updated_at = skipped_at
+        await self._session.flush()
+
+    async def load_video_for_item(self, item: LegacyReindexItemModel) -> ReindexVideoRecord | None:
+        video = await self._session.get(VideoModel, item.video_id)
+        if video is None:
+            return None
+        source_entry = aliased(VectorIndexEntryModel)
+        result = await self._session.execute(
+            select(
+                ChunkModel.id,
+                ChunkModel.text,
+                ChunkModel.enriched_text,
+                source_entry.created_at,
+            )
+            .join(
+                source_entry,
+                and_(
+                    source_entry.chunk_id == ChunkModel.id,
+                    source_entry.index_name == item.source_index_name,
+                ),
+            )
+            .where(ChunkModel.video_id == item.video_id)
+            .order_by(ChunkModel.chunk_index.asc().nulls_last(), ChunkModel.id.asc())
+        )
+        chunks = [
+            ReindexChunkRecord(
+                chunk_id=row.id,
+                text=row.text,
+                enriched_text=row.enriched_text,
+                source_created_at=row.created_at,
+            )
+            for row in result.all()
+        ]
+        return ReindexVideoRecord(
+            video_id=video.id,
+            user_id=video.user_id,
+            project_id=video.project_id,
+            status=video.status,
+            chunks=chunks,
+        )
+
+    async def upsert_reindexed_vectors(self, vectors: list[ReindexedVectorRecord]) -> None:
+        if not vectors:
+            return
+        insert_factory = postgres_insert if self._session.get_bind().dialect.name == "postgresql" else sqlite_insert
+        for vector in vectors:
+            stmt = insert_factory(VectorIndexEntryModel).values(
+                index_name=vector.index_name,
+                chunk_id=vector.chunk_id,
+                user_id=vector.user_id,
+                project_id=vector.project_id,
+                video_id=vector.video_id,
+                embedding_vector=vector.embedding_vector,
+                embedding_model_version=vector.embedding_model_version,
+                created_at=vector.created_at,
+            )
+            update_values = {
+                "user_id": stmt.excluded.user_id,
+                "project_id": stmt.excluded.project_id,
+                "video_id": stmt.excluded.video_id,
+                "embedding_vector": stmt.excluded.embedding_vector,
+                "embedding_model_version": stmt.excluded.embedding_model_version,
+            }
+            await self._session.execute(
+                stmt.on_conflict_do_update(
+                    index_elements=["index_name", "chunk_id"],
+                    set_=update_values,
+                )
+            )
+        await self._session.flush()
+
+    async def target_vector_count(self, *, item: LegacyReindexItemModel) -> int:
+        chunk_ids = (
+            await self._session.execute(
+                select(ChunkModel.id).where(ChunkModel.video_id == item.video_id)
+            )
+        ).scalars().all()
+        if not chunk_ids:
+            return 0
+        count = await self._session.scalar(
+            select(func.count())
+            .select_from(VectorIndexEntryModel)
+            .where(
+                VectorIndexEntryModel.index_name == item.target_index_name,
+                VectorIndexEntryModel.chunk_id.in_(chunk_ids),
+            )
+        )
+        return int(count or 0)
+
+    async def count_old_only_videos(
+        self,
+        *,
+        target_index_name: str,
+        excluded_index_names: set[str],
+    ) -> int:
+        counts = [
+            len(
+                await self._old_only_video_rows(
+                    source_index_name=source_index.index_name,
+                    target_index_name=target_index_name,
+                    limit=None,
+                )
+            )
+            for source_index in await self._source_indexes(excluded_index_names)
+        ]
+        return sum(counts)
+
+    async def _source_indexes(self, excluded_index_names: set[str]) -> list[VectorIndexCatalogModel]:
+        result = await self._session.execute(
+            select(VectorIndexCatalogModel)
+            .where(
+                VectorIndexCatalogModel.index_name.not_in(excluded_index_names),
+                VectorIndexCatalogModel.deleted_at.is_(None),
+            )
+            .order_by(VectorIndexCatalogModel.created_at.asc(), VectorIndexCatalogModel.index_name.asc())
+        )
+        return list(result.scalars().all())
+
+    async def _old_only_video_rows(
+        self,
+        *,
+        source_index_name: str,
+        target_index_name: str,
+        limit: int | None,
+    ) -> list[object]:
+        source_entry = aliased(VectorIndexEntryModel)
+        target_entry = aliased(VectorIndexEntryModel)
+        target_row_exists = (
+            select(target_entry.chunk_id)
+            .where(
+                target_entry.chunk_id == source_entry.chunk_id,
+                target_entry.index_name == target_index_name,
+            )
+            .exists()
+        )
+        stmt = (
+            select(
+                source_entry.video_id.label("video_id"),
+                source_entry.user_id.label("user_id"),
+                source_entry.project_id.label("project_id"),
+            )
+            .join(VideoModel, VideoModel.id == source_entry.video_id)
+            .where(
+                source_entry.index_name == source_index_name,
+                VideoModel.status == "READY",
+                ~target_row_exists,
+            )
+            .group_by(source_entry.video_id, source_entry.user_id, source_entry.project_id)
+            .order_by(func.min(source_entry.created_at).asc(), source_entry.video_id.asc())
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        result = await self._session.execute(stmt)
+        return list(result.all())
+
+    async def _ensure_item(
+        self,
+        *,
+        video_id: UUID,
+        user_id: UUID,
+        project_id: UUID | None,
+        source_index_name: str,
+        source_model_version: str,
+        target_index_name: str,
+        target_model_version: str,
+        now: datetime,
+    ) -> bool:
+        existing = await self._session.scalar(
+            select(LegacyReindexItemModel).where(
+                LegacyReindexItemModel.video_id == video_id,
+                LegacyReindexItemModel.source_index_name == source_index_name,
+                LegacyReindexItemModel.target_index_name == target_index_name,
+            )
+        )
+        if existing is not None:
+            if existing.status in {"SUCCEEDED", "SKIPPED"}:
+                existing.status = "PENDING"
+                existing.completed_at = None
+                existing.failed_stage = None
+                existing.failure_type = None
+                existing.last_error = None
+                existing.source_model_version = source_model_version
+                existing.target_model_version = target_model_version
+                existing.updated_at = now
+            return False
+        self._session.add(
+            LegacyReindexItemModel(
+                video_id=video_id,
+                user_id=user_id,
+                project_id=project_id,
+                source_index_name=source_index_name,
+                source_model_version=source_model_version,
+                target_index_name=target_index_name,
+                target_model_version=target_model_version,
+                status="PENDING",
+                retry_count=0,
+                total_chunk_count=0,
+                completed_chunk_count=0,
+                created_at=now,
+                updated_at=now,
+            )
+        )
+        return True
+
+
+async def ensure_catalog_for_release(
+    *,
+    catalog_store: VectorIndexCatalogStore,
+    release: ModelReleaseModel,
+    embedding_dimension: int,
+    created_at: datetime,
+) -> None:
+    await catalog_store.upsert_index(
+        index_name=release.active_index_name,
+        model_version=release.active_model_version,
+        embedding_dimension=embedding_dimension,
+        created_at=created_at,
+    )
+    if release.previous_index_name is not None and release.previous_model_version is not None:
+        await catalog_store.upsert_index(
+            index_name=release.previous_index_name,
+            model_version=release.previous_model_version,
+            embedding_dimension=embedding_dimension,
+            created_at=created_at,
+        )
+    if release.candidate_index_name is not None and release.candidate_model_version is not None:
+        await catalog_store.upsert_index(
+            index_name=release.candidate_index_name,
+            model_version=release.candidate_model_version,
+            embedding_dimension=embedding_dimension,
+            created_at=created_at,
+        )

--- a/services/feedback-loop-pipeline/src/infra/db/models.py
+++ b/services/feedback-loop-pipeline/src/infra/db/models.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 from uuid import UUID, uuid4
 
+from pgvector.sqlalchemy import Vector
 from sqlalchemy import (
     JSON,
     CheckConstraint,
@@ -25,12 +26,22 @@ class Base(DeclarativeBase):
 
 
 METADATA_JSON_TYPE = JSON().with_variant(JSONB(), "postgresql")
+VECTOR_COLUMN_TYPE = Vector().with_variant(JSON(), "sqlite")
 PROJECT_SERVING_STATES = ("SERVABLE", "ROLLBACK_EXCLUDED")
 ML_RUN_STATUSES = ("PENDING", "RUNNING", "READY_FOR_RELEASE", "FAILED", "SUPERSEDED")
 ML_FAILURE_TYPES = ("FAIL", "ERROR")
 EVALUATION_STATUSES = ("RUNNING", "COMPLETED", "FAILED")
 EVALUATION_DECISIONS = ("PASS", "FAIL")
 RELEASE_STATUSES = ("STABLE", "CANDIDATE_REINDEXING", "ROLLBACK_PREPARING")
+LEGACY_REINDEX_STATUSES = ("PENDING", "RUNNING", "SUCCEEDED", "FAILED", "SKIPPED")
+LEGACY_REINDEX_FAILURE_TYPES = ("FAIL", "ERROR")
+LEGACY_REINDEX_FAILED_STAGES = (
+    "TARGET_LOOKUP",
+    "TEXT_LOAD",
+    "EMBEDDING",
+    "VECTOR_UPSERT",
+    "CONSISTENCY_CHECK",
+)
 
 
 def _check_values(column_name: str, values: tuple[str, ...]) -> str:
@@ -87,7 +98,9 @@ class ChunkModel(Base):
 
     id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True, default=uuid4)
     video_id: Mapped[UUID] = mapped_column(ForeignKey("video.id"), nullable=False)
+    chunk_index: Mapped[int | None] = mapped_column(Integer(), nullable=True)
     text: Mapped[str] = mapped_column(Text(), nullable=False)
+    enriched_text: Mapped[str | None] = mapped_column(Text(), nullable=True)
     embedding_model_version: Mapped[str] = mapped_column(String(64), nullable=False)
 
 
@@ -99,7 +112,25 @@ class VectorIndexEntryModel(Base):
     user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
     project_id: Mapped[UUID | None] = mapped_column(ForeignKey("project.id"), nullable=True)
     video_id: Mapped[UUID] = mapped_column(ForeignKey("video.id"), nullable=False)
+    embedding_vector: Mapped[list[float] | None] = mapped_column(VECTOR_COLUMN_TYPE, nullable=True)
     embedding_model_version: Mapped[str] = mapped_column(String(64), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class VectorIndexCatalogModel(Base):
+    __tablename__ = "vector_index_catalog"
+
+    index_name: Mapped[str] = mapped_column(String(128), primary_key=True)
+    model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    embedding_dimension: Mapped[int] = mapped_column(Integer(), nullable=False)
+    retired_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    delete_after: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    retire_reason: Mapped[str | None] = mapped_column(Text(), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -213,6 +244,57 @@ class ModelReleaseModel(Base):
     candidate_opened_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     candidate_ready_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     switched_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+
+class LegacyReindexItemModel(Base):
+    __tablename__ = "legacy_reindex_item"
+    __table_args__ = (
+        CheckConstraint(_check_values("status", LEGACY_REINDEX_STATUSES), name="ck_legacy_reindex_item_status"),
+        CheckConstraint(
+            "failure_type IS NULL OR " + _check_values("failure_type", LEGACY_REINDEX_FAILURE_TYPES),
+            name="ck_legacy_reindex_item_failure_type",
+        ),
+        CheckConstraint(
+            "failed_stage IS NULL OR " + _check_values("failed_stage", LEGACY_REINDEX_FAILED_STAGES),
+            name="ck_legacy_reindex_item_failed_stage",
+        ),
+        UniqueConstraint(
+            "video_id",
+            "source_index_name",
+            "target_index_name",
+            name="uq_legacy_reindex_item_video_source_target",
+        ),
+        Index("idx_legacy_reindex_item_status_updated", "status", "updated_at"),
+        Index("idx_legacy_reindex_item_target_status", "target_index_name", "status"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid(), primary_key=True, default=uuid4)
+    video_id: Mapped[UUID] = mapped_column(ForeignKey("video.id"), nullable=False)
+    user_id: Mapped[UUID] = mapped_column(Uuid(), nullable=False)
+    project_id: Mapped[UUID | None] = mapped_column(ForeignKey("project.id"), nullable=True)
+    source_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    source_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    target_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    target_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    status: Mapped[str] = mapped_column(Text(), nullable=False, default="PENDING")
+    failed_stage: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    failure_type: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    last_error: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    retry_count: Mapped[int] = mapped_column(Integer(), nullable=False, default=0)
+    total_chunk_count: Mapped[int] = mapped_column(Integer(), nullable=False, default=0)
+    completed_chunk_count: Mapped[int] = mapped_column(Integer(), nullable=False, default=0)
+    started_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
+    completed_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True), nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/services/feedback-loop-pipeline/src/release/legacy_reindex.py
+++ b/services/feedback-loop-pipeline/src/release/legacy_reindex.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Protocol
+from uuid import UUID, uuid4
+
+from loguru import logger
+
+from src.infra.db.legacy_reindex_store import (
+    LegacyReindexStore,
+    ReindexChunkRecord,
+    ReindexVideoRecord,
+    ReindexedVectorRecord,
+    VectorIndexCatalogStore,
+    ensure_catalog_for_release,
+)
+from src.infra.db.models import LegacyReindexItemModel
+from src.infra.db.stores import ModelReleaseStore
+from src.utils.clock import Clock, SystemClock
+
+
+ITEM_FAILED = "failed"
+ITEM_SKIPPED = "skipped"
+ITEM_SUCCEEDED = "succeeded"
+
+
+class EmbeddingBatchPort(Protocol):
+    async def embed_texts(
+        self,
+        texts: list[str],
+        *,
+        trace_id: str,
+        model_version: str | None = None,
+    ) -> object: ...
+
+
+class LegacyReindexLock(Protocol):
+    async def try_acquire(self) -> bool: ...
+
+    async def release(self) -> None: ...
+
+
+class LegacyReindexCoordinatorPort(Protocol):
+    async def run_once(self, *, trace_id: UUID) -> object: ...
+
+
+@dataclass(frozen=True)
+class LegacyReindexRunResult:
+    status: str
+    enqueued_item_count: int = 0
+    processed_item_count: int = 0
+    succeeded_item_count: int = 0
+    failed_item_count: int = 0
+    skipped_item_count: int = 0
+
+
+class LegacyReindexScheduler:
+    def __init__(
+        self,
+        *,
+        coordinator: LegacyReindexCoordinatorPort,
+        lock: LegacyReindexLock,
+        scan_interval_sec: int = 60,
+        sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    ) -> None:
+        self._coordinator = coordinator
+        self._lock = lock
+        self._scan_interval_sec = scan_interval_sec
+        self._sleep = sleep
+
+    async def run_once(self, *, trace_id: UUID) -> object:
+        acquired = await self._lock.try_acquire()
+        if not acquired:
+            return LegacyReindexRunResult(status="lock_busy")
+        try:
+            return await self._coordinator.run_once(trace_id=trace_id)
+        finally:
+            await self._lock.release()
+
+    async def run_until_stopped(
+        self,
+        *,
+        stop_event: asyncio.Event,
+        trace_id_factory: Callable[[], UUID] = uuid4,
+    ) -> None:
+        while not stop_event.is_set():
+            await self.run_once(trace_id=trace_id_factory())
+            if not stop_event.is_set():
+                await self._sleep(self._scan_interval_sec)
+
+
+class LegacyReindexCoordinator:
+    def __init__(
+        self,
+        *,
+        legacy_store: LegacyReindexStore,
+        catalog_store: VectorIndexCatalogStore,
+        embedding_client: EmbeddingBatchPort,
+        batch_size: int,
+        per_run_video_limit: int,
+        throttle_sleep_ms: int,
+        release_store: ModelReleaseStore | None = None,
+        embedding_dimension: int | None = None,
+        clock: Clock | None = None,
+    ) -> None:
+        self._legacy_store = legacy_store
+        self._catalog_store = catalog_store
+        self._embedding_client = embedding_client
+        self._batch_size = batch_size
+        self._per_run_video_limit = per_run_video_limit
+        self._throttle_sleep_ms = throttle_sleep_ms
+        self._release_store = release_store
+        self._embedding_dimension = embedding_dimension
+        self._clock = clock or SystemClock()
+
+    async def run_once(self, *, trace_id: UUID) -> LegacyReindexRunResult:
+        release = await self._current_release()
+        if release is None:
+            return LegacyReindexRunResult(status="missing_release")
+        if release.release_status == "ROLLBACK_PREPARING":
+            return LegacyReindexRunResult(status="paused_for_rollback")
+        now = self._clock.now()
+        if self._embedding_dimension is not None:
+            await ensure_catalog_for_release(
+                catalog_store=self._catalog_store,
+                release=release,
+                embedding_dimension=self._embedding_dimension,
+                created_at=now,
+            )
+        enqueued = await self._legacy_store.enqueue_old_only_items(
+            target_index_name=release.active_index_name,
+            target_model_version=release.active_model_version,
+            excluded_index_names=self._excluded_source_indexes(release),
+            now=now,
+            limit=self._per_run_video_limit,
+        )
+        items = await self._legacy_store.pending_items(limit=self._per_run_video_limit)
+
+        succeeded = 0
+        failed = 0
+        skipped = 0
+        for item in items:
+            item_result = await self._process_item(item, trace_id=trace_id)
+            if item_result == ITEM_SUCCEEDED:
+                succeeded += 1
+            elif item_result == ITEM_SKIPPED:
+                skipped += 1
+            else:
+                failed += 1
+
+        return LegacyReindexRunResult(
+            status="processed",
+            enqueued_item_count=enqueued,
+            processed_item_count=len(items),
+            succeeded_item_count=succeeded,
+            failed_item_count=failed,
+            skipped_item_count=skipped,
+        )
+
+    async def _current_release(self):
+        if self._release_store is None:
+            return None
+        return await self._release_store.get_current()
+
+    async def _process_item(self, item: LegacyReindexItemModel, *, trace_id: UUID) -> str:
+        now = self._clock.now()
+        await self._legacy_store.mark_running(item, started_at=now)
+
+        load_status, video = await self._load_reindexable_video(item)
+        if load_status is not None:
+            return load_status
+        if video is None:
+            raise RuntimeError("reindexable video load returned no video")
+
+        texts = await self._embedding_texts_for_video(item=item, video=video)
+        if texts is None:
+            return ITEM_FAILED
+
+        if not await self._embed_and_upsert_item_batches(item=item, video=video, texts=texts, trace_id=trace_id):
+            return ITEM_FAILED
+
+        return await self._complete_item_if_consistent(item=item, video=video, trace_id=trace_id)
+
+    async def _load_reindexable_video(
+        self,
+        item: LegacyReindexItemModel,
+    ) -> tuple[str | None, ReindexVideoRecord | None]:
+        video = await self._legacy_store.load_video_for_item(item)
+        if video is None:
+            await self._legacy_store.mark_failed(
+                item,
+                failed_stage="TARGET_LOOKUP",
+                error_message="video not found",
+                failed_at=self._clock.now(),
+            )
+            return ITEM_FAILED, None
+        if video.status == "DELETING":
+            await self._legacy_store.mark_skipped(
+                item,
+                reason="video is deleting",
+                skipped_at=self._clock.now(),
+            )
+            return ITEM_SKIPPED, None
+        if video.status != "READY":
+            await self._legacy_store.mark_skipped(
+                item,
+                reason=f"video status is {video.status}",
+                skipped_at=self._clock.now(),
+            )
+            return ITEM_SKIPPED, None
+        if not video.chunks:
+            await self._legacy_store.mark_failed(
+                item,
+                failed_stage="CONSISTENCY_CHECK",
+                error_message="video has no source chunks",
+                failed_at=self._clock.now(),
+            )
+            return ITEM_FAILED, None
+        return None, video
+
+    async def _embedding_texts_for_video(
+        self,
+        *,
+        item: LegacyReindexItemModel,
+        video: ReindexVideoRecord,
+    ) -> list[str] | None:
+        texts = [_embedding_input_text(chunk.enriched_text, chunk.text) for chunk in video.chunks]
+        if any(text is None for text in texts):
+            await self._legacy_store.mark_failed(
+                item,
+                failed_stage="TEXT_LOAD",
+                error_message="chunk text missing",
+                failed_at=self._clock.now(),
+            )
+            return None
+        return [text for text in texts if text is not None]
+
+    async def _embed_and_upsert_item_batches(
+        self,
+        *,
+        item: LegacyReindexItemModel,
+        video: ReindexVideoRecord,
+        texts: list[str],
+        trace_id: UUID,
+    ) -> bool:
+        for start in range(0, len(video.chunks), self._batch_size):
+            chunk_batch = video.chunks[start : start + self._batch_size]
+            text_batch = texts[start : start + self._batch_size]
+            embeddings = await self._embed_item_batch(item=item, texts=text_batch, trace_id=trace_id)
+            if embeddings is None:
+                return False
+            if not await self._validate_item_batch_embeddings(
+                item=item,
+                expected_count=len(chunk_batch),
+                embeddings=embeddings,
+            ):
+                return False
+            await self._upsert_item_batch_vectors(item=item, video=video, chunk_batch=chunk_batch, embeddings=embeddings)
+            await self._throttle_if_needed()
+        return True
+
+    async def _embed_item_batch(
+        self,
+        *,
+        item: LegacyReindexItemModel,
+        texts: list[str],
+        trace_id: UUID,
+    ) -> list[list[float]] | None:
+        try:
+            embedding_batch = await self._embedding_client.embed_texts(
+                texts,
+                trace_id=str(trace_id),
+                model_version=item.target_model_version,
+            )
+            return _extract_embeddings(embedding_batch)
+        except Exception as exc:
+            await self._legacy_store.mark_failed(
+                item,
+                failed_stage="EMBEDDING",
+                error_message=str(exc),
+                failed_at=self._clock.now(),
+            )
+            return None
+
+    async def _validate_item_batch_embeddings(
+        self,
+        *,
+        item: LegacyReindexItemModel,
+        expected_count: int,
+        embeddings: list[list[float]],
+    ) -> bool:
+        if len(embeddings) != expected_count:
+            await self._legacy_store.mark_failed(
+                item,
+                failed_stage="EMBEDDING",
+                error_message="embedding count mismatch",
+                failed_at=self._clock.now(),
+            )
+            return False
+        expected_dimension = await self._target_embedding_dimension(item.target_index_name)
+        if expected_dimension is not None and any(len(vector) != expected_dimension for vector in embeddings):
+            await self._legacy_store.mark_failed(
+                item,
+                failed_stage="VECTOR_UPSERT",
+                error_message="embedding dimension mismatch",
+                failed_at=self._clock.now(),
+            )
+            return False
+        return True
+
+    async def _upsert_item_batch_vectors(
+        self,
+        *,
+        item: LegacyReindexItemModel,
+        video: ReindexVideoRecord,
+        chunk_batch: list[ReindexChunkRecord],
+        embeddings: list[list[float]],
+    ) -> None:
+        await self._legacy_store.upsert_reindexed_vectors(
+            [
+                ReindexedVectorRecord(
+                    index_name=item.target_index_name,
+                    chunk_id=chunk.chunk_id,
+                    user_id=video.user_id,
+                    project_id=video.project_id,
+                    video_id=video.video_id,
+                    embedding_vector=embeddings[index],
+                    embedding_model_version=item.target_model_version,
+                    created_at=chunk.source_created_at,
+                )
+                for index, chunk in enumerate(chunk_batch)
+            ]
+        )
+
+    async def _complete_item_if_consistent(
+        self,
+        *,
+        item: LegacyReindexItemModel,
+        video: ReindexVideoRecord,
+        trace_id: UUID,
+    ) -> str:
+        target_count = await self._legacy_store.target_vector_count(item=item)
+        if target_count != len(video.chunks):
+            await self._legacy_store.mark_failed(
+                item,
+                failed_stage="CONSISTENCY_CHECK",
+                error_message="target index missing chunk vectors",
+                failed_at=self._clock.now(),
+            )
+            return ITEM_FAILED
+        await self._legacy_store.mark_succeeded(
+            item,
+            total_chunk_count=len(video.chunks),
+            completed_at=self._clock.now(),
+        )
+        logger.bind(
+            trace_id=str(trace_id),
+            video_id=str(item.video_id),
+            source_index_name=item.source_index_name,
+            target_index_name=item.target_index_name,
+        ).info("legacy_reindex.item succeeded")
+        return ITEM_SUCCEEDED
+
+    async def _target_embedding_dimension(self, index_name: str) -> int | None:
+        catalog = await self._catalog_store.get(index_name)
+        return catalog.embedding_dimension if catalog is not None else None
+
+    async def _throttle_if_needed(self) -> None:
+        if self._throttle_sleep_ms > 0:
+            await asyncio.sleep(self._throttle_sleep_ms / 1000)
+
+    @staticmethod
+    def _excluded_source_indexes(release) -> set[str]:
+        excluded = {release.active_index_name}
+        if release.candidate_index_name is not None:
+            excluded.add(release.candidate_index_name)
+        return excluded
+
+
+def _embedding_input_text(enriched_text: str | None, text: str | None) -> str | None:
+    if enriched_text is not None and enriched_text.strip():
+        return enriched_text
+    if text is not None and text.strip():
+        return text
+    return None
+
+
+def _extract_embeddings(embedding_batch: object) -> list[list[float]]:
+    embeddings = getattr(embedding_batch, "embeddings", None)
+    if not isinstance(embeddings, list):
+        raise TypeError("embedding batch must expose an embeddings list")
+    return embeddings

--- a/services/feedback-loop-pipeline/src/release/rollback.py
+++ b/services/feedback-loop-pipeline/src/release/rollback.py
@@ -10,6 +10,12 @@ from loguru import logger
 
 from src.infra.db.stores import ModelReleaseStore, ProjectRollbackStore
 from src.observability.metrics import MetricsRecorder, NoopMetricsRecorder
+from src.release.serving_reload import (
+    NoopReleaseChangeCommitter,
+    NoopServingTargetReloader,
+    ReleaseChangeCommitter,
+    ServingTargetReloader,
+)
 from src.utils.clock import Clock, SystemClock
 
 
@@ -65,6 +71,8 @@ class RollbackTransitionManager:
         project_store: ProjectRollbackStore,
         target_readiness: RollbackTargetReadinessPort,
         index_restore: SnapshotIndexRestorePort,
+        release_change_committer: ReleaseChangeCommitter | None = None,
+        serving_target_reloader: ServingTargetReloader | None = None,
         clock: Clock | None = None,
         metrics: MetricsRecorder | None = None,
     ) -> None:
@@ -72,6 +80,12 @@ class RollbackTransitionManager:
         self._project_store = project_store
         self._target_readiness = target_readiness
         self._index_restore = index_restore
+        self._release_change_committer = (
+            release_change_committer or NoopReleaseChangeCommitter()
+        )
+        self._serving_target_reloader = (
+            serving_target_reloader or NoopServingTargetReloader()
+        )
         self._clock = clock or SystemClock()
         self._metrics = metrics or NoopMetricsRecorder()
 
@@ -140,6 +154,8 @@ class RollbackTransitionManager:
             return self._result(message, "blocked_index_restore", affected_project_count=affected_project_count)
 
         await self._release_store.complete_rollback_restore(restored_at=restored_at or self._clock.now())
+        await self._release_change_committer.commit()
+        await self._serving_target_reloader.reload(trace_id=message.trace_id)
         return self._result(message, "restored", affected_project_count=affected_project_count)
 
     def _result(

--- a/services/feedback-loop-pipeline/src/release/serving_reload.py
+++ b/services/feedback-loop-pipeline/src/release/serving_reload.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import Protocol
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+from uuid import UUID
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+
+class ReleaseChangeCommitter(Protocol):
+    async def commit(self) -> None: ...
+
+
+class ServingTargetReloader(Protocol):
+    async def reload(self, *, trace_id: UUID) -> None: ...
+
+
+class NoopReleaseChangeCommitter:
+    async def commit(self) -> None:
+        return None
+
+
+@dataclass(frozen=True)
+class SqlAlchemyReleaseChangeCommitter:
+    session: AsyncSession
+
+    async def commit(self) -> None:
+        await self.session.commit()
+
+
+class NoopServingTargetReloader:
+    async def reload(self, *, trace_id: UUID) -> None:
+        _ = trace_id
+
+
+class SearchServiceReloadError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class SearchServiceServingTargetReloader:
+    base_url: str
+    timeout_sec: float = 5.0
+
+    async def reload(self, *, trace_id: UUID) -> None:
+        await asyncio.to_thread(self._post_reload, trace_id) # urlopen이 동기 함수라 별도 thread로 처리
+
+    def _post_reload(self, trace_id: UUID) -> None:
+        request = Request(
+            f"{self.base_url.rstrip('/')}/internal/reload-serving-targets",
+            data=json.dumps({"trace_id": str(trace_id)}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urlopen(request, timeout=self.timeout_sec) as response:
+                response.read()
+        except (HTTPError, URLError, TimeoutError) as exc:
+            raise SearchServiceReloadError(
+                "search-service serving target reload failed"
+            ) from exc

--- a/services/feedback-loop-pipeline/src/release/transition.py
+++ b/services/feedback-loop-pipeline/src/release/transition.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from loguru import logger
 
+from src.infra.db.models import MLPipelineRunModel, ModelReleaseModel
 from src.infra.db.stores import (
     MLPipelineRunStore,
     ModelReleaseStore,
@@ -17,6 +18,18 @@ from src.utils.clock import Clock, SystemClock
 
 class CandidateReadinessPort(Protocol):
     async def is_candidate_ready(self, *, model_version: str) -> bool: ...
+
+
+class LegacyReindexCutoverGate(Protocol):
+    async def ensure_cutover_ready(
+        self,
+        *,
+        active_index_name: str,
+        active_model_version: str,
+        candidate_index_name: str | None,
+        now: datetime,
+        limit: int = 100,
+    ) -> object: ...
 
 
 class AlwaysReadyCandidateReadiness:
@@ -43,6 +56,7 @@ class CutoverResult:
     status: str
     run_id: UUID
     missing_candidate_chunk_ids: list[UUID]
+    legacy_reindex_video_count: int = 0
 
 
 def candidate_index_name_for_model(candidate_model_version: str) -> str:
@@ -57,15 +71,38 @@ class ServingTransitionManager:
         release_store: ModelReleaseStore,
         vector_reader: VectorIndexProjectionReader,
         readiness: CandidateReadinessPort | None = None,
+        legacy_reindex_gate: LegacyReindexCutoverGate | None = None,
         clock: Clock | None = None,
     ) -> None:
         self._run_store = run_store
         self._release_store = release_store
         self._vector_reader = vector_reader
         self._readiness = readiness or AlwaysReadyCandidateReadiness()
+        self._legacy_reindex_gate = legacy_reindex_gate
         self._clock = clock or SystemClock()
 
     async def open_candidate_release(self, *, run_id: UUID, trace_id: UUID) -> CandidateReleaseResult:
+        run = await self._load_ready_for_release_run(run_id)
+        release = await self._load_current_release()
+        candidate_index_name = run.candidate_index_name or candidate_index_name_for_model(run.candidate_model_version)
+
+        already_open = await self._already_open_candidate_result(
+            run=run,
+            release=release,
+            candidate_index_name=candidate_index_name,
+            trace_id=trace_id,
+        )
+        if already_open is not None:
+            return already_open
+
+        return await self._open_new_candidate_release(
+            run=run,
+            release=release,
+            candidate_index_name=candidate_index_name,
+            trace_id=trace_id,
+        )
+
+    async def _load_ready_for_release_run(self, run_id: UUID):
         run = await self._run_store.get(run_id)
         if run is None:
             raise ReleaseTransitionError(f"MLPipelineRun not found: {run_id}")
@@ -73,38 +110,57 @@ class ServingTransitionManager:
             raise ReleaseTransitionError(f"MLPipelineRun is not READY_FOR_RELEASE: {run_id}")
         if run.candidate_model_version is None:
             raise ReleaseTransitionError(f"MLPipelineRun has no candidate model version: {run_id}")
+        return run
 
+    async def _load_current_release(self):
         release = await self._release_store.get_current()
         if release is None:
             raise ReleaseTransitionError("current ModelRelease row is required")
-        candidate_index_name = run.candidate_index_name or candidate_index_name_for_model(run.candidate_model_version)
-        if (
+        return release
+
+    async def _already_open_candidate_result(
+        self,
+        *,
+        run,
+        release,
+        candidate_index_name: str,
+        trace_id: UUID,
+    ) -> CandidateReleaseResult | None:
+        if not (
             release.release_status == "CANDIDATE_REINDEXING"
             and release.candidate_model_version == run.candidate_model_version
             and release.candidate_index_name == candidate_index_name
         ):
-            if run.candidate_index_name is None:
-                now = self._clock.now()
-                await self._run_store.record_candidate_index(
-                    run_id=run.id,
-                    candidate_index_name=candidate_index_name,
-                    updated_at=now,
-                )
-            self._log_transition(
-                trace_id=trace_id,
-                run_id=run.id,
-                action="candidate_release_open",
-                result="already_open",
-                release_status=release.release_status,
-                candidate_model_version=run.candidate_model_version,
-                candidate_index_name=candidate_index_name,
-            )
-            return CandidateReleaseResult(
-                status="already_open",
-                run_id=run.id,
-                candidate_model_version=run.candidate_model_version,
-                candidate_index_name=candidate_index_name,
-            )
+            return None
+
+        await self._record_candidate_index_if_missing(
+            run=run,
+            candidate_index_name=candidate_index_name,
+        )
+        self._log_transition(
+            trace_id=trace_id,
+            run_id=run.id,
+            action="candidate_release_open",
+            result="already_open",
+            release_status=release.release_status,
+            candidate_model_version=run.candidate_model_version,
+            candidate_index_name=candidate_index_name,
+        )
+        return CandidateReleaseResult(
+            status="already_open",
+            run_id=run.id,
+            candidate_model_version=run.candidate_model_version,
+            candidate_index_name=candidate_index_name,
+        )
+
+    async def _open_new_candidate_release(
+        self,
+        *,
+        run,
+        release,
+        candidate_index_name: str,
+        trace_id: UUID,
+    ) -> CandidateReleaseResult:
         if release.release_status != "STABLE":
             raise ReleaseTransitionError(f"ModelRelease is not STABLE: {release.release_status}")
 
@@ -118,10 +174,9 @@ class ServingTransitionManager:
             current_release = await self._release_store.get_current()
             current_status = current_release.release_status if current_release is not None else "missing"
             raise ReleaseTransitionError(f"ModelRelease is not STABLE: {current_status}")
-        await self._run_store.record_candidate_index(
-            run_id=run.id,
+        await self._record_candidate_index_if_missing(
+            run=run,
             candidate_index_name=candidate_index_name,
-            updated_at=now,
         )
         self._log_transition(
             trace_id=trace_id,
@@ -139,7 +194,68 @@ class ServingTransitionManager:
             candidate_index_name=candidate_index_name,
         )
 
+    async def _record_candidate_index_if_missing(
+        self,
+        *,
+        run,
+        candidate_index_name: str,
+        updated_at: datetime | None = None,
+    ) -> None:
+        if run.candidate_index_name is not None:
+            return
+        await self._run_store.record_candidate_index(
+            run_id=run.id,
+            candidate_index_name=candidate_index_name,
+            updated_at=updated_at or self._clock.now(),
+        )
+
+    # Cutover flow:
+    # 1. candidate release가 열린 상태이고 run과 같은 candidate model인지 확인한다.
+    # 2. candidate model serving이 준비되지 않았으면 cutover를 막는다.
+    # 3. legacy reindex가 남아 있으면 cutover를 막는다.
+    # 4. cutover_time을 고정한 뒤, candidate open 이후 생긴 active row의 candidate row 누락을 확인한다.
+    # 5. 모든 조건이 통과하면 candidate model/index를 active로 승격한다.
     async def cutover_candidate_release(self, *, run_id: UUID, trace_id: UUID) -> CutoverResult:
+        run, release = await self._load_cutover_run_and_release(run_id)
+
+        not_ready = await self._blocked_not_ready_result(
+            run=run,
+            release=release,
+            trace_id=trace_id,
+        )
+        if not_ready is not None:
+            return not_ready
+
+        cutover_time = run.cutover_time or self._clock.now()
+        legacy_block = await self._blocked_legacy_reindex_result(
+            run=run,
+            release=release,
+            cutover_time=cutover_time,
+            trace_id=trace_id,
+        )
+        if legacy_block is not None:
+            return legacy_block
+
+        await self._record_cutover_time_if_missing(run=run, cutover_time=cutover_time)
+
+        missing_rows = await self._blocked_missing_candidate_rows_result(
+            run=run,
+            release=release,
+            cutover_time=cutover_time,
+            trace_id=trace_id,
+        )
+        if missing_rows is not None:
+            return missing_rows
+
+        return await self._complete_candidate_cutover(
+            run=run,
+            release=release,
+            cutover_time=cutover_time,
+            trace_id=trace_id,
+        )
+
+
+    async def _load_cutover_run_and_release(self, run_id: UUID) -> tuple[MLPipelineRunModel, ModelReleaseModel]:
         run = await self._run_store.get(run_id)
         if run is None:
             raise ReleaseTransitionError(f"MLPipelineRun not found: {run_id}")
@@ -154,7 +270,15 @@ class ServingTransitionManager:
             raise ReleaseTransitionError("candidate_opened_at is required for cutover")
         if run.candidate_model_version != release.candidate_model_version:
             raise ReleaseTransitionError("run candidate model does not match current release")
+        return run, release
 
+    async def _blocked_not_ready_result(
+        self,
+        *,
+        run: MLPipelineRunModel,
+        release: ModelReleaseModel,
+        trace_id: UUID,
+    ) -> CutoverResult | None:
         if not await self._readiness.is_candidate_ready(model_version=release.candidate_model_version):
             self._log_transition(
                 trace_id=trace_id,
@@ -166,14 +290,66 @@ class ServingTransitionManager:
                 candidate_index_name=release.candidate_index_name,
             )
             return CutoverResult(status="blocked_not_ready", run_id=run.id, missing_candidate_chunk_ids=[])
+        return None
 
-        cutover_time = run.cutover_time or self._clock.now()
+    async def _blocked_legacy_reindex_result(
+        self,
+        *,
+        run: MLPipelineRunModel,
+        release: ModelReleaseModel,
+        cutover_time: datetime,
+        trace_id: UUID,
+    ) -> CutoverResult | None:
+        legacy_gate_result = await self._ensure_legacy_reindex_ready(
+            active_index_name=release.active_index_name,
+            active_model_version=release.active_model_version,
+            candidate_index_name=release.candidate_index_name,
+            cutover_time=cutover_time,
+        )
+        if legacy_gate_result is None or not getattr(legacy_gate_result, "blocked", False):
+            return None
+
+        remaining_count = int(getattr(legacy_gate_result, "remaining_video_count", 0))
+        self._log_transition(
+            trace_id=trace_id,
+            run_id=run.id,
+            action="candidate_release_cutover",
+            result="blocked_legacy_vectors_remain",
+            release_status=release.release_status,
+            candidate_model_version=release.candidate_model_version,
+            candidate_index_name=release.candidate_index_name,
+            cutover_time=cutover_time,
+            missing_candidate_chunk_count=0,
+            legacy_reindex_video_count=remaining_count,
+        )
+        return CutoverResult(
+            status="blocked_legacy_vectors_remain",
+            run_id=run.id,
+            missing_candidate_chunk_ids=[],
+            legacy_reindex_video_count=remaining_count,
+        )
+
+    async def _record_cutover_time_if_missing(
+        self,
+        *,
+        run: MLPipelineRunModel,
+        cutover_time: datetime,
+    ) -> None:
         if run.cutover_time is None:
             await self._run_store.record_cutover_time(
                 run_id=run.id,
                 cutover_time=cutover_time,
                 updated_at=cutover_time,
             )
+
+    async def _blocked_missing_candidate_rows_result(
+        self,
+        *,
+        run: MLPipelineRunModel,
+        release: ModelReleaseModel,
+        cutover_time: datetime,
+        trace_id: UUID,
+    ) -> CutoverResult | None:
         missing_chunk_ids = await self._vector_reader.find_missing_candidate_chunk_ids(
             active_index_name=release.active_index_name,
             active_model_version=release.active_model_version,
@@ -199,7 +375,16 @@ class ServingTransitionManager:
                 run_id=run.id,
                 missing_candidate_chunk_ids=missing_chunk_ids,
             )
+        return None
 
+    async def _complete_candidate_cutover(
+        self,
+        *,
+        run: MLPipelineRunModel,
+        release: ModelReleaseModel,
+        cutover_time: datetime,
+        trace_id: UUID,
+    ) -> CutoverResult:
         cutover_candidate_model_version = release.candidate_model_version
         cutover_candidate_index_name = release.candidate_index_name
         await self._release_store.mark_candidate_ready(ready_at=cutover_time)
@@ -217,6 +402,23 @@ class ServingTransitionManager:
         )
         return CutoverResult(status="cutover", run_id=run.id, missing_candidate_chunk_ids=[])
 
+    async def _ensure_legacy_reindex_ready(
+        self,
+        *,
+        active_index_name: str,
+        active_model_version: str,
+        candidate_index_name: str | None,
+        cutover_time: datetime,
+    ) -> object | None:
+        if self._legacy_reindex_gate is None:
+            return None
+        return await self._legacy_reindex_gate.ensure_cutover_ready(
+            active_index_name=active_index_name,
+            active_model_version=active_model_version,
+            candidate_index_name=candidate_index_name,
+            now=cutover_time,
+        )
+
     @staticmethod
     def _log_transition(
         *,
@@ -229,6 +431,7 @@ class ServingTransitionManager:
         candidate_index_name: str | None,
         cutover_time: datetime | None = None,
         missing_candidate_chunk_count: int | None = None,
+        legacy_reindex_video_count: int | None = None,
     ) -> None:
         fields = {
             "trace_id": str(trace_id),
@@ -240,6 +443,7 @@ class ServingTransitionManager:
             "candidate_index_name": candidate_index_name,
             "cutover_time": cutover_time.isoformat() if cutover_time is not None else None,
             "missing_candidate_chunk_count": missing_candidate_chunk_count,
+            "legacy_reindex_video_count": legacy_reindex_video_count,
         }
         logger.bind(**{key: value for key, value in fields.items() if value is not None}).info(
             "release.transition handled"

--- a/services/feedback-loop-pipeline/src/release/transition.py
+++ b/services/feedback-loop-pipeline/src/release/transition.py
@@ -13,6 +13,12 @@ from src.infra.db.stores import (
     ModelReleaseStore,
     VectorIndexProjectionReader,
 )
+from src.release.serving_reload import (
+    NoopReleaseChangeCommitter,
+    NoopServingTargetReloader,
+    ReleaseChangeCommitter,
+    ServingTargetReloader,
+)
 from src.utils.clock import Clock, SystemClock
 
 
@@ -72,6 +78,8 @@ class ServingTransitionManager:
         vector_reader: VectorIndexProjectionReader,
         readiness: CandidateReadinessPort | None = None,
         legacy_reindex_gate: LegacyReindexCutoverGate | None = None,
+        release_change_committer: ReleaseChangeCommitter | None = None,
+        serving_target_reloader: ServingTargetReloader | None = None,
         clock: Clock | None = None,
     ) -> None:
         self._run_store = run_store
@@ -79,6 +87,12 @@ class ServingTransitionManager:
         self._vector_reader = vector_reader
         self._readiness = readiness or AlwaysReadyCandidateReadiness()
         self._legacy_reindex_gate = legacy_reindex_gate
+        self._release_change_committer = (
+            release_change_committer or NoopReleaseChangeCommitter()
+        )
+        self._serving_target_reloader = (
+            serving_target_reloader or NoopServingTargetReloader()
+        )
         self._clock = clock or SystemClock()
 
     async def open_candidate_release(self, *, run_id: UUID, trace_id: UUID) -> CandidateReleaseResult:
@@ -389,6 +403,8 @@ class ServingTransitionManager:
         cutover_candidate_index_name = release.candidate_index_name
         await self._release_store.mark_candidate_ready(ready_at=cutover_time)
         await self._release_store.complete_candidate_cutover(switched_at=cutover_time)
+        await self._release_change_committer.commit()
+        await self._serving_target_reloader.reload(trace_id=trace_id)
         self._log_transition(
             trace_id=trace_id,
             run_id=run.id,

--- a/services/feedback-loop-pipeline/tests/integration/test_candidate_release_flow.py
+++ b/services/feedback-loop-pipeline/tests/integration/test_candidate_release_flow.py
@@ -15,7 +15,7 @@
 # - candidate_index_name은 바뀌지 않는다.
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime, timedelta
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -39,6 +39,25 @@ from src.release.transition import ServingTransitionManager
 class _FixedClock:
     def now(self) -> datetime:
         return datetime(2026, 5, 11, 11, 0, tzinfo=UTC)
+
+
+class _RecordingCommitter:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    async def commit(self) -> None:
+        self._events.append("commit")
+
+
+class _RecordingServingTargetReloader:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self.trace_ids: list[UUID] = []
+
+    async def reload(self, *, trace_id: UUID) -> None:
+        self._events.append("reload")
+        self.trace_ids.append(trace_id)
+
 
 @pytest.fixture
 async def session() -> AsyncIterator[AsyncSession]:
@@ -267,6 +286,50 @@ async def test_cutover_promotes_candidate_when_candidate_vector_rows_exist(
     assert release.candidate_index_name is None
     assert release.candidate_ready_at is None
     assert run.candidate_index_name == "candidate-index-model-v2"
+
+
+async def test_cutover_commits_before_reloading_search_targets(
+    session: AsyncSession,
+) -> None:
+    now = datetime(2026, 5, 11, 10, 0, tzinfo=UTC)
+    trace_id = uuid4()
+    events: list[str] = []
+
+    run = MLPipelineRunModel(
+        status="READY_FOR_RELEASE",
+        dataset_version="dataset-v1",
+        baseline_model_version="model-v1",
+        candidate_model_version="model-v2",
+        candidate_index_name="candidate-index-model-v2",
+        cutover_time=now,
+        created_at=now,
+        updated_at=now,
+    )
+    release = ModelReleaseModel(
+        release_status="CANDIDATE_REINDEXING",
+        active_model_version="model-v1",
+        active_index_name="active-index-v1",
+        candidate_model_version="model-v2",
+        candidate_index_name="candidate-index-model-v2",
+        candidate_opened_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add_all([run, release])
+    await session.flush()
+
+    reloader = _RecordingServingTargetReloader(events)
+    result = await ServingTransitionManager(
+        run_store=MLPipelineRunStore(session),
+        release_store=ModelReleaseStore(session),
+        vector_reader=VectorIndexProjectionReader(session),
+        release_change_committer=_RecordingCommitter(events),
+        serving_target_reloader=reloader,
+    ).cutover_candidate_release(run_id=run.id, trace_id=trace_id)
+
+    assert result.status == "cutover"
+    assert events == ["commit", "reload"]
+    assert reloader.trace_ids == [trace_id]
 
 
 async def test_cutover_ignores_active_rows_before_candidate_opened_at(

--- a/services/feedback-loop-pipeline/tests/integration/test_candidate_release_flow.py
+++ b/services/feedback-loop-pipeline/tests/integration/test_candidate_release_flow.py
@@ -102,6 +102,41 @@ async def test_duplicate_handoff_is_noop_when_same_candidate_is_already_open(ses
     assert release.candidate_index_name == "candidate-index-model-v2"
 
 
+async def test_candidate_release_open_returns_opened_result(session: AsyncSession) -> None:
+    now = datetime(2026, 5, 11, 10, 0, tzinfo=UTC)
+    run = MLPipelineRunModel(
+        status="READY_FOR_RELEASE",
+        dataset_version="dataset-v1",
+        baseline_model_version="model-v1",
+        candidate_model_version="model-v2",
+        created_at=now,
+        updated_at=now,
+    )
+    release = ModelReleaseModel(
+        release_status="STABLE",
+        active_model_version="model-v1",
+        active_index_name="active-index-v1",
+        created_at=now,
+        updated_at=now,
+    )
+    session.add_all([run, release])
+    await session.flush()
+
+    result = await ServingTransitionManager(
+        run_store=MLPipelineRunStore(session),
+        release_store=ModelReleaseStore(session),
+        vector_reader=VectorIndexProjectionReader(session),
+        clock=_FixedClock(),
+    ).open_candidate_release(run_id=run.id, trace_id=uuid4())
+
+    assert result.status == "opened"
+    assert result.run_id == run.id
+    assert result.candidate_model_version == "model-v2"
+    assert result.candidate_index_name == "candidate-index-model-v2"
+    assert run.candidate_index_name == "candidate-index-model-v2"
+    assert release.release_status == "CANDIDATE_REINDEXING"
+
+
 async def test_candidate_release_open_does_not_overwrite_when_release_is_not_stable(
     session: AsyncSession,
 ) -> None:

--- a/services/feedback-loop-pipeline/tests/integration/test_legacy_reindex_flow.py
+++ b/services/feedback-loop-pipeline/tests/integration/test_legacy_reindex_flow.py
@@ -1,0 +1,508 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from uuid import UUID, uuid4
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from src.infra.db.legacy_reindex_store import LegacyReindexStore, VectorIndexCatalogStore
+from src.infra.db.models import (
+    Base,
+    ChunkModel,
+    MLPipelineRunModel,
+    LegacyReindexItemModel,
+    ModelReleaseModel,
+    ProjectModel,
+    VectorIndexEntryModel,
+    VectorIndexCatalogModel,
+    VideoModel,
+)
+from src.infra.db.stores import MLPipelineRunStore, ModelReleaseStore, VectorIndexProjectionReader
+from src.release.transition import ServingTransitionManager
+from src.release.legacy_reindex import LegacyReindexCoordinator
+
+
+@dataclass(frozen=True)
+class _EmbeddingBatch:
+    embeddings: list[list[float]]
+    model_version: str
+
+
+class _FakeEmbeddingClient:
+    def __init__(self, *, dimensions: int = 3) -> None:
+        self.dimensions = dimensions
+        self.calls: list[dict[str, object]] = []
+
+    async def embed_texts(
+        self,
+        texts: list[str],
+        *,
+        trace_id: str,
+        model_version: str | None = None,
+    ) -> _EmbeddingBatch:
+        # Async to satisfy the embedding client port used by the coordinator.
+        self.calls.append(
+            {
+                "texts": texts,
+                "trace_id": trace_id,
+                "model_version": model_version,
+            }
+        )
+        return _EmbeddingBatch(
+            embeddings=[
+                [float(len(text)), float(index), float(self.dimensions)]
+                for index, text in enumerate(texts)
+            ],
+            model_version=model_version or "model-b",
+        )
+
+
+class _FailingEmbeddingClient:
+    async def embed_texts(
+        self,
+        texts: list[str],
+        *,
+        trace_id: str,
+        model_version: str | None = None,
+    ) -> _EmbeddingBatch:
+        del texts, trace_id, model_version
+        raise RuntimeError("embedding endpoint unavailable")
+
+
+@pytest.fixture
+async def session() -> AsyncSession:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    try:
+        async with factory() as db_session:
+            yield db_session
+    finally:
+        await engine.dispose()
+
+
+async def test_reindexes_old_only_video_into_active_index(session: AsyncSession) -> None:
+    now = datetime(2026, 5, 27, 9, 0, tzinfo=UTC)
+    user_id = uuid4()
+    project, video = await _seed_project_video(session, user_id=user_id, now=now)
+    chunk = await _seed_chunk(
+        session,
+        video_id=video.id,
+        text="plain transcript",
+        enriched_text="visual enriched transcript",
+    )
+    source_created_at = datetime(2026, 5, 20, 9, 0, tzinfo=UTC)
+    await _seed_release_and_catalog(
+        session,
+        active_index="index-b",
+        active_model="model-b",
+        previous_index="index-a",
+        previous_model="model-a",
+        now=now,
+    )
+    session.add(
+        VectorIndexEntryModel(
+            index_name="index-a",
+            chunk_id=chunk.id,
+            user_id=user_id,
+            project_id=project.id,
+            video_id=video.id,
+            embedding_model_version="model-a",
+            embedding_vector=[1.0, 0.0, 3.0],
+            created_at=source_created_at,
+        )
+    )
+    await session.flush()
+
+    embedding_client = _FakeEmbeddingClient()
+    result = await _coordinator(session, embedding_client=embedding_client).run_once(
+        trace_id=uuid4()
+    )
+
+    assert result.enqueued_item_count == 1
+    assert result.succeeded_item_count == 1
+    assert embedding_client.calls[0]["texts"] == ["visual enriched transcript"]
+    assert embedding_client.calls[0]["model_version"] == "model-b"
+
+    source_entry = await session.get(VectorIndexEntryModel, ("index-a", chunk.id))
+    target_entry = await session.get(VectorIndexEntryModel, ("index-b", chunk.id))
+    assert source_entry is not None
+    assert target_entry is not None
+    assert target_entry.embedding_model_version == "model-b"
+    assert target_entry.embedding_vector == pytest.approx([26.0, 0.0, 3.0])
+    assert target_entry.created_at.replace(tzinfo=UTC) == source_created_at
+
+    item = await session.scalar(select(LegacyReindexItemModel))
+    assert item is not None
+    assert item.status == "SUCCEEDED"
+    assert item.total_chunk_count == 1
+    assert item.completed_chunk_count == 1
+
+
+async def test_reindex_uses_text_fallback_when_enriched_text_is_blank(
+    session: AsyncSession,
+) -> None:
+    now = datetime(2026, 5, 27, 9, 0, tzinfo=UTC)
+    user_id = uuid4()
+    project, video = await _seed_project_video(session, user_id=user_id, now=now)
+    chunk = await _seed_chunk(session, video_id=video.id, text="plain transcript", enriched_text="")
+    await _seed_release_and_catalog(
+        session,
+        active_index="index-b",
+        active_model="model-b",
+        previous_index="index-a",
+        previous_model="model-a",
+        now=now,
+    )
+    session.add(
+        VectorIndexEntryModel(
+            index_name="index-a",
+            chunk_id=chunk.id,
+            user_id=user_id,
+            project_id=project.id,
+            video_id=video.id,
+            embedding_model_version="model-a",
+            embedding_vector=[1.0, 0.0, 3.0],
+            created_at=now,
+        )
+    )
+    await session.flush()
+
+    embedding_client = _FakeEmbeddingClient()
+    result = await _coordinator(session, embedding_client=embedding_client).run_once(
+        trace_id=uuid4()
+    )
+
+    assert result.succeeded_item_count == 1
+    assert embedding_client.calls[0]["texts"] == ["plain transcript"]
+
+
+async def test_deleting_video_item_is_skipped_without_vector_upsert(
+    session: AsyncSession,
+) -> None:
+    now = datetime(2026, 5, 27, 9, 0, tzinfo=UTC)
+    user_id = uuid4()
+    project, video = await _seed_project_video(session, user_id=user_id, now=now)
+    chunk = await _seed_chunk(session, video_id=video.id, text="plain transcript")
+    await _seed_release_and_catalog(
+        session,
+        active_index="index-b",
+        active_model="model-b",
+        previous_index="index-a",
+        previous_model="model-a",
+        now=now,
+    )
+    session.add_all(
+        [
+            VectorIndexEntryModel(
+                index_name="index-a",
+                chunk_id=chunk.id,
+                user_id=user_id,
+                project_id=project.id,
+                video_id=video.id,
+                embedding_model_version="model-a",
+                embedding_vector=[1.0, 0.0, 3.0],
+                created_at=now,
+            ),
+            LegacyReindexItemModel(
+                video_id=video.id,
+                user_id=user_id,
+                project_id=project.id,
+                source_index_name="index-a",
+                source_model_version="model-a",
+                target_index_name="index-b",
+                target_model_version="model-b",
+                status="PENDING",
+                retry_count=0,
+                total_chunk_count=0,
+                completed_chunk_count=0,
+                created_at=now,
+                updated_at=now,
+            ),
+        ]
+    )
+    await session.flush()
+    video.status = "DELETING"
+    await session.flush()
+
+    embedding_client = _FakeEmbeddingClient()
+    result = await _coordinator(session, embedding_client=embedding_client).run_once(
+        trace_id=uuid4()
+    )
+
+    assert result.skipped_item_count == 1
+    assert embedding_client.calls == []
+    assert await session.get(VectorIndexEntryModel, ("index-b", chunk.id)) is None
+
+    item = await session.scalar(select(LegacyReindexItemModel))
+    assert item is not None
+    assert item.status == "SKIPPED"
+    assert item.last_error == "video is deleting"
+
+
+async def test_vector_dimension_mismatch_marks_item_failed(session: AsyncSession) -> None:
+    now = datetime(2026, 5, 27, 9, 0, tzinfo=UTC)
+    user_id = uuid4()
+    project, video = await _seed_project_video(session, user_id=user_id, now=now)
+    chunk = await _seed_chunk(session, video_id=video.id, text="plain transcript")
+    await _seed_release_and_catalog(
+        session,
+        active_index="index-b",
+        active_model="model-b",
+        previous_index="index-a",
+        previous_model="model-a",
+        now=now,
+        embedding_dimension=4,
+    )
+    session.add(
+        VectorIndexEntryModel(
+            index_name="index-a",
+            chunk_id=chunk.id,
+            user_id=user_id,
+            project_id=project.id,
+            video_id=video.id,
+            embedding_model_version="model-a",
+            embedding_vector=[1.0, 0.0, 3.0],
+            created_at=now,
+        )
+    )
+    await session.flush()
+
+    result = await _coordinator(
+        session,
+        embedding_client=_FakeEmbeddingClient(dimensions=3),
+    ).run_once(trace_id=uuid4())
+
+    assert result.failed_item_count == 1
+    item = await session.scalar(select(LegacyReindexItemModel))
+    assert item is not None
+    assert item.status == "FAILED"
+    assert item.failed_stage == "VECTOR_UPSERT"
+    assert item.failure_type == "ERROR"
+    assert item.last_error == "embedding dimension mismatch"
+
+
+async def test_embedding_failure_marks_item_failed(session: AsyncSession) -> None:
+    now = datetime(2026, 5, 27, 9, 0, tzinfo=UTC)
+    user_id = uuid4()
+    project, video = await _seed_project_video(session, user_id=user_id, now=now)
+    chunk = await _seed_chunk(session, video_id=video.id, text="plain transcript")
+    await _seed_release_and_catalog(
+        session,
+        active_index="index-b",
+        active_model="model-b",
+        previous_index="index-a",
+        previous_model="model-a",
+        now=now,
+    )
+    session.add(
+        VectorIndexEntryModel(
+            index_name="index-a",
+            chunk_id=chunk.id,
+            user_id=user_id,
+            project_id=project.id,
+            video_id=video.id,
+            embedding_model_version="model-a",
+            embedding_vector=[1.0, 0.0, 3.0],
+            created_at=now,
+        )
+    )
+    await session.flush()
+
+    result = await _coordinator(
+        session,
+        embedding_client=_FailingEmbeddingClient(),
+    ).run_once(trace_id=uuid4())
+
+    assert result.failed_item_count == 1
+    item = await session.scalar(select(LegacyReindexItemModel))
+    assert item is not None
+    assert item.status == "FAILED"
+    assert item.failed_stage == "EMBEDDING"
+    assert item.last_error == "embedding endpoint unavailable"
+    assert await session.get(VectorIndexEntryModel, ("index-b", chunk.id)) is None
+
+
+async def test_cutover_blocks_and_enqueues_when_legacy_vectors_remain(
+    session: AsyncSession,
+) -> None:
+    now = datetime(2026, 5, 27, 9, 0, tzinfo=UTC)
+    user_id = uuid4()
+    project, video = await _seed_project_video(session, user_id=user_id, now=now)
+    chunk = await _seed_chunk(session, video_id=video.id, text="plain transcript")
+    run = MLPipelineRunModel(
+        status="READY_FOR_RELEASE",
+        dataset_version="dataset-v1",
+        baseline_model_version="model-b",
+        candidate_model_version="model-c",
+        candidate_index_name="index-c",
+        created_at=now,
+        updated_at=now,
+    )
+    release = ModelReleaseModel(
+        release_status="CANDIDATE_REINDEXING",
+        active_model_version="model-b",
+        active_index_name="index-b",
+        previous_model_version="model-a",
+        previous_index_name="index-a",
+        candidate_model_version="model-c",
+        candidate_index_name="index-c",
+        candidate_opened_at=now,
+        created_at=now,
+        updated_at=now,
+    )
+    session.add_all(
+        [
+            run,
+            release,
+            VectorIndexCatalogModel(
+                index_name="index-a",
+                model_version="model-a",
+                embedding_dimension=3,
+                created_at=now,
+            ),
+            VectorIndexCatalogModel(
+                index_name="index-b",
+                model_version="model-b",
+                embedding_dimension=3,
+                created_at=now,
+            ),
+            VectorIndexCatalogModel(
+                index_name="index-c",
+                model_version="model-c",
+                embedding_dimension=3,
+                created_at=now,
+            ),
+            VectorIndexEntryModel(
+                index_name="index-a",
+                chunk_id=chunk.id,
+                user_id=user_id,
+                project_id=project.id,
+                video_id=video.id,
+                embedding_model_version="model-a",
+                embedding_vector=[1.0, 0.0, 3.0],
+                created_at=now,
+            ),
+        ]
+    )
+    await session.flush()
+
+    result = await ServingTransitionManager(
+        run_store=MLPipelineRunStore(session),
+        release_store=ModelReleaseStore(session),
+        vector_reader=VectorIndexProjectionReader(session),
+        legacy_reindex_gate=LegacyReindexStore(session),
+    ).cutover_candidate_release(run_id=run.id, trace_id=uuid4())
+
+    assert result.status == "blocked_legacy_vectors_remain"
+    assert result.legacy_reindex_video_count == 1
+    assert release.release_status == "CANDIDATE_REINDEXING"
+
+    item = await session.scalar(select(LegacyReindexItemModel))
+    assert item is not None
+    assert item.video_id == video.id
+    assert item.source_index_name == "index-a"
+    assert item.target_index_name == "index-b"
+    assert item.status == "PENDING"
+
+
+async def _seed_project_video(
+    session: AsyncSession,
+    *,
+    user_id: UUID,
+    now: datetime,
+) -> tuple[ProjectModel, VideoModel]:
+    project = ProjectModel(user_id=user_id, title="Project", created_at=now, updated_at=now)
+    session.add(project)
+    await session.flush()
+    video = VideoModel(
+        user_id=user_id,
+        project_id=project.id,
+        title="Video",
+        status="READY",
+        updated_at=now,
+    )
+    session.add(video)
+    await session.flush()
+    return project, video
+
+
+async def _seed_chunk(
+    session: AsyncSession,
+    *,
+    video_id: UUID,
+    text: str,
+    enriched_text: str | None = None,
+) -> ChunkModel:
+    chunk = ChunkModel(
+        video_id=video_id,
+        chunk_index=0,
+        text=text,
+        enriched_text=enriched_text,
+        embedding_model_version="model-a",
+    )
+    session.add(chunk)
+    await session.flush()
+    return chunk
+
+
+async def _seed_release_and_catalog(
+    session: AsyncSession,
+    *,
+    active_index: str,
+    active_model: str,
+    previous_index: str,
+    previous_model: str,
+    now: datetime,
+    embedding_dimension: int = 3,
+) -> None:
+    session.add(
+        ModelReleaseModel(
+            release_status="STABLE",
+            active_model_version=active_model,
+            active_index_name=active_index,
+            previous_model_version=previous_model,
+            previous_index_name=previous_index,
+            created_at=now,
+            updated_at=now,
+        )
+    )
+    session.add_all(
+        [
+            VectorIndexCatalogModel(
+                index_name=previous_index,
+                model_version=previous_model,
+                embedding_dimension=embedding_dimension,
+                created_at=now,
+            ),
+            VectorIndexCatalogModel(
+                index_name=active_index,
+                model_version=active_model,
+                embedding_dimension=embedding_dimension,
+                created_at=now,
+            ),
+        ]
+    )
+    await session.flush()
+
+
+def _coordinator(
+    session: AsyncSession,
+    *,
+    embedding_client: object,
+) -> LegacyReindexCoordinator:
+    return LegacyReindexCoordinator(
+        legacy_store=LegacyReindexStore(session),
+        catalog_store=VectorIndexCatalogStore(session),
+        embedding_client=embedding_client,
+        batch_size=8,
+        per_run_video_limit=100,
+        throttle_sleep_ms=0,
+        release_store=ModelReleaseStore(session),
+    )

--- a/services/feedback-loop-pipeline/tests/integration/test_rollback_flow.py
+++ b/services/feedback-loop-pipeline/tests/integration/test_rollback_flow.py
@@ -1,6 +1,6 @@
 from collections.abc import AsyncIterator
 from datetime import UTC, datetime
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -46,6 +46,24 @@ class _RecordingRestore:
         # Async to satisfy the snapshot restore port contract.
         self.calls.append(index_name)
         return True
+
+
+class _RecordingCommitter:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+
+    async def commit(self) -> None:
+        self._events.append("commit")
+
+
+class _RecordingServingTargetReloader:
+    def __init__(self, events: list[str]) -> None:
+        self._events = events
+        self.trace_ids: list[UUID] = []
+
+    async def reload(self, *, trace_id: UUID) -> None:
+        self._events.append("reload")
+        self.trace_ids.append(trace_id)
 
 
 @pytest.fixture
@@ -139,6 +157,53 @@ async def test_rollback_request_excludes_affected_projects_and_restores_snapshot
     assert release.candidate_model_version is None
     assert release.candidate_index_name is None
     assert release.candidate_ready_at is None
+
+
+async def test_rollback_commits_before_reloading_search_targets(
+    session: AsyncSession,
+) -> None:
+    switched_at = datetime(2026, 5, 11, 11, 0, tzinfo=UTC)
+    trace_id = uuid4()
+    events: list[str] = []
+    session.add(
+        ModelReleaseModel(
+            release_status="STABLE",
+            active_model_version="model-v2",
+            active_index_name="active-index-v2",
+            previous_model_version="model-v1",
+            previous_index_name="active-index-v1",
+            rollback_snapshot_active_model_version="model-v1",
+            rollback_snapshot_active_index_name="active-index-v1",
+            rollback_snapshot_captured_at=switched_at,
+            switched_at=switched_at,
+        )
+    )
+    await session.flush()
+
+    reloader = _RecordingServingTargetReloader(events)
+    result = await RollbackTransitionManager(
+        release_store=ModelReleaseStore(session),
+        project_store=ProjectRollbackStore(session),
+        target_readiness=AlwaysReadyRollbackTarget(),
+        index_restore=ImmediateIndexRestore(),
+        clock=_FixedClock(),
+        release_change_committer=_RecordingCommitter(events),
+        serving_target_reloader=reloader,
+    ).handle_request(
+        RollbackRequestMessage(
+            message_type="ROLLBACK_REQUEST",
+            payload_version="v1",
+            trace_id=trace_id,
+            attempt=1,
+            issued_at=switched_at,
+            expected_active_model_version="model-v2",
+            expected_switched_at=switched_at,
+        )
+    )
+
+    assert result.status == "restored"
+    assert events == ["commit", "reload"]
+    assert reloader.trace_ids == [trace_id]
 
 
 async def test_stale_rollback_request_leaves_release_and_projects_unchanged(

--- a/services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_lock.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_lock.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from src.infra.db.legacy_reindex_lock import PostgresAdvisoryLegacyReindexLock
+
+
+@dataclass(frozen=True)
+class _Dialect:
+    name: str
+
+
+@dataclass(frozen=True)
+class _Bind:
+    dialect: _Dialect
+
+
+class _Result:
+    def __init__(self, value: bool) -> None:
+        self._value = value
+
+    def scalar(self) -> bool:
+        return self._value
+
+
+class _Session:
+    def __init__(self, *, dialect_name: str, lock_value: bool = True) -> None:
+        self._bind = _Bind(dialect=_Dialect(name=dialect_name))
+        self._lock_value = lock_value
+        self.calls: list[tuple[str, dict[str, str]]] = []
+
+    def get_bind(self) -> _Bind:
+        return self._bind
+
+    async def execute(self, statement: object, params: dict[str, str]) -> _Result:
+        self.calls.append((str(statement), params))
+        return _Result(self._lock_value)
+
+
+async def test_postgres_lock_uses_advisory_lock_and_unlock() -> None:
+    session = _Session(dialect_name="postgresql", lock_value=True)
+    lock = PostgresAdvisoryLegacyReindexLock(session, lock_name="legacy-reindex-test")
+
+    acquired = await lock.try_acquire()
+    await lock.release()
+
+    assert acquired is True
+    assert "pg_try_advisory_lock" in session.calls[0][0]
+    assert "pg_advisory_unlock" in session.calls[1][0]
+    assert session.calls[0][1] == {"lock_name": "legacy-reindex-test"}
+
+
+async def test_non_postgres_lock_is_local_noop() -> None:
+    session = _Session(dialect_name="sqlite")
+    lock = PostgresAdvisoryLegacyReindexLock(session)
+
+    acquired = await lock.try_acquire()
+    await lock.release()
+
+    assert acquired is True
+    assert session.calls == []

--- a/services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_lock.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_lock.py
@@ -45,9 +45,12 @@ async def test_postgres_lock_uses_advisory_lock_and_unlock() -> None:
     await lock.release()
 
     assert acquired is True
-    assert "pg_try_advisory_lock" in session.calls[0][0]
-    assert "pg_advisory_unlock" in session.calls[1][0]
-    assert session.calls[0][1] == {"lock_name": "legacy-reindex-test"}
+    assert len(session.calls) == 2
+    (lock_statement, lock_params), (unlock_statement, unlock_params) = session.calls
+    assert "pg_try_advisory_lock" in lock_statement
+    assert "pg_advisory_unlock" in unlock_statement
+    assert lock_params == {"lock_name": "legacy-reindex-test"}
+    assert unlock_params == {"lock_name": "legacy-reindex-test"}
 
 
 async def test_non_postgres_lock_is_local_noop() -> None:

--- a/services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_scheduler.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_scheduler.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from uuid import UUID, uuid4
+
+from src.release.legacy_reindex import LegacyReindexScheduler
+
+
+@dataclass(frozen=True)
+class _RunResult:
+    status: str
+
+
+class _BusyLock:
+    async def try_acquire(self) -> bool:
+        return False
+
+    async def release(self) -> None:
+        raise AssertionError("busy lock must not be released")
+
+
+class _AvailableLock:
+    def __init__(self) -> None:
+        self.released = False
+
+    async def try_acquire(self) -> bool:
+        return True
+
+    async def release(self) -> None:
+        self.released = True
+
+
+class _Coordinator:
+    def __init__(self) -> None:
+        self.trace_ids: list[UUID] = []
+
+    async def run_once(self, *, trace_id: UUID) -> _RunResult:
+        self.trace_ids.append(trace_id)
+        return _RunResult(status="processed")
+
+
+class _StoppingCoordinator:
+    def __init__(self, stop_event: asyncio.Event) -> None:
+        self._stop_event = stop_event
+        self.trace_ids: list[UUID] = []
+
+    async def run_once(self, *, trace_id: UUID) -> _RunResult:
+        self.trace_ids.append(trace_id)
+        self._stop_event.set()
+        return _RunResult(status="processed")
+
+
+async def test_scheduler_skips_when_global_lock_is_busy() -> None:
+    coordinator = _Coordinator()
+
+    result = await LegacyReindexScheduler(
+        coordinator=coordinator,
+        lock=_BusyLock(),
+    ).run_once(trace_id=uuid4())
+
+    assert result.status == "lock_busy"
+    assert coordinator.trace_ids == []
+
+
+async def test_scheduler_runs_and_releases_global_lock() -> None:
+    coordinator = _Coordinator()
+    lock = _AvailableLock()
+    trace_id = uuid4()
+
+    result = await LegacyReindexScheduler(
+        coordinator=coordinator,
+        lock=lock,
+    ).run_once(trace_id=trace_id)
+
+    assert result.status == "processed"
+    assert coordinator.trace_ids == [trace_id]
+    assert lock.released is True
+
+
+async def test_scheduler_loop_runs_until_stop_event_is_set() -> None:
+    stop_event = asyncio.Event()
+    coordinator = _StoppingCoordinator(stop_event)
+    trace_id = uuid4()
+
+    await LegacyReindexScheduler(
+        coordinator=coordinator,
+        lock=_AvailableLock(),
+        scan_interval_sec=60,
+    ).run_until_stopped(
+        stop_event=stop_event,
+        trace_id_factory=lambda: trace_id,
+    )
+
+    assert coordinator.trace_ids == [trace_id]

--- a/services/feedback-loop-pipeline/tests/unit/test_settings.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_settings.py
@@ -39,6 +39,10 @@ def test_settings_load_required_feedback_loop_configuration(monkeypatch: pytest.
     assert settings.rollback_restore_timeout_sec == 300
     assert settings.stuck_run_timeout_sec == 3600
     assert settings.reconciliation_interval_sec == 60
+    assert settings.legacy_reindex_scan_interval_sec == 60
+    assert settings.legacy_reindex_batch_size == 8
+    assert settings.legacy_reindex_per_run_video_limit == 100
+    assert settings.legacy_reindex_throttle_sleep_ms == 0
     assert settings.max_retries == 3
     assert settings.retry_backoff_sec == pytest.approx(1.0)
 
@@ -62,3 +66,19 @@ def test_settings_load_dataset_eligibility_threshold_overrides(monkeypatch: pyte
 
     assert settings.min_training_group_count == 15
     assert settings.min_negative_count == 30
+
+
+def test_settings_load_legacy_reindex_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key, value in _required_env().items():
+        monkeypatch.setenv(key, value)
+    monkeypatch.setenv("LEGACY_REINDEX_SCAN_INTERVAL_SEC", "30")
+    monkeypatch.setenv("LEGACY_REINDEX_BATCH_SIZE", "4")
+    monkeypatch.setenv("LEGACY_REINDEX_PER_RUN_VIDEO_LIMIT", "12")
+    monkeypatch.setenv("LEGACY_REINDEX_THROTTLE_SLEEP_MS", "0")
+
+    settings = Settings()
+
+    assert settings.legacy_reindex_scan_interval_sec == 30
+    assert settings.legacy_reindex_batch_size == 4
+    assert settings.legacy_reindex_per_run_video_limit == 12
+    assert settings.legacy_reindex_throttle_sleep_ms == 0

--- a/services/feedback-loop-pipeline/tests/unit/test_settings.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_settings.py
@@ -37,6 +37,7 @@ def test_settings_load_required_feedback_loop_configuration(monkeypatch: pytest.
     assert settings.training_timeout_sec == 900
     assert settings.evaluation_timeout_sec == 300
     assert settings.rollback_restore_timeout_sec == 300
+    assert settings.search_service_url == ""
     assert settings.stuck_run_timeout_sec == 3600
     assert settings.reconciliation_interval_sec == 60
     assert settings.legacy_reindex_scan_interval_sec == 60

--- a/services/managed-embedding-endpoint/poetry.lock
+++ b/services/managed-embedding-endpoint/poetry.lock
@@ -247,6 +247,76 @@ typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 trio = ["trio (>=0.32.0)"]
 
 [[package]]
+name = "asyncpg"
+version = "0.31.0"
+description = "An asyncio PostgreSQL driver"
+optional = false
+python-versions = ">=3.9.0"
+groups = ["main"]
+files = [
+    {file = "asyncpg-0.31.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:831712dd3cf117eec68575a9b50da711893fd63ebe277fc155ecae1c6c9f0f61"},
+    {file = "asyncpg-0.31.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:0b17c89312c2f4ccea222a3a6571f7df65d4ba2c0e803339bfc7bed46a96d3be"},
+    {file = "asyncpg-0.31.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3faa62f997db0c9add34504a68ac2c342cfee4d57a0c3062fcf0d86c7f9cb1e8"},
+    {file = "asyncpg-0.31.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8ea599d45c361dfbf398cb67da7fd052affa556a401482d3ff1ee99bd68808a1"},
+    {file = "asyncpg-0.31.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:795416369c3d284e1837461909f58418ad22b305f955e625a4b3a2521d80a5f3"},
+    {file = "asyncpg-0.31.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:a8d758dac9d2e723e173d286ef5e574f0b350ec00e9186fce84d0fc5f6a8e6b8"},
+    {file = "asyncpg-0.31.0-cp310-cp310-win32.whl", hash = "sha256:2d076d42eb583601179efa246c5d7ae44614b4144bc1c7a683ad1222814ed095"},
+    {file = "asyncpg-0.31.0-cp310-cp310-win_amd64.whl", hash = "sha256:9ea33213ac044171f4cac23740bed9a3805abae10e7025314cfbd725ec670540"},
+    {file = "asyncpg-0.31.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eee690960e8ab85063ba93af2ce128c0f52fd655fdff9fdb1a28df01329f031d"},
+    {file = "asyncpg-0.31.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2657204552b75f8288de08ca60faf4a99a65deef3a71d1467454123205a88fab"},
+    {file = "asyncpg-0.31.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a429e842a3a4b4ea240ea52d7fe3f82d5149853249306f7ff166cb9948faa46c"},
+    {file = "asyncpg-0.31.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c0807be46c32c963ae40d329b3a686356e417f674c976c07fa49f1b30303f109"},
+    {file = "asyncpg-0.31.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e5d5098f63beeae93512ee513d4c0c53dc12e9aa2b7a1af5a81cddf93fe4e4da"},
+    {file = "asyncpg-0.31.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37fc6c00a814e18eef51833545d1891cac9aa69140598bb076b4cd29b3e010b9"},
+    {file = "asyncpg-0.31.0-cp311-cp311-win32.whl", hash = "sha256:5a4af56edf82a701aece93190cc4e094d2df7d33f6e915c222fb09efbb5afc24"},
+    {file = "asyncpg-0.31.0-cp311-cp311-win_amd64.whl", hash = "sha256:480c4befbdf079c14c9ca43c8c5e1fe8b6296c96f1f927158d4f1e750aacc047"},
+    {file = "asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad"},
+    {file = "asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d"},
+    {file = "asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a"},
+    {file = "asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671"},
+    {file = "asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec"},
+    {file = "asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20"},
+    {file = "asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8"},
+    {file = "asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186"},
+    {file = "asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b"},
+    {file = "asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e"},
+    {file = "asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403"},
+    {file = "asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4"},
+    {file = "asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2"},
+    {file = "asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602"},
+    {file = "asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696"},
+    {file = "asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab"},
+    {file = "asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44"},
+    {file = "asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5"},
+    {file = "asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2"},
+    {file = "asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2"},
+    {file = "asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218"},
+    {file = "asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d"},
+    {file = "asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b"},
+    {file = "asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d"},
+    {file = "asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3"},
+    {file = "asyncpg-0.31.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ebb3cde58321a1f89ce41812be3f2a98dddedc1e76d0838aba1d724f1e4e1a95"},
+    {file = "asyncpg-0.31.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e6974f36eb9a224d8fb428bcf66bd411aa12cf57c2967463178149e73d4de366"},
+    {file = "asyncpg-0.31.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc2b685f400ceae428f79f78b58110470d7b4466929a7f78d455964b17ad1008"},
+    {file = "asyncpg-0.31.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bb223567dea5f47c45d347f2bde5486be8d9f40339f27217adb3fb1c3be51298"},
+    {file = "asyncpg-0.31.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:22be6e02381bab3101cd502d9297ac71e2f966c86e20e78caead9934c98a8af6"},
+    {file = "asyncpg-0.31.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:37a58919cfef2448a920df00d1b2f821762d17194d0dbf355d6dde8d952c04f9"},
+    {file = "asyncpg-0.31.0-cp39-cp39-win32.whl", hash = "sha256:c1a9c5b71d2371a2290bc93336cd05ba4ec781683cab292adbddc084f89443c6"},
+    {file = "asyncpg-0.31.0-cp39-cp39-win_amd64.whl", hash = "sha256:c1e1ab5bc65373d92dd749d7308c5b26fb2dc0fbe5d3bf68a32b676aa3bcd24a"},
+    {file = "asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735"},
+]
+
+[package.extras]
+gssauth = ["gssapi ; platform_system != \"Windows\"", "sspilib ; platform_system == \"Windows\""]
+
+[[package]]
 name = "attrs"
 version = "26.1.0"
 description = "Classes Without Boilerplate"
@@ -4247,4 +4317,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "6d4cebd0a2760576e29936a4fa55806fc5e3e0d93bb63b0a031a4797b8743ca5"
+content-hash = "6277e74436b6d6405dc066f3a9c8fb7862d296486e631f79cebabc0fad661124"

--- a/services/managed-embedding-endpoint/pyproject.toml
+++ b/services/managed-embedding-endpoint/pyproject.toml
@@ -11,6 +11,7 @@ uvicorn = { version = ">=0.29,<1.0", extras = ["standard"] }
 pydantic-settings = ">=2.3,<3.0"
 httpx = ">=0.27,<1.0"
 loguru = ">=0.7,<1.0"
+asyncpg = ">=0.29,<1.0"
 FlagEmbedding = "*"
 transformers = ">=4.44.2,<5.0.0"
 torch = { version = "==2.7.1", source = "pytorch-cpu" }

--- a/services/managed-embedding-endpoint/src/api/v1/router.py
+++ b/services/managed-embedding-endpoint/src/api/v1/router.py
@@ -1,7 +1,8 @@
 from fastapi import APIRouter
 
 from src.api.v1.routers.embed import router as embed_router
+from src.api.v1.routers.internal import router as internal_router
 
 router = APIRouter()
 router.include_router(embed_router)
-
+router.include_router(internal_router)

--- a/services/managed-embedding-endpoint/src/api/v1/routers/embed.py
+++ b/services/managed-embedding-endpoint/src/api/v1/routers/embed.py
@@ -29,6 +29,7 @@ async def embed(request: Request, body: EmbedRequest) -> EmbedResponse:
             inference_service.embed,
             body.texts,
             payload_size,
+            body.model_version,
             trace_id,
         )
     finally:
@@ -41,4 +42,7 @@ async def health(request: Request) -> HealthResponse:
     model_state: ModelState = request.app.state.model_state
     if not model_state.ready:
         raise ServiceUnavailableError("Model is not ready.")
-    return HealthResponse(status="ok", model_version=model_state.model_version)
+    return HealthResponse(
+        status="ok",
+        ready_model_versions=model_state.ready_model_versions,
+    )

--- a/services/managed-embedding-endpoint/src/api/v1/routers/internal.py
+++ b/services/managed-embedding-endpoint/src/api/v1/routers/internal.py
@@ -1,0 +1,31 @@
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from src.middlewares.error_handler import ServiceUnavailableError
+from src.services.model_reloader import ModelRuntimeReloader
+
+router = APIRouter(prefix="/internal")
+
+
+class ReloadModelsRequest(BaseModel):
+    trace_id: str | None = None
+
+
+class ReloadModelsResponse(BaseModel):
+    ready_model_versions: list[str]
+
+
+@router.post("/reload-models")
+async def reload_models(
+    request: Request,
+    body: ReloadModelsRequest,
+) -> ReloadModelsResponse:
+    reloader: ModelRuntimeReloader | None = getattr(
+        request.app.state,
+        "model_reloader",
+        None,
+    )
+    if reloader is None:
+        raise ServiceUnavailableError("Model reloader is not configured.")
+    result = await reloader.reload(trace_id=body.trace_id or request.state.trace_id)
+    return ReloadModelsResponse(ready_model_versions=result.ready_model_versions)

--- a/services/managed-embedding-endpoint/src/core/artifact_resolver.py
+++ b/services/managed-embedding-endpoint/src/core/artifact_resolver.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from src.core.settings import Settings
+
+
+class ModelArtifactResolver:
+    """Resolve model versions to loadable artifact refs."""
+
+    def __init__(self, settings: Settings) -> None:
+        self._settings = settings
+
+    def resolve(self, model_version: str) -> str:
+        if self._settings.model_artifact_root:
+            return str(Path(self._settings.model_artifact_root) / model_version)
+
+        artifact_path = self._settings.model_artifact_path
+        if Path(artifact_path).name == model_version:
+            return artifact_path
+
+        return model_version

--- a/services/managed-embedding-endpoint/src/core/bootstrap.py
+++ b/services/managed-embedding-endpoint/src/core/bootstrap.py
@@ -1,34 +1,55 @@
 from src.core.model_state import ModelState
+from src.core.runtime_registry import RuntimeRegistry
 from src.core.settings import Settings
 from src.infra.loader_factory import build_model_loader
 from src.infra.model_loader import ModelLoader
+from src.infra.release_repository import (
+    AsyncpgModelReleaseRepository,
+    ModelReleaseRepository,
+    NullModelReleaseRepository,
+)
 from src.infra.runtime import EmbeddingRuntime
 from src.observability.logging import error, info
 from src.services.inference_service import InferenceService
+from src.services.model_reloader import ModelRuntimeReloader
 
 
-def bootstrap(settings: Settings) -> tuple[ModelState, InferenceService | None]:
+def bootstrap(
+    settings: Settings,
+) -> tuple[ModelState, InferenceService | None, ModelRuntimeReloader]:
     """Wire production dependencies at startup.
 
     Returns (model_state, inference_service_or_none).
     On model-load failure the process stays alive; /health and /embed will return 503.
     """
     model_state = ModelState()
+    runtime_registry = RuntimeRegistry()
     loader = build_model_loader(settings, model_state)
 
     runtime = _try_load_model(loader, settings.model_artifact_path)
+    if runtime is not None and model_state.model_version:
+        runtime_registry.replace({model_state.model_version: runtime})
 
-    if runtime is None:
-        return model_state, None
-
-    info(
-        "model.load.success",
-        model_version=model_state.model_version,
-        result="success",
+    reloader = ModelRuntimeReloader(
+        settings=settings,
+        model_state=model_state,
+        runtime_registry=runtime_registry,
+        release_repository=_build_release_repository(settings),
+        loader_factory=lambda state: build_model_loader(settings, state),
     )
 
-    inference_service = InferenceService(settings, model_state, runtime)
-    return model_state, inference_service
+    if runtime is not None:
+        info(
+            "model.load.success",
+            model_version=model_state.model_version,
+            result="success",
+        )
+
+    inference_service = InferenceService(
+        settings=settings,
+        runtime_registry=runtime_registry,
+    )
+    return model_state, inference_service, reloader
 
 
 def _try_load_model(loader: ModelLoader, artifact_path: str) -> EmbeddingRuntime | None:
@@ -43,3 +64,9 @@ def _try_load_model(loader: ModelLoader, artifact_path: str) -> EmbeddingRuntime
             result="failure",
         )
         return None
+
+
+def _build_release_repository(settings: Settings) -> ModelReleaseRepository:
+    if not settings.database_url:
+        return NullModelReleaseRepository()
+    return AsyncpgModelReleaseRepository(settings.database_url)

--- a/services/managed-embedding-endpoint/src/core/model_release_seed.py
+++ b/services/managed-embedding-endpoint/src/core/model_release_seed.py
@@ -1,0 +1,93 @@
+import argparse
+import asyncio
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class SeedModelRelease:
+    active_model_version: str
+    active_index_name: str
+
+
+def derive_seed_model_release(
+    *,
+    model_artifact_path: str,
+    active_index_name: str | None = None,
+) -> SeedModelRelease:
+    model_version = Path(model_artifact_path).name
+    return SeedModelRelease(
+        active_model_version=model_version,
+        active_index_name=active_index_name or f"vector-{model_version}",
+    )
+
+
+async def seed_model_release(
+    *,
+    database_url: str,
+    model_artifact_path: str,
+    active_index_name: str | None = None,
+) -> bool:
+    import asyncpg
+
+    seed = derive_seed_model_release(
+        model_artifact_path=model_artifact_path,
+        active_index_name=active_index_name,
+    )
+    conn = await asyncpg.connect(_normalize_database_url(database_url))
+    try:
+        status = await conn.execute(
+            """
+            INSERT INTO model_release (
+                singleton_key,
+                active_model_version,
+                active_index_name
+            )
+            VALUES (1, $1, $2)
+            ON CONFLICT (singleton_key) DO NOTHING
+            """,
+            seed.active_model_version,
+            seed.active_index_name,
+        )
+    finally:
+        await conn.close()
+    return status == "INSERT 0 1"
+
+
+def _normalize_database_url(database_url: str) -> str:
+    return database_url.replace("postgresql+asyncpg://", "postgresql://", 1)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Seed the singleton ModelRelease row from MODEL_ARTIFACT_PATH.",
+    )
+    parser.add_argument("--database-url", default=os.getenv("DATABASE_URL", ""))
+    parser.add_argument(
+        "--model-artifact-path",
+        default=os.getenv("MODEL_ARTIFACT_PATH", ""),
+    )
+    parser.add_argument(
+        "--active-index-name",
+        default=os.getenv("ACTIVE_INDEX_NAME"),
+    )
+    return parser.parse_args()
+
+
+async def _run() -> None:
+    args = _parse_args()
+    if not args.database_url:
+        raise SystemExit("DATABASE_URL is required")
+    if not args.model_artifact_path:
+        raise SystemExit("MODEL_ARTIFACT_PATH is required")
+    inserted = await seed_model_release(
+        database_url=args.database_url,
+        model_artifact_path=args.model_artifact_path,
+        active_index_name=args.active_index_name,
+    )
+    print("inserted" if inserted else "already_exists")
+
+
+if __name__ == "__main__":
+    asyncio.run(_run())

--- a/services/managed-embedding-endpoint/src/core/model_state.py
+++ b/services/managed-embedding-endpoint/src/core/model_state.py
@@ -2,29 +2,53 @@ import threading
 
 
 class ModelState:
-    """Thread-safe container for model readiness and version tracking."""
+    """여러 thread에서 안전하게 ready model version 목록을 관리한다."""
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._ready = False
-        self._model_version: str = ""
+        self._ready_model_versions: list[str] = []
 
     @property
     def ready(self) -> bool:
         with self._lock:
-            return self._ready
+            return bool(self._ready_model_versions)
 
     @property
     def model_version(self) -> str:
         with self._lock:
-            return self._model_version
+            return self._ready_model_versions[0] if self._ready_model_versions else ""
+
+    @property
+    def ready_model_versions(self) -> list[str]:
+        with self._lock:
+            return list(self._ready_model_versions)
 
     def mark_ready(self, model_version: str) -> None:
         with self._lock:
-            self._ready = True
-            self._model_version = model_version
+            if model_version not in self._ready_model_versions:
+                self._ready_model_versions.append(model_version)
 
-    def mark_not_ready(self) -> None:
+    def clear_ready_version(self, model_version: str | None = None) -> None:
         with self._lock:
-            self._ready = False
-            self._model_version = ""
+            if model_version is None:
+                self._ready_model_versions = []
+                return
+            self._ready_model_versions = [
+                version
+                for version in self._ready_model_versions
+                if version != model_version
+            ]
+
+    def is_ready(self, model_version: str) -> bool:
+        with self._lock:
+            return model_version in self._ready_model_versions
+
+    def replace_ready_versions(self, model_versions: list[str]) -> None:
+        with self._lock:
+            seen: set[str] = set()
+            self._ready_model_versions = []
+            for version in model_versions:
+                if version in seen:
+                    continue
+                self._ready_model_versions.append(version)
+                seen.add(version)

--- a/services/managed-embedding-endpoint/src/core/runtime_registry.py
+++ b/services/managed-embedding-endpoint/src/core/runtime_registry.py
@@ -1,0 +1,32 @@
+import threading
+from collections.abc import Mapping
+
+from src.infra.runtime import EmbeddingRuntime
+
+
+class RuntimeRegistry:
+    """Thread-safe runtime map with atomic whole-registry replacement."""
+
+    def __init__(
+        self,
+        runtimes: Mapping[str, EmbeddingRuntime] | None = None,
+    ) -> None:
+        self._lock = threading.Lock()
+        self._runtimes = dict(runtimes or {})
+
+    def get(self, model_version: str) -> EmbeddingRuntime | None:
+        with self._lock:
+            return self._runtimes.get(model_version)
+
+    def snapshot(self) -> dict[str, EmbeddingRuntime]:
+        with self._lock:
+            return dict(self._runtimes)
+
+    def replace(
+        self,
+        runtimes: Mapping[str, EmbeddingRuntime],
+    ) -> dict[str, EmbeddingRuntime]:
+        with self._lock:
+            previous = self._runtimes
+            self._runtimes = dict(runtimes)
+            return previous

--- a/services/managed-embedding-endpoint/src/core/settings.py
+++ b/services/managed-embedding-endpoint/src/core/settings.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from pathlib import Path
 
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -20,15 +21,23 @@ class Settings(BaseSettings):
 
     # Model (required)
     model_artifact_path: str = Field(alias="MODEL_ARTIFACT_PATH", min_length=1)
+    model_artifact_root: str = Field(default="", alias="MODEL_ARTIFACT_ROOT")
 
     # Model cache (optional)
     model_cache_dir: str = Field(default="", alias="MODEL_CACHE_DIR")
+
+    # ModelRelease read model (optional for local single-model bootstrap)
+    database_url: str = Field(default="", alias="DATABASE_URL")
 
     # Guardrails
     max_texts_per_request: int = Field(default=32, alias="MAX_TEXTS_PER_REQUEST", ge=1)
     max_text_length_chars: int = Field(default=4096, alias="MAX_TEXT_LENGTH_CHARS", ge=1)
     max_payload_bytes: int = Field(default=262144, alias="MAX_PAYLOAD_BYTES", ge=1)
     max_concurrency: int = Field(default=1, alias="MAX_CONCURRENCY", ge=1)
+
+    @property
+    def bootstrap_model_version(self) -> str:
+        return Path(self.model_artifact_path).name
 
 
 @lru_cache

--- a/services/managed-embedding-endpoint/src/infra/model_loader.py
+++ b/services/managed-embedding-endpoint/src/infra/model_loader.py
@@ -21,7 +21,4 @@ class ModelLoader(ABC):
         ...
 
     def _resolve_version(self, artifact_path: str) -> str:
-        path = Path(artifact_path)
-        if path.exists():
-            return str(path.resolve())
-        return artifact_path
+        return Path(artifact_path).name

--- a/services/managed-embedding-endpoint/src/infra/release_repository.py
+++ b/services/managed-embedding-endpoint/src/infra/release_repository.py
@@ -1,0 +1,55 @@
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class ModelReleaseSnapshot:
+    active_model_version: str
+    previous_model_version: str | None = None
+    candidate_model_version: str | None = None
+
+
+class ModelReleaseRepository(Protocol):
+    async def get_current(self) -> ModelReleaseSnapshot | None:
+        """Return current ModelRelease serving model versions."""
+        ...
+
+
+class NullModelReleaseRepository:
+    async def get_current(self) -> ModelReleaseSnapshot | None:
+        return None
+
+
+# ModelRelease SOT를 endpoint runtime reload에 연결하는 읽기 전용 repository
+class AsyncpgModelReleaseRepository:
+    def __init__(self, database_url: str) -> None:
+        self._database_url = database_url
+
+    async def get_current(self) -> ModelReleaseSnapshot | None:
+        import asyncpg
+
+        conn = await asyncpg.connect(_normalize_database_url(self._database_url))
+        try:
+            row = await conn.fetchrow(
+                """
+                SELECT active_model_version,
+                       previous_model_version,
+                       candidate_model_version
+                FROM model_release
+                WHERE singleton_key = 1
+                """
+            )
+        finally:
+            await conn.close()
+
+        if row is None:
+            return None
+        return ModelReleaseSnapshot(
+            active_model_version=row["active_model_version"],
+            previous_model_version=row["previous_model_version"],
+            candidate_model_version=row["candidate_model_version"],
+        )
+
+
+def _normalize_database_url(database_url: str) -> str:
+    return database_url.replace("postgresql+asyncpg://", "postgresql://", 1)

--- a/services/managed-embedding-endpoint/src/main.py
+++ b/services/managed-embedding-endpoint/src/main.py
@@ -1,3 +1,6 @@
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from src.api.v1.router import router as api_v1_router
@@ -7,13 +10,16 @@ from src.core.model_state import ModelState
 from src.core.settings import Settings, get_settings
 from src.middlewares.error_handler import register_exception_handlers
 from src.middlewares.trace import TraceIdMiddleware
+from src.observability.logging import error
 from src.services.inference_service import InferenceService
+from src.services.model_reloader import ModelRuntimeReloader
 
 
 def create_app(
     settings: Settings | None = None,
     model_state: ModelState | None = None,
     inference_service: InferenceService | None = None,
+    model_reloader: ModelRuntimeReloader | None = None,
 ) -> FastAPI:
     """Create the FastAPI application.
 
@@ -22,7 +28,7 @@ def create_app(
     """
     app_settings = settings or get_settings()
 
-    app = FastAPI(title=app_settings.app_name)
+    app = FastAPI(title=app_settings.app_name, lifespan=lifespan)
     app.state.settings = app_settings
     app.state.admission_controller = AdmissionController(app_settings.max_concurrency)
 
@@ -31,15 +37,37 @@ def create_app(
         app.state.model_state = model_state
         if inference_service is not None:
             app.state.inference_service = inference_service
+        if model_reloader is not None:
+            app.state.model_reloader = model_reloader
     else:
         # Production path: bootstrap real dependencies.
-        boot_model_state, boot_service = bootstrap(app_settings)
+        boot_model_state, boot_service, boot_reloader = bootstrap(app_settings)
         app.state.model_state = boot_model_state
-        if boot_service is not None:
-            app.state.inference_service = boot_service
+        app.state.model_reloader = boot_reloader
+        app.state.inference_service = boot_service
 
     app.add_middleware(TraceIdMiddleware)
     register_exception_handlers(app)
     app.include_router(api_v1_router)
 
     return app
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+    await reload_models_on_startup(app)
+    yield
+
+
+async def reload_models_on_startup(app: FastAPI) -> None:
+    reloader: ModelRuntimeReloader | None = getattr(
+        app.state,
+        "model_reloader",
+        None,
+    )
+    if reloader is None:
+        return
+    try:
+        await reloader.reload(trace_id="startup")
+    except Exception as exc:
+        error("model.startup_reload_failed", error=str(exc), trace_id="startup")

--- a/services/managed-embedding-endpoint/src/schemas/embed_dto.py
+++ b/services/managed-embedding-endpoint/src/schemas/embed_dto.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel, Field
 
 class EmbedRequest(BaseModel):
     texts: list[Annotated[str, Field(min_length=1)]] = Field(min_length=1)
+    model_version: str = Field(min_length=1)
 
 
 class EmbedResponse(BaseModel):
@@ -13,7 +14,7 @@ class EmbedResponse(BaseModel):
 
 class HealthResponse(BaseModel):
     status: str
-    model_version: str
+    ready_model_versions: list[str]
 
 
 class ErrorResponse(BaseModel):

--- a/services/managed-embedding-endpoint/src/services/inference_service.py
+++ b/services/managed-embedding-endpoint/src/services/inference_service.py
@@ -1,6 +1,6 @@
 import time
 
-from src.core.model_state import ModelState
+from src.core.runtime_registry import RuntimeRegistry
 from src.core.settings import Settings
 from src.infra.runtime import EmbeddingRuntime
 from src.middlewares.error_handler import (
@@ -10,37 +10,35 @@ from src.middlewares.error_handler import (
 )
 from src.observability.logging import error, info
 
-
+# Embedding 요청을 지정된 model runtime으로 라우팅하고 입력/응답을 검증한다.
 class InferenceService:
-    """Orchestrates guardrail checks, admission control, and embedding inference."""
 
     def __init__(
         self,
         settings: Settings,
-        model_state: ModelState,
-        runtime: EmbeddingRuntime,
+        runtime_registry: RuntimeRegistry,
     ) -> None:
         self._settings = settings
-        self._model_state = model_state
-        self._runtime = runtime
+        self._runtime_registry = runtime_registry
 
     def embed(
         self,
         texts: list[str],
         payload_size: int,
+        model_version: str,
         trace_id: str | None = None,
     ) -> list[list[float]]:
         self._check_guardrails(texts, payload_size)
-        self._check_readiness()
+        runtime = self._runtime_for(model_version)
         start = time.monotonic()
-        result = self._call_runtime(texts, trace_id)
+        result = self._call_runtime(runtime, texts, trace_id)
         elapsed_ms = (time.monotonic() - start) * 1000
         info(
             "embed.success",
             text_count=len(texts),
             payload_size=payload_size,
             duration_ms=round(elapsed_ms, 1),
-            model_version=self._model_state.model_version,
+            model_version=model_version,
             trace_id=trace_id,
         )
         return result
@@ -65,17 +63,22 @@ class InferenceService:
                 f"Payload size {payload_size} bytes exceeds maximum {max_bytes}."
             )
 
-    def _check_readiness(self) -> None:
-        if not self._model_state.ready:
-            raise ServiceUnavailableError("Model is not ready.")
+    def _runtime_for(self, model_version: str) -> EmbeddingRuntime:
+        runtime = self._runtime_registry.get(model_version)
+        if runtime is None:
+            raise ServiceUnavailableError(
+                f"Model version is not ready: {model_version}."
+            )
+        return runtime
 
     def _call_runtime(
         self,
+        runtime: EmbeddingRuntime,
         texts: list[str],
         trace_id: str | None,
     ) -> list[list[float]]:
         try:
-            embeddings = self._runtime.encode(texts)
+            embeddings = runtime.encode(texts)
         except Exception as exc:
             error("runtime.encode failed", error=str(exc), trace_id=trace_id)
             raise ServiceUnavailableError("Embedding runtime error.") from exc

--- a/services/managed-embedding-endpoint/src/services/model_reloader.py
+++ b/services/managed-embedding-endpoint/src/services/model_reloader.py
@@ -1,0 +1,180 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from src.core.artifact_resolver import ModelArtifactResolver
+from src.core.model_state import ModelState
+from src.core.runtime_registry import RuntimeRegistry
+from src.core.settings import Settings
+from src.infra.model_loader import ModelLoader
+from src.infra.release_repository import ModelReleaseRepository, ModelReleaseSnapshot
+from src.infra.runtime import EmbeddingRuntime
+from src.middlewares.error_handler import ServiceUnavailableError
+from src.observability.logging import error, info, warning
+
+
+@dataclass(frozen=True, slots=True)
+class ReloadResult:
+    ready_model_versions: list[str]
+
+
+@dataclass(frozen=True, slots=True)
+class _ReloadTarget:
+    role: str
+    model_version: str
+
+
+class ModelRuntimeReloader:
+    """ModelRelease 서빙 상태에 맞춰 model runtime 목록을 다시 로드한다."""
+
+    def __init__(
+        self,
+        *,
+        settings: Settings,
+        model_state: ModelState,
+        runtime_registry: RuntimeRegistry,
+        release_repository: ModelReleaseRepository,
+        loader_factory: Callable[[ModelState], ModelLoader],
+    ) -> None:
+        self._settings = settings
+        self._model_state = model_state
+        self._runtime_registry = runtime_registry
+        self._release_repository = release_repository
+        self._loader_factory = loader_factory
+        self._artifact_resolver = ModelArtifactResolver(settings)
+    '''
+    1. model_release 읽음
+    2. active/previous/candidate target 목록 만듦
+    3. 현재 runtime 목록 가져옴
+    4. target별로 기존 runtime 재사용 또는 새로 load
+    5. RuntimeRegistry를 새 runtime 목록으로 교체
+    6. ModelState ready_model_versions 갱신
+    7. 더 이상 안 쓰는 runtime close
+    8. ready_model_versions 반환
+    
+    '''
+    async def reload(self, trace_id: str | None = None) -> ReloadResult:
+        try:
+            release = await self._release_repository.get_current()
+        except Exception as exc:
+            error("model_release.read_failed", error=str(exc), trace_id=trace_id)
+            raise ServiceUnavailableError("ModelRelease read failed.") from exc
+
+        targets = self._targets_from_release(release)
+        current_runtimes = self._runtime_registry.snapshot()
+        new_runtimes: dict[str, EmbeddingRuntime] = {}
+        ready_versions: list[str] = []
+
+        for target in targets:
+            runtime = self._load_or_reuse_runtime(
+                target,
+                current_runtimes,
+                trace_id,
+            )
+            if runtime is None:
+                continue
+            if target.model_version in new_runtimes:
+                continue
+            new_runtimes[target.model_version] = runtime
+            ready_versions.append(target.model_version)
+
+        previous_runtimes = self._runtime_registry.replace(new_runtimes)
+        self._model_state.replace_ready_versions(ready_versions)
+        self._unload_stale_runtimes(previous_runtimes, new_runtimes, trace_id)
+
+        info(
+            "model.reload.success",
+            ready_model_versions=ready_versions,
+            trace_id=trace_id,
+        )
+        return ReloadResult(ready_model_versions=ready_versions)
+
+    def _targets_from_release(
+        self,
+        release: ModelReleaseSnapshot | None,
+    ) -> list[_ReloadTarget]:
+        if release is None:
+            return [
+                _ReloadTarget(
+                    role="active",
+                    model_version=self._settings.bootstrap_model_version,
+                )
+            ]
+
+        targets = [_ReloadTarget("active", release.active_model_version)]
+        if release.previous_model_version:
+            targets.append(_ReloadTarget("previous", release.previous_model_version))
+        if release.candidate_model_version:
+            targets.append(_ReloadTarget("candidate", release.candidate_model_version))
+        return targets
+
+    def _load_or_reuse_runtime(
+        self,
+        target: _ReloadTarget,
+        current_runtimes: dict[str, EmbeddingRuntime],
+        trace_id: str | None,
+    ) -> EmbeddingRuntime | None:
+        runtime = current_runtimes.get(target.model_version)
+        if runtime is not None:
+            return runtime
+
+        artifact_path = self._artifact_resolver.resolve(target.model_version)
+        temp_state = ModelState()
+        loader = self._loader_factory(temp_state)
+        try:
+            runtime = loader.load(artifact_path)
+        except Exception as exc:
+            if target.role == "active":
+                error(
+                    "model.reload.active_failed",
+                    model_version=target.model_version,
+                    artifact_path=artifact_path,
+                    error=str(exc),
+                    trace_id=trace_id,
+                )
+                raise ServiceUnavailableError("active model load failed") from exc
+            warning(
+                "model.reload.optional_failed",
+                role=target.role,
+                model_version=target.model_version,
+                artifact_path=artifact_path,
+                error=str(exc),
+                trace_id=trace_id,
+            )
+            return None
+
+        if not temp_state.is_ready(target.model_version):
+            if target.role == "active":
+                raise ServiceUnavailableError(
+                    f"Loaded model version mismatch: {target.model_version}."
+                )
+            warning(
+                "model.reload.optional_version_mismatch",
+                role=target.role,
+                model_version=target.model_version,
+                ready_model_versions=temp_state.ready_model_versions,
+                trace_id=trace_id,
+            )
+            return None
+        return runtime
+
+    @staticmethod
+    def _unload_stale_runtimes(
+        previous_runtimes: dict[str, EmbeddingRuntime],
+        new_runtimes: dict[str, EmbeddingRuntime],
+        trace_id: str | None,
+    ) -> None:
+        for model_version, runtime in previous_runtimes.items():
+            if model_version in new_runtimes:
+                continue
+            close = getattr(runtime, "close", None)
+            if not callable(close):
+                continue
+            try:
+                close()
+            except Exception as exc:
+                warning(
+                    "model.reload.unload_failed",
+                    model_version=model_version,
+                    error=str(exc),
+                    trace_id=trace_id,
+                )

--- a/services/managed-embedding-endpoint/tests/api/test_embed.py
+++ b/services/managed-embedding-endpoint/tests/api/test_embed.py
@@ -10,7 +10,10 @@ class TestEmbedSuccess:
     async def test_single_text_returns_one_embedding(
         self, ready_client: httpx.AsyncClient
     ):
-        response = await ready_client.post("/embed", json={"texts": ["hello"]})
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": ["hello"], "model_version": "test-model"},
+        )
 
         assert response.status_code == 200
         body = response.json()
@@ -21,7 +24,10 @@ class TestEmbedSuccess:
         self, ready_client: httpx.AsyncClient
     ):
         texts = ["one", "two", "three"]
-        response = await ready_client.post("/embed", json={"texts": texts})
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": texts, "model_version": "test-model"},
+        )
 
         assert response.status_code == 200
         body = response.json()
@@ -30,17 +36,63 @@ class TestEmbedSuccess:
     async def test_response_has_trace_id_header(
         self, ready_client: httpx.AsyncClient
     ):
-        response = await ready_client.post("/embed", json={"texts": ["hello"]})
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": ["hello"], "model_version": "test-model"},
+        )
 
         assert "x-trace-id" in response.headers
 
     async def test_response_does_not_contain_model_version(
         self, ready_client: httpx.AsyncClient
     ):
-        response = await ready_client.post("/embed", json={"texts": ["hello"]})
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": ["hello"], "model_version": "test-model"},
+        )
 
         body = response.json()
         assert "model_version" not in body
+
+    async def test_routes_to_requested_model_version(
+        self,
+        app_factory: Callable[..., object],
+        inference_service_factory: Callable[..., object],
+        ready_model_state_factory: Callable[[str], object],
+        settings_factory: Callable[..., object],
+    ):
+        settings = settings_factory()
+        model_state = ready_model_state_factory("fake-20260526T143000KST")
+        model_state.mark_ready("fake-20260526T144000KST")
+        service = inference_service_factory(
+            settings=settings,
+            model_state=model_state,
+            runtimes={
+                "fake-20260526T143000KST": StubRuntime(offset=0.0),
+                "fake-20260526T144000KST": StubRuntime(offset=10.0),
+            },
+        )
+        app = app_factory(
+            settings=settings,
+            model_state=model_state,
+            inference_service=service,
+        )
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="https://test",
+        ) as client:
+            response = await client.post(
+                "/embed",
+                json={
+                    "texts": ["abcd"],
+                    "model_version": "fake-20260526T144000KST",
+                },
+            )
+
+        assert response.status_code == 200
+        body = response.json()
+        assert body["embeddings"][0] == [14.0] * EMBEDDING_DIM
 
 
 class TestEmbedNotReady:
@@ -48,7 +100,18 @@ class TestEmbedNotReady:
         self, not_ready_client: httpx.AsyncClient
     ):
         response = await not_ready_client.post(
-            "/embed", json={"texts": ["hello"]}
+            "/embed",
+            json={"texts": ["hello"], "model_version": "test-model"},
+        )
+
+        assert response.status_code == 503
+
+    async def test_returns_503_for_unknown_model_version(
+        self, ready_client: httpx.AsyncClient
+    ):
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": ["hello"], "model_version": "missing-model"},
         )
 
         assert response.status_code == 503
@@ -58,7 +121,10 @@ class TestEmbedValidation:
     async def test_empty_texts_returns_400(
         self, ready_client: httpx.AsyncClient
     ):
-        response = await ready_client.post("/embed", json={"texts": []})
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": [], "model_version": "test-model"},
+        )
 
         assert response.status_code == 400
 
@@ -69,10 +135,20 @@ class TestEmbedValidation:
 
         assert response.status_code == 400
 
+    async def test_missing_model_version_returns_400(
+        self, ready_client: httpx.AsyncClient
+    ):
+        response = await ready_client.post("/embed", json={"texts": ["hello"]})
+
+        assert response.status_code == 400
+
     async def test_empty_string_in_texts_returns_400(
         self, ready_client: httpx.AsyncClient
     ):
-        response = await ready_client.post("/embed", json={"texts": [""]})
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": [""], "model_version": "test-model"},
+        )
 
         assert response.status_code == 400
 
@@ -80,7 +156,10 @@ class TestEmbedValidation:
         self, ready_client: httpx.AsyncClient
     ):
         texts = ["text"] * 33  # default max is 32
-        response = await ready_client.post("/embed", json={"texts": texts})
+        response = await ready_client.post(
+            "/embed",
+            json={"texts": texts, "model_version": "test-model"},
+        )
 
         assert response.status_code == 400
         body = response.json()
@@ -113,7 +192,8 @@ class TestEmbedGuardrails:
             base_url="https://test",
         ) as client:
             response = await client.post(
-                "/embed", json={"texts": ["a" * 20]}
+                "/embed",
+                json={"texts": ["a" * 20], "model_version": "test-model"},
             )
 
         assert response.status_code == 400
@@ -145,7 +225,8 @@ class TestEmbedGuardrails:
             base_url="https://test",
         ) as client:
             response = await client.post(
-                "/embed", json={"texts": ["a" * 100]}
+                "/embed",
+                json={"texts": ["a" * 100], "model_version": "test-model"},
             )
 
         assert response.status_code == 413
@@ -180,10 +261,18 @@ class TestEmbedAdmissionControl:
             transport=httpx.ASGITransport(app=app),
             base_url="https://test",
         ) as client:
-            first = asyncio.create_task(client.post("/embed", json={"texts": ["first"]}))
+            first = asyncio.create_task(
+                client.post(
+                    "/embed",
+                    json={"texts": ["first"], "model_version": "test-model"},
+                )
+            )
             await asyncio.to_thread(slow_runtime.entered.wait, 5)
 
-            second = await client.post("/embed", json={"texts": ["second"]})
+            second = await client.post(
+                "/embed",
+                json={"texts": ["second"], "model_version": "test-model"},
+            )
 
             slow_runtime.release.set()
             first_response = await first

--- a/services/managed-embedding-endpoint/tests/api/test_health.py
+++ b/services/managed-embedding-endpoint/tests/api/test_health.py
@@ -2,7 +2,7 @@ import httpx
 
 
 class TestHealthReady:
-    async def test_returns_200_with_status_and_model_version(
+    async def test_returns_200_with_status_and_ready_model_versions(
         self, ready_client: httpx.AsyncClient
     ):
         response = await ready_client.get("/health")
@@ -10,7 +10,7 @@ class TestHealthReady:
         assert response.status_code == 200
         body = response.json()
         assert body["status"] == "ok"
-        assert body["model_version"]  # non-empty string
+        assert body["ready_model_versions"] == ["test-model"]
 
     async def test_response_has_trace_id_header(
         self, ready_client: httpx.AsyncClient

--- a/services/managed-embedding-endpoint/tests/api/test_reload_models.py
+++ b/services/managed-embedding-endpoint/tests/api/test_reload_models.py
@@ -1,0 +1,70 @@
+from collections.abc import Callable
+
+import httpx
+from fastapi import FastAPI
+
+from src.core.model_state import ModelState
+from src.core.settings import Settings
+from src.services.inference_service import InferenceService
+
+
+class _FakeReloader:
+    def __init__(self, ready_model_versions: list[str]) -> None:
+        self._ready_model_versions = ready_model_versions
+        self.trace_ids: list[str | None] = []
+
+    async def reload(self, trace_id: str | None):
+        self.trace_ids.append(trace_id)
+        return type(
+            "ReloadResult",
+            (),
+            {"ready_model_versions": self._ready_model_versions},
+        )()
+
+
+class TestReloadModels:
+    async def test_returns_ready_model_versions(
+        self,
+        app_factory: Callable[..., FastAPI],
+        settings_factory: Callable[..., Settings],
+        ready_model_state_factory: Callable[[str], ModelState],
+        inference_service_factory: Callable[..., InferenceService],
+    ):
+        settings = settings_factory()
+        model_state = ready_model_state_factory()
+        fake_reloader = _FakeReloader(["active-v2", "previous-v1"])
+        app = app_factory(
+            settings=settings,
+            model_state=model_state,
+            inference_service=inference_service_factory(
+                settings=settings,
+                model_state=model_state,
+            ),
+            model_reloader=fake_reloader,
+        )
+
+        async with httpx.AsyncClient(
+            transport=httpx.ASGITransport(app=app),
+            base_url="https://test",
+        ) as client:
+            response = await client.post(
+                "/internal/reload-models",
+                json={"trace_id": "trace-body"},
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {
+            "ready_model_versions": ["active-v2", "previous-v1"]
+        }
+        assert fake_reloader.trace_ids == ["trace-body"]
+
+    async def test_returns_503_when_reloader_is_missing(
+        self,
+        ready_client: httpx.AsyncClient,
+    ):
+        response = await ready_client.post(
+            "/internal/reload-models",
+            json={"trace_id": "trace-body"},
+        )
+
+        assert response.status_code == 503

--- a/services/managed-embedding-endpoint/tests/conftest.py
+++ b/services/managed-embedding-endpoint/tests/conftest.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi import FastAPI
 
 from src.core.model_state import ModelState
+from src.core.runtime_registry import RuntimeRegistry
 from src.core.settings import Settings
 from src.main import create_app
 from src.services.inference_service import InferenceService
@@ -15,13 +16,14 @@ TEST_MODEL_PATH = "/app/test-model"
 
 
 class StubRuntime:
-    """Deterministic runtime: embedding[i] = [float(len(text))] * dim."""
+    """Deterministic runtime: embedding[i] = [float(len(text) + offset)] * dim."""
 
-    def __init__(self, dim: int = EMBEDDING_DIM) -> None:
+    def __init__(self, dim: int = EMBEDDING_DIM, offset: float = 0.0) -> None:
         self._dim = dim
+        self._offset = offset
 
     def encode(self, texts: list[str]) -> list[list[float]]:
-        return [[float(len(t))] * self._dim for t in texts]
+        return [[float(len(t)) + self._offset] * self._dim for t in texts]
 
 
 class SlowRuntime:
@@ -57,7 +59,7 @@ def settings_factory() -> Callable[..., Settings]:
 
 @pytest.fixture()
 def ready_model_state_factory() -> Callable[[str], ModelState]:
-    def _make(version: str = TEST_MODEL_PATH) -> ModelState:
+    def _make(version: str = "test-model") -> ModelState:
         state = ModelState()
         state.mark_ready(version)
         return state
@@ -78,21 +80,23 @@ def slow_runtime() -> SlowRuntime:
 @pytest.fixture()
 def inference_service_factory(
     settings_factory: Callable[..., Settings],
-    ready_model_state_factory: Callable[[str], ModelState],
 ) -> Callable[..., InferenceService]:
     def _make(
         *,
         settings: Settings | None = None,
         model_state: ModelState | None = None,
         runtime: object | None = None,
+        runtime_registry: RuntimeRegistry | None = None,
+        runtimes: dict[str, object] | None = None,
     ) -> InferenceService:
         effective_settings = settings or settings_factory()
-        effective_state = model_state or ready_model_state_factory()
-        effective_runtime = runtime or StubRuntime()
+        runtime_model_version = model_state.model_version if model_state is not None else "test-model"
+        effective_registry = runtime_registry or RuntimeRegistry(
+            runtimes or {runtime_model_version: runtime or StubRuntime()}
+        )
         return InferenceService(
-            effective_settings,
-            effective_state,
-            effective_runtime,  # type: ignore[arg-type]
+            settings=effective_settings,
+            runtime_registry=effective_registry,  # type: ignore[arg-type]
         )
 
     return _make
@@ -105,11 +109,13 @@ def app_factory() -> Callable[..., FastAPI]:
         settings: Settings,
         model_state: ModelState,
         inference_service: InferenceService | None = None,
+        model_reloader: object | None = None,
     ) -> FastAPI:
         return create_app(
             settings=settings,
             model_state=model_state,
             inference_service=inference_service,
+            model_reloader=model_reloader,
         )
 
     return _make

--- a/services/managed-embedding-endpoint/tests/unit/test_artifact_resolver.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_artifact_resolver.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from src.core.artifact_resolver import ModelArtifactResolver
+from src.core.settings import Settings
+
+
+class TestModelArtifactResolver:
+    def test_resolves_model_version_under_artifact_root(self, tmp_path: Path):
+        root = tmp_path / "models"
+        settings = Settings(
+            MODEL_ARTIFACT_PATH=str(root / "bge-m3-20260526T143000KST"),
+            MODEL_ARTIFACT_ROOT=str(root),
+        )
+        resolver = ModelArtifactResolver(settings)
+
+        assert resolver.resolve("bge-m3-20260526T144000KST") == str(
+            root / "bge-m3-20260526T144000KST"
+        )
+
+    def test_uses_model_artifact_path_when_root_is_missing_and_version_matches(
+        self,
+        tmp_path: Path,
+    ):
+        artifact_path = tmp_path / "models" / "bge-m3-20260526T143000KST"
+        settings = Settings(MODEL_ARTIFACT_PATH=str(artifact_path))
+        resolver = ModelArtifactResolver(settings)
+
+        assert resolver.resolve("bge-m3-20260526T143000KST") == str(artifact_path)
+
+    def test_falls_back_to_version_as_artifact_ref_when_no_root_or_matching_path(self):
+        settings = Settings(MODEL_ARTIFACT_PATH="/models/bge-m3-20260526T143000KST")
+        resolver = ModelArtifactResolver(settings)
+
+        assert resolver.resolve("BAAI/bge-m3") == "BAAI/bge-m3"

--- a/services/managed-embedding-endpoint/tests/unit/test_bge_runtime.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_bge_runtime.py
@@ -82,7 +82,7 @@ class TestBgeModelLoaderSuccess:
 
         factory.assert_called_once_with(str(artifact_dir.resolve()), use_fp16=True)
         assert state.ready is True
-        assert state.model_version == str(artifact_dir.resolve())
+        assert state.model_version == artifact_dir.name
         assert isinstance(runtime, BgeEmbeddingRuntime)
 
     def test_load_passes_cache_dir_when_set(self, tmp_path: Path):
@@ -133,7 +133,7 @@ class TestBgeModelLoaderSuccess:
             cache_dir=str(cache_dir),
         )
         assert state.ready is True
-        assert state.model_version == "BAAI/bge-m3"
+        assert state.model_version == "bge-m3"
         assert isinstance(runtime, BgeEmbeddingRuntime)
 
 

--- a/services/managed-embedding-endpoint/tests/unit/test_embed_dto.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_embed_dto.py
@@ -6,31 +6,40 @@ from src.schemas.embed_dto import EmbedRequest
 
 class TestEmbedRequestValid:
     def test_single_text(self):
-        req = EmbedRequest(texts=["hello"])
+        req = EmbedRequest(texts=["hello"], model_version="test-model")
         assert req.texts == ["hello"]
+        assert req.model_version == "test-model"
 
     def test_multiple_texts(self):
-        req = EmbedRequest(texts=["a", "b", "c"])
+        req = EmbedRequest(texts=["a", "b", "c"], model_version="test-model")
         assert len(req.texts) == 3
 
 
 class TestEmbedRequestInvalid:
     def test_empty_texts_list(self):
         with pytest.raises(ValidationError):
-            EmbedRequest(texts=[])
+            EmbedRequest(texts=[], model_version="test-model")
 
     def test_missing_texts_field(self):
         with pytest.raises(ValidationError):
             EmbedRequest()
 
+    def test_missing_model_version_field(self):
+        with pytest.raises(ValidationError):
+            EmbedRequest(texts=["hello"])
+
     def test_texts_wrong_type(self):
         with pytest.raises(ValidationError):
-            EmbedRequest(texts="not a list")
+            EmbedRequest(texts="not a list", model_version="test-model")
 
     def test_empty_string_in_texts(self):
         with pytest.raises(ValidationError):
-            EmbedRequest(texts=[""])
+            EmbedRequest(texts=[""], model_version="test-model")
 
     def test_empty_string_among_valid_texts(self):
         with pytest.raises(ValidationError):
-            EmbedRequest(texts=["hello", "", "world"])
+            EmbedRequest(texts=["hello", "", "world"], model_version="test-model")
+
+    def test_empty_model_version(self):
+        with pytest.raises(ValidationError):
+            EmbedRequest(texts=["hello"], model_version="")

--- a/services/managed-embedding-endpoint/tests/unit/test_inference_service.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_inference_service.py
@@ -2,7 +2,7 @@ from collections.abc import Callable
 
 import pytest
 
-from src.core.model_state import ModelState
+from src.core.runtime_registry import RuntimeRegistry
 from src.core.settings import Settings
 from src.middlewares.error_handler import (
     InvalidArgumentError,
@@ -17,13 +17,14 @@ EMBEDDING_DIM = 4
 class _StubRuntime:
     """Deterministic runtime: embedding[i] = [float(len(text))] * dim."""
 
-    def __init__(self, dim: int = EMBEDDING_DIM) -> None:
+    def __init__(self, dim: int = EMBEDDING_DIM, offset: float = 0.0) -> None:
         self._dim = dim
+        self._offset = offset
         self.call_log: list[list[str]] = []
 
     def encode(self, texts: list[str]) -> list[list[float]]:
         self.call_log.append(texts)
-        return [[float(len(t))] * self._dim for t in texts]
+        return [[float(len(t)) + self._offset] * self._dim for t in texts]
 
 
 class _ErrorRuntime:
@@ -47,6 +48,22 @@ class _BadTypeRuntime:
         return [["not", "a", "float"]] * len(texts)  # type: ignore[list-item]
 
 
+class TestConstruction:
+    def test_uses_injected_runtime_registry(
+        self,
+        settings_factory: Callable[..., Settings],
+    ):
+        runtime = _StubRuntime()
+        service = InferenceService(
+            settings=settings_factory(),
+            runtime_registry=RuntimeRegistry({"test-model": runtime}),
+        )
+
+        result = service.embed(["hello"], payload_size=10, model_version="test-model")
+
+        assert result[0] == pytest.approx([5.0] * EMBEDDING_DIM)
+
+
 class TestGuardrails:
     def test_texts_count_exceeds_max(
         self,
@@ -58,7 +75,7 @@ class TestGuardrails:
         )
 
         with pytest.raises(InvalidArgumentError, match="Too many texts"):
-            service.embed(["a", "b", "c"], payload_size=10)
+            service.embed(["a", "b", "c"], payload_size=10, model_version="test-model")
 
     def test_individual_text_length_exceeds_max(
         self,
@@ -70,7 +87,7 @@ class TestGuardrails:
         )
 
         with pytest.raises(InvalidArgumentError, match="index 0 is 10 chars"):
-            service.embed(["a" * 10], payload_size=10)
+            service.embed(["a" * 10], payload_size=10, model_version="test-model")
 
     def test_payload_size_exceeds_max(
         self,
@@ -82,7 +99,7 @@ class TestGuardrails:
         )
 
         with pytest.raises(PayloadTooLargeError, match="exceeds maximum 50"):
-            service.embed(["hello"], payload_size=100)
+            service.embed(["hello"], payload_size=100, model_version="test-model")
 
     def test_all_within_limits_passes(
         self,
@@ -97,7 +114,7 @@ class TestGuardrails:
             )
         )
 
-        result = service.embed(["hello", "world"], payload_size=30)
+        result = service.embed(["hello", "world"], payload_size=30, model_version="test-model")
 
         assert len(result) == 2
 
@@ -107,20 +124,18 @@ class TestReadinessCheck:
         self,
         inference_service_factory: Callable[..., InferenceService],
     ):
-        not_ready = ModelState()
-        service = inference_service_factory(model_state=not_ready)
+        service = inference_service_factory(runtime_registry=RuntimeRegistry())
 
         with pytest.raises(ServiceUnavailableError, match="not ready"):
-            service.embed(["hello"], payload_size=10)
+            service.embed(["hello"], payload_size=10, model_version="test-model")
 
     def test_model_ready_passes(
         self,
         inference_service_factory: Callable[..., InferenceService],
-        ready_model_state_factory: Callable[[str], ModelState],
     ):
-        service = inference_service_factory(model_state=ready_model_state_factory())
+        service = inference_service_factory()
 
-        result = service.embed(["hello"], payload_size=10)
+        result = service.embed(["hello"], payload_size=10, model_version="test-model")
 
         assert len(result) == 1
 
@@ -133,7 +148,7 @@ class TestEmbedSuccess:
         runtime = _StubRuntime()
         service = inference_service_factory(runtime=runtime)
 
-        result = service.embed(["hello"], payload_size=10)
+        result = service.embed(["hello"], payload_size=10, model_version="test-model")
 
         assert len(result) == 1
         assert result[0] == pytest.approx([5.0] * EMBEDDING_DIM)
@@ -146,7 +161,7 @@ class TestEmbedSuccess:
         service = inference_service_factory(runtime=runtime)
 
         texts = ["a", "bb", "ccc"]
-        result = service.embed(texts, payload_size=20)
+        result = service.embed(texts, payload_size=20, model_version="test-model")
 
         assert len(result) == 3
         assert result[0] == pytest.approx([1.0] * EMBEDDING_DIM)
@@ -161,7 +176,7 @@ class TestEmbedSuccess:
         service = inference_service_factory(runtime=runtime)
 
         texts = ["foo", "bar"]
-        service.embed(texts, payload_size=10)
+        service.embed(texts, payload_size=10, model_version="test-model")
 
         assert runtime.call_log == [["foo", "bar"]]
 
@@ -174,7 +189,7 @@ class TestResponseValidation:
         service = inference_service_factory(runtime=_WrongLengthRuntime())
 
         with pytest.raises(ServiceUnavailableError, match="2 embeddings for 3 texts"):
-            service.embed(["a", "b", "c"], payload_size=10)
+            service.embed(["a", "b", "c"], payload_size=10, model_version="test-model")
 
     def test_empty_when_shouldnt_raises(
         self,
@@ -183,7 +198,7 @@ class TestResponseValidation:
         service = inference_service_factory(runtime=_WrongLengthRuntime())
 
         with pytest.raises(ServiceUnavailableError, match="0 embeddings for 1 texts"):
-            service.embed(["a"], payload_size=5)
+            service.embed(["a"], payload_size=5, model_version="test-model")
 
     def test_runtime_exception_raises_unavailable(
         self,
@@ -192,7 +207,7 @@ class TestResponseValidation:
         service = inference_service_factory(runtime=_ErrorRuntime())
 
         with pytest.raises(ServiceUnavailableError, match="runtime error"):
-            service.embed(["hello"], payload_size=10)
+            service.embed(["hello"], payload_size=10, model_version="test-model")
 
     def test_non_numeric_embedding_raises(
         self,
@@ -201,7 +216,7 @@ class TestResponseValidation:
         service = inference_service_factory(runtime=_BadTypeRuntime())
 
         with pytest.raises(ServiceUnavailableError, match="not a list of numeric"):
-            service.embed(["hello"], payload_size=10)
+            service.embed(["hello"], payload_size=10, model_version="test-model")
 
 
 class TestLogging:
@@ -219,10 +234,16 @@ class TestLogging:
 
         monkeypatch.setattr("src.services.inference_service.info", _fake_info)
 
-        service.embed(["hello"], payload_size=10, trace_id="trace-123")
+        service.embed(
+            ["hello"],
+            payload_size=10,
+            model_version="test-model",
+            trace_id="trace-123",
+        )
 
         assert captured["message"] == "embed.success"
         assert captured["fields"]["trace_id"] == "trace-123"
+        assert captured["fields"]["model_version"] == "test-model"
 
     def test_runtime_error_log_includes_trace_id(
         self,
@@ -239,7 +260,42 @@ class TestLogging:
         monkeypatch.setattr("src.services.inference_service.error", _fake_error)
 
         with pytest.raises(ServiceUnavailableError, match="runtime error"):
-            service.embed(["hello"], payload_size=10, trace_id="trace-456")
+            service.embed(
+                ["hello"],
+                payload_size=10,
+                model_version="test-model",
+                trace_id="trace-456",
+            )
 
         assert captured["message"] == "runtime.encode failed"
         assert captured["fields"]["trace_id"] == "trace-456"
+
+
+class TestModelVersionRouting:
+    def test_unknown_model_version_raises(
+        self,
+        inference_service_factory: Callable[..., InferenceService],
+    ):
+        service = inference_service_factory()
+
+        with pytest.raises(ServiceUnavailableError, match="not ready"):
+            service.embed(["hello"], payload_size=10, model_version="missing-model")
+
+    def test_routes_to_requested_model_runtime(
+        self,
+        inference_service_factory: Callable[..., InferenceService],
+    ):
+        service = inference_service_factory(
+            runtimes={
+                "fake-20260526T143000KST": _StubRuntime(offset=0.0),
+                "fake-20260526T144000KST": _StubRuntime(offset=10.0),
+            },
+        )
+
+        result = service.embed(
+            ["abcd"],
+            payload_size=10,
+            model_version="fake-20260526T144000KST",
+        )
+
+        assert result[0] == pytest.approx([14.0] * EMBEDDING_DIM)

--- a/services/managed-embedding-endpoint/tests/unit/test_model_loader.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_model_loader.py
@@ -46,7 +46,7 @@ class TestLoadSuccess:
 
         loader.load(artifact)
 
-        expected_version = str(Path(artifact).resolve())
+        expected_version = Path(artifact).name
         assert state.model_version == expected_version
 
     def test_returns_embedding_runtime(self, tmp_path: Path):
@@ -57,13 +57,13 @@ class TestLoadSuccess:
 
         assert hasattr(runtime, "encode")
 
-    def test_model_version_uses_remote_model_id_when_path_missing(self):
+    def test_model_version_uses_last_segment_when_path_missing(self):
         state = ModelState()
         loader = _SuccessLoader(state)
 
         loader.load("BAAI/bge-m3")
 
-        assert state.model_version == "BAAI/bge-m3"
+        assert state.model_version == "bge-m3"
 
 
 class TestLoadFailure:

--- a/services/managed-embedding-endpoint/tests/unit/test_model_release_seed.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_model_release_seed.py
@@ -1,0 +1,20 @@
+from src.core.model_release_seed import derive_seed_model_release
+
+
+class TestDeriveSeedModelRelease:
+    def test_derives_version_from_model_artifact_path_last_segment(self):
+        seed = derive_seed_model_release(
+            model_artifact_path="/home/artyom9/models/bge-m3-20260526T143000KST"
+        )
+
+        assert seed.active_model_version == "bge-m3-20260526T143000KST"
+        assert seed.active_index_name == "vector-bge-m3-20260526T143000KST"
+
+    def test_allows_explicit_active_index_name(self):
+        seed = derive_seed_model_release(
+            model_artifact_path="/home/artyom9/models/bge-m3-20260526T143000KST",
+            active_index_name="custom-index",
+        )
+
+        assert seed.active_model_version == "bge-m3-20260526T143000KST"
+        assert seed.active_index_name == "custom-index"

--- a/services/managed-embedding-endpoint/tests/unit/test_model_runtime_reloader.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_model_runtime_reloader.py
@@ -1,0 +1,182 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from src.core.model_state import ModelState
+from src.core.runtime_registry import RuntimeRegistry
+from src.core.settings import Settings
+from src.infra.release_repository import ModelReleaseSnapshot
+from src.infra.runtime import EmbeddingRuntime
+from src.middlewares.error_handler import ServiceUnavailableError
+from src.services.model_reloader import ModelRuntimeReloader
+
+
+class _StubRuntime:
+    def __init__(self, value: float) -> None:
+        self._value = value
+        self.closed = False
+
+    def encode(self, texts: list[str]) -> list[list[float]]:
+        return [[self._value] for _ in texts]
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _FakeReleaseRepository:
+    def __init__(self, snapshot: ModelReleaseSnapshot | None) -> None:
+        self._snapshot = snapshot
+
+    async def get_current(self) -> ModelReleaseSnapshot | None:
+        return self._snapshot
+
+
+class _FakeLoader:
+    def __init__(
+        self,
+        state: ModelState,
+        values_by_path: dict[str, float],
+        failing_paths: set[str],
+    ) -> None:
+        self._state = state
+        self._values_by_path = values_by_path
+        self._failing_paths = failing_paths
+
+    def load(self, artifact_path: str) -> EmbeddingRuntime:
+        if artifact_path in self._failing_paths:
+            raise FileNotFoundError(artifact_path)
+        version = Path(artifact_path).name
+        self._state.mark_ready(version)
+        return _StubRuntime(self._values_by_path[artifact_path])
+
+
+@dataclass(slots=True)
+class _LoaderFactory:
+    values_by_path: dict[str, float]
+    failing_paths: set[str]
+
+    def __call__(self, state: ModelState) -> _FakeLoader:
+        return _FakeLoader(state, self.values_by_path, self.failing_paths)
+
+
+def _reloader(
+    *,
+    tmp_path: Path,
+    snapshot: ModelReleaseSnapshot | None,
+    values_by_version: dict[str, float],
+    failing_versions: set[str] | None = None,
+) -> tuple[ModelRuntimeReloader, RuntimeRegistry, ModelState]:
+    root = tmp_path / "models"
+    settings = Settings(
+        MODEL_ARTIFACT_PATH=str(root / "active-v1"),
+        MODEL_ARTIFACT_ROOT=str(root),
+    )
+    values_by_path = {
+        str(root / version): value for version, value in values_by_version.items()
+    }
+    failing_paths = {str(root / version) for version in failing_versions or set()}
+    state = ModelState()
+    registry = RuntimeRegistry()
+    return (
+        ModelRuntimeReloader(
+            settings=settings,
+            model_state=state,
+            runtime_registry=registry,
+            release_repository=_FakeReleaseRepository(snapshot),
+            loader_factory=_LoaderFactory(values_by_path, failing_paths),
+        ),
+        registry,
+        state,
+    )
+
+
+class TestModelRuntimeReloader:
+    async def test_loads_active_previous_candidate_from_model_release(
+        self,
+        tmp_path: Path,
+    ):
+        snapshot = ModelReleaseSnapshot(
+            active_model_version="active-v2",
+            previous_model_version="active-v1",
+            candidate_model_version="candidate-v3",
+        )
+        reloader, registry, state = _reloader(
+            tmp_path=tmp_path,
+            snapshot=snapshot,
+            values_by_version={
+                "active-v2": 2.0,
+                "active-v1": 1.0,
+                "candidate-v3": 3.0,
+            },
+        )
+
+        result = await reloader.reload(trace_id="trace-1")
+
+        assert result.ready_model_versions == [
+            "active-v2",
+            "active-v1",
+            "candidate-v3",
+        ]
+        assert state.ready_model_versions == result.ready_model_versions
+        assert registry.get("candidate-v3").encode(["x"]) == [[3.0]]
+
+    async def test_previous_candidate_load_failure_keeps_active_ready(
+        self,
+        tmp_path: Path,
+    ):
+        snapshot = ModelReleaseSnapshot(
+            active_model_version="active-v2",
+            previous_model_version="active-v1",
+            candidate_model_version="candidate-v3",
+        )
+        reloader, registry, state = _reloader(
+            tmp_path=tmp_path,
+            snapshot=snapshot,
+            values_by_version={"active-v2": 2.0},
+            failing_versions={"active-v1", "candidate-v3"},
+        )
+
+        result = await reloader.reload(trace_id="trace-1")
+
+        assert result.ready_model_versions == ["active-v2"]
+        assert state.ready_model_versions == ["active-v2"]
+        assert registry.get("active-v2").encode(["x"]) == [[2.0]]
+        assert registry.get("active-v1") is None
+
+    async def test_active_load_failure_preserves_existing_registry(
+        self,
+        tmp_path: Path,
+    ):
+        snapshot = ModelReleaseSnapshot(active_model_version="active-v2")
+        reloader, registry, state = _reloader(
+            tmp_path=tmp_path,
+            snapshot=snapshot,
+            values_by_version={"active-v1": 1.0},
+            failing_versions={"active-v2"},
+        )
+        registry.replace({"active-v1": _StubRuntime(1.0)})
+        state.replace_ready_versions(["active-v1"])
+
+        with pytest.raises(ServiceUnavailableError, match="active model load failed"):
+            await reloader.reload(trace_id="trace-1")
+
+        assert state.ready_model_versions == ["active-v1"]
+        assert registry.get("active-v1").encode(["x"]) == [[1.0]]
+
+    async def test_unloads_stale_runtime_after_successful_swap(self, tmp_path: Path):
+        snapshot = ModelReleaseSnapshot(active_model_version="active-v2")
+        reloader, registry, state = _reloader(
+            tmp_path=tmp_path,
+            snapshot=snapshot,
+            values_by_version={"active-v2": 2.0},
+        )
+        stale = _StubRuntime(1.0)
+        registry.replace({"active-v1": stale})
+        state.replace_ready_versions(["active-v1"])
+
+        await reloader.reload(trace_id="trace-1")
+
+        assert stale.closed is True
+        assert registry.get("active-v1") is None

--- a/services/managed-embedding-endpoint/tests/unit/test_model_state.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_model_state.py
@@ -6,16 +6,29 @@ class TestModelState:
         state = ModelState()
         assert state.ready is False
         assert state.model_version == ""
+        assert state.ready_model_versions == []
 
     def test_mark_ready(self):
         state = ModelState()
         state.mark_ready("BAAI/bge-m3")
         assert state.ready is True
         assert state.model_version == "BAAI/bge-m3"
+        assert state.ready_model_versions == ["BAAI/bge-m3"]
 
-    def test_mark_not_ready_resets(self):
+    def test_mark_ready_tracks_multiple_versions_in_order(self):
+        state = ModelState()
+        state.mark_ready("fake-20260526T143000KST")
+        state.mark_ready("fake-20260526T144000KST")
+
+        assert state.ready_model_versions == [
+            "fake-20260526T143000KST",
+            "fake-20260526T144000KST",
+        ]
+
+    def test_clear_ready_version_resets(self):
         state = ModelState()
         state.mark_ready("BAAI/bge-m3")
-        state.mark_not_ready()
+        state.clear_ready_version()
         assert state.ready is False
         assert state.model_version == ""
+        assert state.ready_model_versions == []

--- a/services/managed-embedding-endpoint/tests/unit/test_settings.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_settings.py
@@ -22,6 +22,14 @@ class TestSettingsDefaults:
         settings = Settings(MODEL_ARTIFACT_PATH="BAAI/bge-m3")
         assert settings.model_cache_dir == ""
 
+    def test_model_artifact_root_default_empty(self):
+        settings = Settings(MODEL_ARTIFACT_PATH="BAAI/bge-m3")
+        assert settings.model_artifact_root == ""
+
+    def test_database_url_default_empty(self):
+        settings = Settings(MODEL_ARTIFACT_PATH="BAAI/bge-m3")
+        assert settings.database_url == ""
+
 
 class TestSettingsRequired:
     """Verify required fields cause validation failure when missing."""
@@ -55,3 +63,12 @@ class TestSettingsOverrides:
     def test_custom_port(self):
         settings = Settings(MODEL_ARTIFACT_PATH="BAAI/bge-m3", PORT=9000)
         assert settings.port == 9000
+
+    def test_custom_release_reload_settings(self):
+        settings = Settings(
+            MODEL_ARTIFACT_PATH="/models/bge-m3-20260526T143000KST",
+            MODEL_ARTIFACT_ROOT="/models",
+            DATABASE_URL="postgresql+asyncpg://user:pass@db/app",
+        )
+        assert settings.model_artifact_root == "/models"
+        assert settings.database_url == "postgresql+asyncpg://user:pass@db/app"

--- a/services/managed-embedding-endpoint/tests/unit/test_startup_reload.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_startup_reload.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+
+from src.main import reload_models_on_startup
+
+
+class _FakeReloader:
+    def __init__(self) -> None:
+        self.trace_ids: list[str] = []
+
+    async def reload(self, trace_id: str):
+        self.trace_ids.append(trace_id)
+
+
+class TestStartupReload:
+    async def test_calls_model_reloader_with_startup_trace_id(self):
+        app = FastAPI()
+        reloader = _FakeReloader()
+        app.state.model_reloader = reloader
+
+        await reload_models_on_startup(app)
+
+        assert reloader.trace_ids == ["startup"]
+
+    async def test_noops_when_reloader_missing(self):
+        app = FastAPI()
+
+        await reload_models_on_startup(app)

--- a/services/pipeline-worker/src/infra/ai/embedding_client.py
+++ b/services/pipeline-worker/src/infra/ai/embedding_client.py
@@ -28,7 +28,7 @@ class EmbeddingClient:
         self._model_version = model_version
         self._client = client or httpx.AsyncClient()
 
-    async def get_model_version(self, trace_id: str) -> str:
+    async def get_ready_model_versions(self, trace_id: str) -> list[str]:
         response = await self._client.get(
             f"{self._base_url}/health",
             headers={"X-Trace-Id": trace_id},
@@ -36,16 +36,30 @@ class EmbeddingClient:
         )
         response.raise_for_status()
         payload = response.json()
-        model_version = payload.get("model_version")
-        if not model_version:
+        ready_model_versions = payload.get("ready_model_versions")
+        if not isinstance(ready_model_versions, list) or not ready_model_versions:
             raise ExternalAIAdapterError(
                 code="INTERNAL_ERROR",
-                message="Embedding model_version missing from health response",
+                message="Embedding ready_model_versions missing from health response",
                 trace_id=trace_id,
                 provider="embedding-endpoint",
                 retryable=False,
             )
-        return str(model_version)
+        return [str(version) for version in ready_model_versions]
+
+    async def get_model_version(self, trace_id: str) -> str:
+        ready_model_versions = await self.get_ready_model_versions(trace_id)
+        if self._model_version in ready_model_versions:
+            return self._model_version
+        if len(ready_model_versions) == 1:
+            return ready_model_versions[0]
+        raise ExternalAIAdapterError(
+            code="INTERNAL_ERROR",
+            message="Configured embedding model_version is not ready",
+            trace_id=trace_id,
+            provider="embedding-endpoint",
+            retryable=False,
+        )
 
     async def embed_texts(
         self,
@@ -68,7 +82,10 @@ class EmbeddingClient:
             try:
                 response = await self._client.post(
                     f"{self._base_url}/embed",
-                    json={"texts": texts, "model_version": model_version or self._model_version},
+                    json={
+                        "texts": texts,
+                        "model_version": model_version or self._model_version,
+                    },
                     headers={"X-Trace-Id": trace_id},
                     timeout=self._timeout_sec,
                 )

--- a/services/pipeline-worker/tests/support.py
+++ b/services/pipeline-worker/tests/support.py
@@ -48,6 +48,8 @@ def build_ffmpeg_adapter() -> tuple[FFmpegClient, RecordingFFmpegRunner]:
 def build_embedding_client(
     *,
     model_version: str = "v001",
+    ready_model_versions: list[str] | None = None,
+    health_payload: dict | None = None,
     embeddings_factory: Callable[[list[str]], list[list[float]]] | None = None,
     fail_embed_times: int = 0,
     embedding_model_version: str = "v001",
@@ -61,7 +63,14 @@ def build_embedding_client(
 
     def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/health":
-            return httpx.Response(200, json={"status": "ok", "model_version": model_version})
+            return httpx.Response(
+                200,
+                json=health_payload
+                or {
+                    "status": "ok",
+                    "ready_model_versions": ready_model_versions or [model_version],
+                },
+            )
         if request.url.path == "/embed":
             if state["failures"] > 0:
                 state["failures"] -= 1

--- a/services/pipeline-worker/tests/unit/test_embedding_client.py
+++ b/services/pipeline-worker/tests/unit/test_embedding_client.py
@@ -31,3 +31,32 @@ async def test_embedding_client_rejects_empty_input() -> None:
         await client.embed_texts([], trace_id="trace-3")
 
 
+@pytest.mark.asyncio
+async def test_embedding_client_reads_ready_model_versions_from_health() -> None:
+    client = build_embedding_client(model_version="v001")
+
+    versions = await client.get_ready_model_versions(trace_id="trace-4")
+
+    assert versions == ["v001"]
+
+
+@pytest.mark.asyncio
+async def test_embedding_client_get_model_version_uses_configured_ready_version() -> None:
+    client = build_embedding_client(
+        model_version="v002",
+        ready_model_versions=["v001", "v002"],
+        embedding_model_version="v002",
+    )
+
+    version = await client.get_model_version(trace_id="trace-5")
+
+    assert version == "v002"
+
+
+@pytest.mark.asyncio
+async def test_embedding_client_rejects_health_without_ready_model_versions() -> None:
+    client = build_embedding_client(health_payload={"status": "ok", "model_version": "v001"})
+
+    with pytest.raises(ExternalAIAdapterError, match="ready_model_versions"):
+        await client.get_ready_model_versions(trace_id="trace-6")
+

--- a/services/pipeline-worker/tools/fake_embedding_server.py
+++ b/services/pipeline-worker/tools/fake_embedding_server.py
@@ -8,7 +8,7 @@ Usage:
     python tools/fake_embedding_server.py 9000     # custom port
 
 Endpoints:
-    GET  /health  → {"status": "ok", "model_version": "fake-v001"}
+    GET  /health  → {"status": "ok", "ready_model_versions": ["fake-v001"]}
     POST /embed   → {"embeddings": [[...], ...]}   (384-dim random vectors)
 """
 
@@ -24,7 +24,9 @@ MODEL_VERSION = "fake-v001"
 class Handler(BaseHTTPRequestHandler):
     def do_GET(self) -> None:
         if self.path == "/health":
-            self._json_response({"status": "ok", "model_version": MODEL_VERSION})
+            self._json_response(
+                {"status": "ok", "ready_model_versions": [MODEL_VERSION]}
+            )
         else:
             self.send_error(404)
 
@@ -54,7 +56,7 @@ def main() -> None:
     port = int(sys.argv[1]) if len(sys.argv) > 1 else 8090
     server = HTTPServer(("0.0.0.0", port), Handler)
     print(f"Fake embedding server on http://0.0.0.0:{port}")
-    print(f"  GET  /health → model_version={MODEL_VERSION}")
+    print(f"  GET  /health → ready_model_versions={[MODEL_VERSION]}")
     print(f"  POST /embed  → {EMBEDDING_DIM}-dim random vectors")
     try:
         server.serve_forever()

--- a/services/search-service/src/api/v1/routers/internal.py
+++ b/services/search-service/src/api/v1/routers/internal.py
@@ -1,0 +1,59 @@
+# 모델 변경시 DB의 ModelRelease를 다시 읽어서 search-service 메모리에 있는 검색 target을 교체
+
+from fastapi import APIRouter, Request
+from pydantic import BaseModel
+
+from src.infra.db.search_repository import ServingSearchTargets
+from src.middlewares.error_handler import ServiceUnavailableError
+from src.services.serving_targets import ServingSearchTargetProvider
+
+router = APIRouter(prefix="/internal", tags=["internal"])
+
+
+class ReloadServingTargetsRequest(BaseModel):
+    trace_id: str | None = None
+
+
+class ServingTargetResponse(BaseModel):
+    model_version: str
+    index_name: str
+
+
+class ReloadServingTargetsResponse(BaseModel):
+    active: ServingTargetResponse
+    previous: ServingTargetResponse | None = None # 필수 아님
+
+
+@router.post("/reload-serving-targets")
+async def reload_serving_targets(
+    request: Request,
+    body: ReloadServingTargetsRequest,
+) -> ReloadServingTargetsResponse:
+    _ = body.trace_id
+    provider = _get_serving_target_provider(request)
+    targets = await provider.reload()
+    return _to_response(targets)
+
+
+def _get_serving_target_provider(request: Request) -> ServingSearchTargetProvider:
+    container = getattr(request.app.state, "container", None)
+    provider = getattr(container, "serving_target_provider", None)
+    if provider is None:
+        raise ServiceUnavailableError("Serving target provider is not configured.")
+    return provider
+
+
+def _to_response(targets: ServingSearchTargets) -> ReloadServingTargetsResponse:
+    previous = None
+    if targets.previous is not None:
+        previous = ServingTargetResponse(
+            model_version=targets.previous.model_version,
+            index_name=targets.previous.index_name,
+        )
+    return ReloadServingTargetsResponse(
+        active=ServingTargetResponse(
+            model_version=targets.active.model_version,
+            index_name=targets.active.index_name,
+        ),
+        previous=previous,
+    )

--- a/services/search-service/src/bootstrap.py
+++ b/services/search-service/src/bootstrap.py
@@ -50,7 +50,6 @@ def build_production_container(settings: Settings) -> DependencyContainer:
     llm_adapter = _build_llm_adapter(settings)
     serving_target_provider = ServingSearchTargetProvider(
         SearchRepository(session_factory),
-        ttl_sec=settings.search_target_cache_ttl_sec,
     )
 
     return DependencyContainer(

--- a/services/search-service/src/bootstrap.py
+++ b/services/search-service/src/bootstrap.py
@@ -6,11 +6,13 @@ and registers them in the DependencyContainer.
 
 from src.core.config import Settings
 from src.core.dependencies import DependencyContainer
+from src.infra.db.search_repository import SearchRepository
 from src.infra.db.session import create_engine, create_session_factory
 from src.infra.embedding.client import EmbeddingClient
 from src.infra.llm.base import LLMAdapter
 from src.infra.llm.gemini_adapter import GeminiLLMAdapter
 from src.infra.llm.mock_adapter import MockLLMAdapter
+from src.services.serving_targets import ServingSearchTargetProvider
 
 
 def _build_llm_adapter(settings: Settings) -> LLMAdapter:
@@ -46,6 +48,10 @@ def build_production_container(settings: Settings) -> DependencyContainer:
     )
 
     llm_adapter = _build_llm_adapter(settings)
+    serving_target_provider = ServingSearchTargetProvider(
+        SearchRepository(session_factory),
+        ttl_sec=settings.search_target_cache_ttl_sec,
+    )
 
     return DependencyContainer(
         settings=settings,
@@ -53,4 +59,5 @@ def build_production_container(settings: Settings) -> DependencyContainer:
         db_session_factory=session_factory,
         embedding_client=embedding_client,
         llm_adapter=llm_adapter,
+        serving_target_provider=serving_target_provider,
     )

--- a/services/search-service/src/core/config.py
+++ b/services/search-service/src/core/config.py
@@ -52,6 +52,11 @@ class Settings(BaseSettings):
         alias="SEARCH_SNAPSHOT_TTL_HOURS",
         ge=1,
     )
+    search_target_cache_ttl_sec: int = Field(
+        default=60,
+        alias="SEARCH_TARGET_CACHE_TTL_SEC",
+        ge=1,
+    )
 
     # Timeout & retry
     embedding_timeout_sec: int = Field(default=2, alias="EMBEDDING_TIMEOUT_SEC")

--- a/services/search-service/src/core/config.py
+++ b/services/search-service/src/core/config.py
@@ -52,12 +52,6 @@ class Settings(BaseSettings):
         alias="SEARCH_SNAPSHOT_TTL_HOURS",
         ge=1,
     )
-    search_target_cache_ttl_sec: int = Field(
-        default=60,
-        alias="SEARCH_TARGET_CACHE_TTL_SEC",
-        ge=1,
-    )
-
     # Timeout & retry
     embedding_timeout_sec: int = Field(default=2, alias="EMBEDDING_TIMEOUT_SEC")
     embedding_max_retries: int = Field(default=1, alias="EMBEDDING_MAX_RETRIES")

--- a/services/search-service/src/core/config.py
+++ b/services/search-service/src/core/config.py
@@ -47,6 +47,11 @@ class Settings(BaseSettings):
     search_top_k: int = Field(default=20, alias="SEARCH_TOP_K")
     final_top_k: int = Field(default=5, alias="FINAL_TOP_K")
     rrf_k: int = Field(default=60, alias="RRF_K")
+    search_snapshot_ttl_hours: int = Field(
+        default=168,
+        alias="SEARCH_SNAPSHOT_TTL_HOURS",
+        ge=1,
+    )
 
     # Timeout & retry
     embedding_timeout_sec: int = Field(default=2, alias="EMBEDDING_TIMEOUT_SEC")

--- a/services/search-service/src/core/dependencies.py
+++ b/services/search-service/src/core/dependencies.py
@@ -9,6 +9,7 @@ from src.infra.db.search_repository import SearchRepository
 from src.infra.embedding.client import EmbeddingClient
 from src.infra.llm.base import LLMAdapter
 from src.services.search_orchestrator import SearchOrchestrator
+from src.services.serving_targets import ServingSearchTargetProvider
 
 
 @dataclass(slots=True)
@@ -18,6 +19,7 @@ class DependencyContainer:
     db_session_factory: async_sessionmaker[AsyncSession] | None = None
     embedding_client: EmbeddingClient | None = None
     llm_adapter: LLMAdapter | None = None
+    serving_target_provider: ServingSearchTargetProvider | None = None
 
     async def aclose(self) -> None:
         if self.embedding_client is not None:
@@ -86,8 +88,14 @@ def get_search_orchestrator(
         raise RuntimeError("llm_adapter not initialized. Use bootstrap.")
 
     repo = SearchRepository(container.db_session_factory)
+    if container.serving_target_provider is None:
+        container.serving_target_provider = ServingSearchTargetProvider(
+            repo,
+            ttl_sec=container.settings.search_target_cache_ttl_sec,
+        )
     return SearchOrchestrator(
         repo=repo,
+        serving_target_provider=container.serving_target_provider,
         embedding_client=container.embedding_client,
         llm_adapter=container.llm_adapter,
         search_top_k=container.settings.search_top_k,

--- a/services/search-service/src/core/dependencies.py
+++ b/services/search-service/src/core/dependencies.py
@@ -21,6 +21,10 @@ class DependencyContainer:
     llm_adapter: LLMAdapter | None = None
     serving_target_provider: ServingSearchTargetProvider | None = None
 
+    async def astart(self) -> None:
+        if self.serving_target_provider is not None:
+            await self.serving_target_provider.load()
+
     async def aclose(self) -> None:
         if self.embedding_client is not None:
             await self.embedding_client.aclose()
@@ -86,13 +90,10 @@ def get_search_orchestrator(
         raise RuntimeError("embedding_client not initialized. Use bootstrap.")
     if container.llm_adapter is None:
         raise RuntimeError("llm_adapter not initialized. Use bootstrap.")
+    if container.serving_target_provider is None:
+        raise RuntimeError("serving_target_provider not initialized. Use bootstrap.")
 
     repo = SearchRepository(container.db_session_factory)
-    if container.serving_target_provider is None:
-        container.serving_target_provider = ServingSearchTargetProvider(
-            repo,
-            ttl_sec=container.settings.search_target_cache_ttl_sec,
-        )
     return SearchOrchestrator(
         repo=repo,
         serving_target_provider=container.serving_target_provider,

--- a/services/search-service/src/core/dependencies.py
+++ b/services/search-service/src/core/dependencies.py
@@ -93,4 +93,5 @@ def get_search_orchestrator(
         search_top_k=container.settings.search_top_k,
         final_top_k=container.settings.final_top_k,
         rrf_k=container.settings.rrf_k,
+        snapshot_ttl_hours=container.settings.search_snapshot_ttl_hours,
     )

--- a/services/search-service/src/infra/db/models.py
+++ b/services/search-service/src/infra/db/models.py
@@ -8,7 +8,17 @@ from datetime import datetime
 from uuid import UUID
 
 from pgvector.sqlalchemy import Vector
-from sqlalchemy import DateTime, ForeignKey, Integer, JSON, String, Text, Uuid, func
+from sqlalchemy import (
+    CheckConstraint,
+    DateTime,
+    ForeignKey,
+    Integer,
+    JSON,
+    String,
+    Text,
+    Uuid,
+    func,
+)
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column
 
@@ -85,6 +95,22 @@ class SearchResponseSnapshotModel(Base):
         DateTime(timezone=True), nullable=False, server_default=func.now()
     )
     expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class ModelReleaseModel(Base):
+    __tablename__ = "model_release"
+    __table_args__ = (
+        CheckConstraint("singleton_key = 1", name="ck_model_release_singleton_key"),
+    )
+
+    singleton_key: Mapped[int] = mapped_column(Integer(), primary_key=True, default=1)
+    release_status: Mapped[str] = mapped_column(Text(), nullable=False)
+    active_model_version: Mapped[str] = mapped_column(String(128), nullable=False)
+    active_index_name: Mapped[str] = mapped_column(String(128), nullable=False)
+    previous_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    previous_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_model_version: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    candidate_index_name: Mapped[str | None] = mapped_column(String(128), nullable=True)
 
 
 class VectorIndexEntryModel(Base):

--- a/services/search-service/src/infra/db/search_repository.py
+++ b/services/search-service/src/infra/db/search_repository.py
@@ -11,7 +11,13 @@ from sqlalchemy import exists, not_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import aliased
 
-from src.infra.db.models import ChunkModel, ProjectModel, SearchResponseSnapshotModel, VideoModel
+from src.infra.db.models import (
+    ChunkModel,
+    ModelReleaseModel,
+    ProjectModel,
+    SearchResponseSnapshotModel,
+    VideoModel,
+)
 
 DEFAULT_VECTOR_INDEX_NAME = "default-index"
 
@@ -63,6 +69,12 @@ class ANNCandidate:
 
 
 @dataclass(frozen=True, slots=True)
+class ServingSearchTarget:
+    model_version: str
+    index_name: str
+
+
+@dataclass(frozen=True, slots=True)
 class SearchResponseSnapshotWrite:
     req_id: UUID
     user_id: UUID
@@ -81,6 +93,22 @@ class SearchResponseSnapshotWrite:
 class SearchRepository:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
+
+    async def get_active_search_target(self) -> ServingSearchTarget | None:
+        """Read the currently active search model/index from ModelRelease SOT."""
+        async with self._session_factory() as session:
+            stmt = select(
+                ModelReleaseModel.active_model_version,
+                ModelReleaseModel.active_index_name,
+            ).where(ModelReleaseModel.singleton_key == 1)
+            result = await session.execute(stmt)
+            row = result.one_or_none()
+            if row is None:
+                return None
+            return ServingSearchTarget(
+                model_version=row.active_model_version,
+                index_name=row.active_index_name,
+            )
 
     async def check_corpus_readiness(
         self, user_id: UUID, project_id: UUID
@@ -156,6 +184,7 @@ class SearchRepository:
         user_id: UUID,
         project_id: UUID,
         query_embedding: list[float],
+        index_name: str = DEFAULT_VECTOR_INDEX_NAME,
         *,
         top_k: int,
     ) -> list[ANNCandidate]:
@@ -189,7 +218,7 @@ class SearchRepository:
                 {
                     "user_id": user_id,
                     "project_id": project_id,
-                    "index_name": DEFAULT_VECTOR_INDEX_NAME,
+                    "index_name": index_name,
                     "query_embedding": str(query_embedding),
                     "top_k": top_k,
                 },

--- a/services/search-service/src/infra/db/search_repository.py
+++ b/services/search-service/src/infra/db/search_repository.py
@@ -75,6 +75,30 @@ class ServingSearchTarget:
 
 
 @dataclass(frozen=True, slots=True)
+class ServingSearchTargets:
+    active: ServingSearchTarget
+    previous: ServingSearchTarget | None = None
+
+    @property
+    def target_entries(self) -> list[tuple[str, ServingSearchTarget]]:
+        entries = [("active", self.active)]
+        if self.previous is not None:
+            entries.append(("previous", self.previous))
+        return entries
+
+    @property
+    def served_vector_paths(self) -> list[dict[str, str]]:
+        return [
+            {
+                "role": role,
+                "model_version": target.model_version,
+                "index_name": target.index_name,
+            }
+            for role, target in self.target_entries
+        ]
+
+
+@dataclass(frozen=True, slots=True)
 class SearchResponseSnapshotWrite:
     req_id: UUID
     user_id: UUID
@@ -94,21 +118,31 @@ class SearchRepository:
     def __init__(self, session_factory: async_sessionmaker[AsyncSession]) -> None:
         self._session_factory = session_factory
 
-    async def get_active_search_target(self) -> ServingSearchTarget | None:
-        """Read the currently active search model/index from ModelRelease SOT."""
+    async def get_serving_search_targets(self) -> ServingSearchTargets | None:
+        """Read active and optional previous search targets from ModelRelease SOT."""
         async with self._session_factory() as session:
             stmt = select(
                 ModelReleaseModel.active_model_version,
                 ModelReleaseModel.active_index_name,
+                ModelReleaseModel.previous_model_version,
+                ModelReleaseModel.previous_index_name,
             ).where(ModelReleaseModel.singleton_key == 1)
             result = await session.execute(stmt)
             row = result.one_or_none()
             if row is None:
                 return None
-            return ServingSearchTarget(
+            active = ServingSearchTarget(
                 model_version=row.active_model_version,
                 index_name=row.active_index_name,
             )
+            previous = None
+            if row.previous_model_version and row.previous_index_name:
+                previous = ServingSearchTarget(
+                    model_version=row.previous_model_version,
+                    index_name=row.previous_index_name,
+                )
+            return ServingSearchTargets(active=active, previous=previous)
+
 
     async def check_corpus_readiness(
         self, user_id: UUID, project_id: UUID

--- a/services/search-service/src/infra/embedding/client.py
+++ b/services/search-service/src/infra/embedding/client.py
@@ -32,18 +32,25 @@ class EmbeddingClient:
         self._max_retries = max_retries
         self._client = client or httpx.AsyncClient()
 
-    async def embed_query(self, query: str, *, trace_id: str) -> EmbeddingResult:
-        """Embed a single normalized query text.
+    async def embed_query(
+        self,
+        query: str,
+        *,
+        trace_id: str,
+        model_version: str,
+    ) -> EmbeddingResult:
+        """정규화된 검색 query 하나를 지정된 model_version으로 embedding한다.
 
-        Returns the first embedding vector from the response.
-        Raises ServiceUnavailableError on final failure.
+        응답에서 단일 embedding vector를 꺼내 반환한다.
+        재시도 후에도 실패하면 ServiceUnavailableError를 발생시킨다.
         """
 
+        # 쿼리 임베딩 전용 함수라 따로 빼지 않고 안에 둠
         async def _attempt() -> EmbeddingResult:
             try:
                 response = await self._client.post(
                     f"{self._base_url}/embed",
-                    json={"texts": [query]},
+                    json={"texts": [query], "model_version": model_version},
                     headers={"X-Trace-Id": trace_id},
                     timeout=self._timeout_sec,
                 )
@@ -67,7 +74,7 @@ class EmbeddingClient:
             payload = response.json()
             embeddings = payload.get("embeddings")
 
-            # Validate response shape per SPEC §2.1 / §4.1
+          
             if not embeddings or len(embeddings) != 1:
                 raise ServiceUnavailableError(
                     "Embedding response shape mismatch: "

--- a/services/search-service/src/main.py
+++ b/services/search-service/src/main.py
@@ -3,6 +3,7 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from src.api.v1.router import api_v1_router
+from src.api.v1.routers.internal import router as internal_router
 from src.bootstrap import build_production_container
 from src.core.config import Settings, get_settings
 from src.core.dependencies import DependencyContainer
@@ -26,6 +27,9 @@ def create_app(
     @asynccontextmanager
     async def lifespan(app: FastAPI):
         app.state.container = resolved_container
+        container_astart = getattr(resolved_container, "astart", None)
+        if callable(container_astart):
+            await container_astart()
         try:
             yield
         finally:
@@ -39,6 +43,7 @@ def create_app(
 
     app.add_middleware(TraceIdMiddleware)
     register_exception_handlers(app)
+    app.include_router(internal_router)
     app.include_router(api_v1_router, prefix=app_settings.api_v1_prefix)
 
     return app

--- a/services/search-service/src/services/search_orchestrator.py
+++ b/services/search-service/src/services/search_orchestrator.py
@@ -28,6 +28,7 @@ from src.infra.db.search_repository import (
     SearchRepository,
     SearchResponseSnapshotWrite,
     ServingSearchTarget,
+    ServingSearchTargets,
 )
 from src.infra.embedding.client import EmbeddingClient
 from src.infra.llm.base import LLMAdapter, LLMAdapterError
@@ -57,6 +58,12 @@ class SearchResult:
     req_id: UUID
     answer: str
     chunks: list[ChunkResponse]
+
+# Query embedding이 검색해야 할 model/index target
+@dataclass(frozen=True, slots=True)
+class _TargetQueryEmbedding:
+    target: ServingSearchTarget
+    embedding: list[float] # 질문쿼리
 
 
 def _empty_result(req_id: UUID) -> SearchResult:
@@ -100,12 +107,12 @@ class SearchOrchestrator:
         if readiness.non_ready_count > 0:
             raise SearchNotReadyError()
 
-        target = await self._get_active_search_target()
+        targets = await self._get_serving_search_targets()
 
         # Steps 7-8
-        query_embedding = await self._embed_query(query, trace_id)
+        target_embeddings = await self._embed_query_targets(query, trace_id, targets)
         fts_results, ann_results = await self._retrieve(
-            user_id, project_id, query, query_embedding, target
+            user_id, project_id, query, target_embeddings
         )
 
         # Steps 9-10
@@ -135,7 +142,7 @@ class SearchOrchestrator:
             project_id=project_id,
             query=query,
             chunks=chunks,
-            target=target,
+            targets=targets,
             trace_id=trace_id,
         )
 
@@ -145,38 +152,60 @@ class SearchOrchestrator:
     # Private steps
     # ------------------------------------------------------------------
 
-    async def _get_active_search_target(self) -> ServingSearchTarget:
-        target = await self._repo.get_active_search_target()
-        if target is None:
+    async def _get_serving_search_targets(self) -> ServingSearchTargets:
+        targets = await self._repo.get_serving_search_targets()
+        if targets is None:
             raise ServiceUnavailableError("ModelRelease active search target is missing.")
-        return target
+        return targets
 
-    async def _embed_query(self, query: str, trace_id: str) -> list[float]:
+    async def _embed_query_targets(
+        self,
+        query: str,
+        trace_id: str,
+        targets: ServingSearchTargets,
+    ) -> list[_TargetQueryEmbedding]:
         """Step 6: Query embedding via Managed Embedding Endpoint."""
-        result = await self._embedding_client.embed_query(query, trace_id=trace_id)
-        return result.embedding
+        embeddings: list[_TargetQueryEmbedding] = []
+        for _, target in targets.target_entries:
+            result = await self._embedding_client.embed_query(
+                query,
+                trace_id=trace_id,
+                model_version=target.model_version,
+            )
+            embeddings.append(
+                _TargetQueryEmbedding(
+                    target=target,
+                    embedding=result.embedding,
+                )
+            )
+        return embeddings
 
     async def _retrieve(
         self,
         user_id: UUID,
         project_id: UUID,
         query: str,
-        query_embedding: list[float],
-        target: ServingSearchTarget,
+        target_embeddings: list[_TargetQueryEmbedding],
     ) -> tuple[list[FTSCandidate], list[ANNCandidate]]:
         """Step 7: FTS/ANN parallel retrieval."""
-        return await asyncio.gather(
-            self._repo.fts_search(
-                user_id, project_id, query, top_k=self._search_top_k
-            ),
+        fts_task = self._repo.fts_search(
+            user_id, project_id, query, top_k=self._search_top_k
+        )
+        ann_tasks = [
             self._repo.ann_search(
                 user_id,
                 project_id,
-                query_embedding,
-                target.index_name,
+                target_embedding.embedding,
+                target_embedding.target.index_name,
                 top_k=self._search_top_k,
-            ),
-        )
+            )
+            for target_embedding in target_embeddings
+        ]
+        results = await asyncio.gather(fts_task, *ann_tasks)
+        ann_results: list[ANNCandidate] = []
+        for result in results[1:]:
+            ann_results.extend(result)
+        return results[0], ann_results
 
     def _merge(
         self,
@@ -290,7 +319,7 @@ class SearchOrchestrator:
         project_id: UUID,
         query: str,
         chunks: list[ChunkResponse],
-        target: ServingSearchTarget,
+        targets: ServingSearchTargets,
         trace_id: str,
     ) -> None:
         if not chunks:
@@ -303,15 +332,9 @@ class SearchOrchestrator:
             query_text=query,
             topk_chunk_ids=[str(chunk.chunk_id) for chunk in chunks],
             used_chunk_ids=[str(chunk.chunk_id) for chunk in chunks if chunk.used],
-            active_model_version=target.model_version,
-            active_index_name=target.index_name,
-            served_vector_paths=[
-                {
-                    "role": "active",
-                    "model_version": target.model_version,
-                    "index_name": target.index_name,
-                }
-            ],
+            active_model_version=targets.active.model_version,
+            active_index_name=targets.active.index_name,
+            served_vector_paths=targets.served_vector_paths,
             project_serving_state="SERVABLE",
             expires_at=datetime.now(UTC) + timedelta(hours=self._snapshot_ttl_hours),
         )

--- a/services/search-service/src/services/search_orchestrator.py
+++ b/services/search-service/src/services/search_orchestrator.py
@@ -17,6 +17,7 @@ Implements SPEC §3.1 steps 5-16:
 
 import asyncio
 from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 from src.common.logging import warning as log_warning
@@ -25,6 +26,8 @@ from src.infra.db.search_repository import (
     ChunkRecord,
     FTSCandidate,
     SearchRepository,
+    SearchResponseSnapshotWrite,
+    ServingSearchTarget,
 )
 from src.infra.embedding.client import EmbeddingClient
 from src.infra.llm.base import LLMAdapter, LLMAdapterError
@@ -70,6 +73,7 @@ class SearchOrchestrator:
         search_top_k: int = 20,
         final_top_k: int = 5,
         rrf_k: int = 60,
+        snapshot_ttl_hours: int = 168,
     ) -> None:
         self._repo = repo
         self._embedding_client = embedding_client
@@ -77,6 +81,7 @@ class SearchOrchestrator:
         self._search_top_k = search_top_k
         self._final_top_k = final_top_k
         self._rrf_k = rrf_k
+        self._snapshot_ttl_hours = snapshot_ttl_hours
 
     async def execute(
         self,
@@ -95,10 +100,12 @@ class SearchOrchestrator:
         if readiness.non_ready_count > 0:
             raise SearchNotReadyError()
 
+        target = await self._get_active_search_target()
+
         # Steps 7-8
         query_embedding = await self._embed_query(query, trace_id)
         fts_results, ann_results = await self._retrieve(
-            user_id, project_id, query, query_embedding
+            user_id, project_id, query, query_embedding, target
         )
 
         # Steps 9-10
@@ -122,11 +129,27 @@ class SearchOrchestrator:
         )
         chunks = self._apply_used_refs(chunks, used_refs)
 
+        await self._save_snapshot(
+            req_id=req_id,
+            user_id=user_id,
+            project_id=project_id,
+            query=query,
+            chunks=chunks,
+            target=target,
+            trace_id=trace_id,
+        )
+
         return SearchResult(req_id=req_id, answer=answer, chunks=chunks)
 
     # ------------------------------------------------------------------
     # Private steps
     # ------------------------------------------------------------------
+
+    async def _get_active_search_target(self) -> ServingSearchTarget:
+        target = await self._repo.get_active_search_target()
+        if target is None:
+            raise ServiceUnavailableError("ModelRelease active search target is missing.")
+        return target
 
     async def _embed_query(self, query: str, trace_id: str) -> list[float]:
         """Step 6: Query embedding via Managed Embedding Endpoint."""
@@ -139,6 +162,7 @@ class SearchOrchestrator:
         project_id: UUID,
         query: str,
         query_embedding: list[float],
+        target: ServingSearchTarget,
     ) -> tuple[list[FTSCandidate], list[ANNCandidate]]:
         """Step 7: FTS/ANN parallel retrieval."""
         return await asyncio.gather(
@@ -146,7 +170,11 @@ class SearchOrchestrator:
                 user_id, project_id, query, top_k=self._search_top_k
             ),
             self._repo.ann_search(
-                user_id, project_id, query_embedding, top_k=self._search_top_k
+                user_id,
+                project_id,
+                query_embedding,
+                target.index_name,
+                top_k=self._search_top_k,
             ),
         )
 
@@ -253,3 +281,46 @@ class SearchOrchestrator:
             chunk.model_copy(update={"used": chunk.ref in used_ref_set})
             for chunk in chunks
         ]
+
+    async def _save_snapshot(
+        self,
+        *,
+        req_id: UUID,
+        user_id: UUID,
+        project_id: UUID,
+        query: str,
+        chunks: list[ChunkResponse],
+        target: ServingSearchTarget,
+        trace_id: str,
+    ) -> None:
+        if not chunks:
+            return
+
+        snapshot = SearchResponseSnapshotWrite(
+            req_id=req_id,
+            user_id=user_id,
+            project_id=project_id,
+            query_text=query,
+            topk_chunk_ids=[str(chunk.chunk_id) for chunk in chunks],
+            used_chunk_ids=[str(chunk.chunk_id) for chunk in chunks if chunk.used],
+            active_model_version=target.model_version,
+            active_index_name=target.index_name,
+            served_vector_paths=[
+                {
+                    "role": "active",
+                    "model_version": target.model_version,
+                    "index_name": target.index_name,
+                }
+            ],
+            project_serving_state="SERVABLE",
+            expires_at=datetime.now(UTC) + timedelta(hours=self._snapshot_ttl_hours),
+        )
+        try:
+            await self._repo.save_search_response_snapshot(snapshot)
+        except Exception as exc:
+            log_warning(
+                "search.snapshot_write_failed",
+                trace_id=trace_id,
+                req_id=str(req_id),
+                error=str(exc),
+            )

--- a/services/search-service/src/services/search_orchestrator.py
+++ b/services/search-service/src/services/search_orchestrator.py
@@ -61,20 +61,14 @@ class SearchOrchestrator:
         repo: SearchRepository,
         embedding_client: EmbeddingClient,
         llm_adapter: LLMAdapter,
-        serving_target_provider: ServingSearchTargetProvider | None = None,
+        serving_target_provider: ServingSearchTargetProvider,
         search_top_k: int = 20,
         final_top_k: int = 5,
         rrf_k: int = 60,
         snapshot_ttl_hours: int = 168,
     ) -> None:
         self._repo = repo
-        self._serving_target_provider = (
-            serving_target_provider
-            or ServingSearchTargetProvider(
-                repo,
-                ttl_sec=60,
-            )
-        )
+        self._serving_target_provider = serving_target_provider
         self._embedding_client = embedding_client
         self._llm_adapter = llm_adapter
         self._search_top_k = search_top_k
@@ -92,20 +86,17 @@ class SearchOrchestrator:
     ) -> SearchResult:
         req_id = uuid4()
 
-        # Steps 5-6: Single-query corpus readiness gate
         readiness = await self._repo.check_corpus_readiness(user_id, project_id)
         if readiness.total_videos == 0:
             raise NoVideosUploadedError()
         if readiness.non_ready_count > 0:
             raise SearchNotReadyError()
 
-        targets, fts_results, ann_results = (
-            await self._retrieve_with_target_refresh_retry(
-                user_id=user_id,
-                project_id=project_id,
-                query=query,
-                trace_id=trace_id,
-            )
+        targets, fts_results, ann_results = await self._retrieve_once(
+            user_id=user_id,
+            project_id=project_id,
+            query=query,
+            trace_id=trace_id,
         )
 
        
@@ -145,11 +136,7 @@ class SearchOrchestrator:
     # Private steps
     # ------------------------------------------------------------------
 
-    async def _get_serving_search_targets(self) -> ServingSearchTargets:
-        return await self._serving_target_provider.get()
-
-    # 캐시 조회 흐름 관리 + 실패 시 재시도 제어
-    async def _retrieve_with_target_refresh_retry(
+    async def _retrieve_once(
         self,
         *,
         user_id: UUID,
@@ -161,40 +148,7 @@ class SearchOrchestrator:
         list[FTSCandidate],
         list[ANNCandidate],
     ]:
-        try:
-            return await self._retrieve_once_with_serving_targets(
-                user_id=user_id,
-                project_id=project_id,
-                query=query,
-                trace_id=trace_id,
-                force_refresh=False,
-            )
-        except ServiceUnavailableError:
-            self._serving_target_provider.invalidate()
-            return await self._retrieve_once_with_serving_targets(
-                user_id=user_id,
-                project_id=project_id,
-                query=query,
-                trace_id=trace_id,
-                force_refresh=True,
-            )
-    # 실제 버전 조회해서 검색까지 수행
-    async def _retrieve_once_with_serving_targets(
-        self,
-        *,
-        user_id: UUID,
-        project_id: UUID,
-        query: str,
-        trace_id: str,
-        force_refresh: bool,
-    ) -> tuple[
-        ServingSearchTargets,
-        list[FTSCandidate],
-        list[ANNCandidate],
-    ]:
-        targets = await self._serving_target_provider.get(
-            force_refresh=force_refresh
-        )
+        targets = self._serving_target_provider.get()
         target_embeddings = await self._embed_query_targets(query, trace_id, targets)
         fts_results, ann_results = await self._retrieve(
             user_id, project_id, query, target_embeddings
@@ -207,7 +161,6 @@ class SearchOrchestrator:
         trace_id: str,
         targets: ServingSearchTargets,
     ) -> list[_TargetQueryEmbedding]:
-        """Step 6: Query embedding via Managed Embedding Endpoint."""
         embeddings: list[_TargetQueryEmbedding] = []
         for _, target in targets.target_entries:
             result = await self._embedding_client.embed_query(
@@ -230,7 +183,6 @@ class SearchOrchestrator:
         query: str,
         target_embeddings: list[_TargetQueryEmbedding],
     ) -> tuple[list[FTSCandidate], list[ANNCandidate]]:
-        """Step 7: FTS/ANN parallel retrieval."""
         fts_task = self._repo.fts_search(
             user_id, project_id, query, top_k=self._search_top_k
         )
@@ -255,7 +207,6 @@ class SearchOrchestrator:
         fts_results: list[FTSCandidate],
         ann_results: list[ANNCandidate],
     ) -> list[RRFCandidate]:
-        """Step 8: RRF merge, limited to FINAL_TOP_K."""
         return rrf_merge(
             fts_results, ann_results, k=self._rrf_k, top_k=self._final_top_k
         )
@@ -266,7 +217,6 @@ class SearchOrchestrator:
         project_id: UUID,
         merged: list[RRFCandidate],
     ) -> list[ChunkRecord]:
-        """Step 9: SOT serving gate — verify ownership and READY status."""
         chunk_ids = [c.chunk_id for c in merged]
         return await self._repo.sot_gate(user_id, project_id, chunk_ids)
 
@@ -283,7 +233,6 @@ class SearchOrchestrator:
     def _build_chunks(
         ordered_records: list[ChunkRecord],
     ) -> list[ChunkResponse]:
-        """Steps 11-12: Assign ref by RRF rank, build chunks in ref ASC order."""
         return [
             ChunkResponse(
                 ref=i + 1,

--- a/services/search-service/src/services/search_orchestrator.py
+++ b/services/search-service/src/services/search_orchestrator.py
@@ -1,20 +1,3 @@
-"""Search Orchestrator — hybrid search pipeline.
-
-Implements SPEC §3.1 steps 5-16:
-  5. Whole-corpus readiness gate
-  6. Searchable corpus existence check
-  7. Query embedding
-  8. FTS/ANN parallel retrieval
-  9. RRF merge
- 10. SOT serving gate
- 11. Empty result check
- 12. Citation ref assignment
- 13. chunks assembly
- 14. prompt builder + LLM call
- 15. response parsing + used_refs interpretation
- 16. final answer return
-"""
-
 import asyncio
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
@@ -45,6 +28,7 @@ from src.services.prompt_builder import (
     build_user_prompt,
 )
 from src.services.rrf import RRFCandidate, rrf_merge
+from src.services.serving_targets import ServingSearchTargetProvider
 from src.services.used_refs_parser import (
     count_answer_blocks,
     count_used_refs_blocks,
@@ -77,12 +61,20 @@ class SearchOrchestrator:
         repo: SearchRepository,
         embedding_client: EmbeddingClient,
         llm_adapter: LLMAdapter,
+        serving_target_provider: ServingSearchTargetProvider | None = None,
         search_top_k: int = 20,
         final_top_k: int = 5,
         rrf_k: int = 60,
         snapshot_ttl_hours: int = 168,
     ) -> None:
         self._repo = repo
+        self._serving_target_provider = (
+            serving_target_provider
+            or ServingSearchTargetProvider(
+                repo,
+                ttl_sec=60,
+            )
+        )
         self._embedding_client = embedding_client
         self._llm_adapter = llm_adapter
         self._search_top_k = search_top_k
@@ -107,15 +99,16 @@ class SearchOrchestrator:
         if readiness.non_ready_count > 0:
             raise SearchNotReadyError()
 
-        targets = await self._get_serving_search_targets()
-
-        # Steps 7-8
-        target_embeddings = await self._embed_query_targets(query, trace_id, targets)
-        fts_results, ann_results = await self._retrieve(
-            user_id, project_id, query, target_embeddings
+        targets, fts_results, ann_results = (
+            await self._retrieve_with_target_refresh_retry(
+                user_id=user_id,
+                project_id=project_id,
+                query=query,
+                trace_id=trace_id,
+            )
         )
 
-        # Steps 9-10
+       
         merged = self._merge(fts_results, ann_results)
         if not merged:
             return _empty_result(req_id)
@@ -124,11 +117,11 @@ class SearchOrchestrator:
         if not records:
             return _empty_result(req_id)
 
-        # Steps 12-13
+      
         ordered_records = self._order_records(merged, records)
         chunks = self._build_chunks(ordered_records)
 
-        # Steps 14-16
+       
         answer, used_refs = await self._generate_answer(
             query=query,
             ordered_records=ordered_records,
@@ -153,10 +146,60 @@ class SearchOrchestrator:
     # ------------------------------------------------------------------
 
     async def _get_serving_search_targets(self) -> ServingSearchTargets:
-        targets = await self._repo.get_serving_search_targets()
-        if targets is None:
-            raise ServiceUnavailableError("ModelRelease active search target is missing.")
-        return targets
+        return await self._serving_target_provider.get()
+
+    # 캐시 조회 흐름 관리 + 실패 시 재시도 제어
+    async def _retrieve_with_target_refresh_retry(
+        self,
+        *,
+        user_id: UUID,
+        project_id: UUID,
+        query: str,
+        trace_id: str,
+    ) -> tuple[
+        ServingSearchTargets,
+        list[FTSCandidate],
+        list[ANNCandidate],
+    ]:
+        try:
+            return await self._retrieve_once_with_serving_targets(
+                user_id=user_id,
+                project_id=project_id,
+                query=query,
+                trace_id=trace_id,
+                force_refresh=False,
+            )
+        except ServiceUnavailableError:
+            self._serving_target_provider.invalidate()
+            return await self._retrieve_once_with_serving_targets(
+                user_id=user_id,
+                project_id=project_id,
+                query=query,
+                trace_id=trace_id,
+                force_refresh=True,
+            )
+    # 실제 버전 조회해서 검색까지 수행
+    async def _retrieve_once_with_serving_targets(
+        self,
+        *,
+        user_id: UUID,
+        project_id: UUID,
+        query: str,
+        trace_id: str,
+        force_refresh: bool,
+    ) -> tuple[
+        ServingSearchTargets,
+        list[FTSCandidate],
+        list[ANNCandidate],
+    ]:
+        targets = await self._serving_target_provider.get(
+            force_refresh=force_refresh
+        )
+        target_embeddings = await self._embed_query_targets(query, trace_id, targets)
+        fts_results, ann_results = await self._retrieve(
+            user_id, project_id, query, target_embeddings
+        )
+        return targets, fts_results, ann_results
 
     async def _embed_query_targets(
         self,

--- a/services/search-service/src/services/serving_targets.py
+++ b/services/search-service/src/services/serving_targets.py
@@ -1,6 +1,4 @@
 import asyncio
-import time
-from collections.abc import Callable
 
 from src.infra.db.search_repository import SearchRepository, ServingSearchTargets
 from src.middlewares.error_handler import ServiceUnavailableError
@@ -11,42 +9,37 @@ class ServingSearchTargetProvider:
         self,
         repo: SearchRepository,
         *,
-        ttl_sec: int,
-        now_func: Callable[[], float] = time.monotonic,
+        loaded_targets: ServingSearchTargets | None = None,
     ) -> None:
         self._repo = repo
-        self._ttl_sec = ttl_sec
-        self._now_func = now_func
         self._lock = asyncio.Lock()
-        self._cached_targets: ServingSearchTargets | None = None
-        self._expires_at = 0.0
+        self._targets = loaded_targets
 
-    async def get(self, *, force_refresh: bool = False) -> ServingSearchTargets:
-        now = self._now_func()
-        if not force_refresh and self._is_cache_valid(now):
-            assert self._cached_targets is not None
-            return self._cached_targets
-        
-        # 캐시 히트가 아닌경우 락 걸고 db 조회, 여러 요청이 db조회 못하게
+    async def load(self) -> None:
+        if self._targets is not None:
+            return
+
         async with self._lock:
-            now = self._now_func()
-            if not force_refresh and self._is_cache_valid(now):
-                assert self._cached_targets is not None
-                return self._cached_targets
+            if self._targets is not None:
+                return
 
-            targets = await self._repo.get_serving_search_targets()
-            if targets is None:
-                raise ServiceUnavailableError(
-                    "ModelRelease active search target is missing."
-                )
+            self._targets = await self._read_targets()
 
-            self._cached_targets = targets
-            self._expires_at = now + self._ttl_sec
+    async def reload(self) -> ServingSearchTargets:
+        async with self._lock:
+            targets = await self._read_targets()
+            self._targets = targets
             return targets
 
-    def invalidate(self) -> None:
-        self._cached_targets = None
-        self._expires_at = 0.0
+    async def _read_targets(self) -> ServingSearchTargets:
+        targets = await self._repo.get_serving_search_targets()
+        if targets is None:
+            raise ServiceUnavailableError(
+                "ModelRelease active search target is missing."
+            )
+        return targets
 
-    def _is_cache_valid(self, now: float) -> bool:
-        return self._cached_targets is not None and now < self._expires_at
+    def get(self) -> ServingSearchTargets:
+        if self._targets is None:
+            raise ServiceUnavailableError("Serving search targets are not loaded.")
+        return self._targets

--- a/services/search-service/src/services/serving_targets.py
+++ b/services/search-service/src/services/serving_targets.py
@@ -1,0 +1,52 @@
+import asyncio
+import time
+from collections.abc import Callable
+
+from src.infra.db.search_repository import SearchRepository, ServingSearchTargets
+from src.middlewares.error_handler import ServiceUnavailableError
+
+
+class ServingSearchTargetProvider:
+    def __init__(
+        self,
+        repo: SearchRepository,
+        *,
+        ttl_sec: int,
+        now_func: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._repo = repo
+        self._ttl_sec = ttl_sec
+        self._now_func = now_func
+        self._lock = asyncio.Lock()
+        self._cached_targets: ServingSearchTargets | None = None
+        self._expires_at = 0.0
+
+    async def get(self, *, force_refresh: bool = False) -> ServingSearchTargets:
+        now = self._now_func()
+        if not force_refresh and self._is_cache_valid(now):
+            assert self._cached_targets is not None
+            return self._cached_targets
+        
+        # 캐시 히트가 아닌경우 락 걸고 db 조회, 여러 요청이 db조회 못하게
+        async with self._lock:
+            now = self._now_func()
+            if not force_refresh and self._is_cache_valid(now):
+                assert self._cached_targets is not None
+                return self._cached_targets
+
+            targets = await self._repo.get_serving_search_targets()
+            if targets is None:
+                raise ServiceUnavailableError(
+                    "ModelRelease active search target is missing."
+                )
+
+            self._cached_targets = targets
+            self._expires_at = now + self._ttl_sec
+            return targets
+
+    def invalidate(self) -> None:
+        self._cached_targets = None
+        self._expires_at = 0.0
+
+    def _is_cache_valid(self, now: float) -> bool:
+        return self._cached_targets is not None and now < self._expires_at

--- a/services/search-service/tests/api/test_reload_serving_targets.py
+++ b/services/search-service/tests/api/test_reload_serving_targets.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from unittest.mock import AsyncMock
+
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from src.middlewares.error_handler import register_exception_handlers
+from src.middlewares.trace import TraceIdMiddleware
+from src.infra.db.search_repository import (
+    ServingSearchTarget,
+    ServingSearchTargets,
+)
+
+
+@dataclass
+class _FakeContainer:
+    serving_target_provider: object | None
+
+
+def _targets() -> ServingSearchTargets:
+    return ServingSearchTargets(
+        active=ServingSearchTarget(
+            model_version="embedding-v2",
+            index_name="active-index-v2",
+        ),
+        previous=ServingSearchTarget(
+            model_version="embedding-v1",
+            index_name="previous-index-v1",
+        ),
+    )
+
+
+async def test_reload_serving_targets_returns_reloaded_targets() -> None:
+    from src.api.v1.routers.internal import router
+
+    provider = AsyncMock()
+    provider.reload.return_value = _targets()
+
+    app = FastAPI()
+    app.state.container = _FakeContainer(serving_target_provider=provider)
+    app.add_middleware(TraceIdMiddleware)
+    register_exception_handlers(app)
+    app.include_router(router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="https://testserver",
+    ) as client:
+        response = await client.post(
+            "/internal/reload-serving-targets",
+            json={"trace_id": "trace-body"},
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "active": {
+            "model_version": "embedding-v2",
+            "index_name": "active-index-v2",
+        },
+        "previous": {
+            "model_version": "embedding-v1",
+            "index_name": "previous-index-v1",
+        },
+    }
+    provider.reload.assert_awaited_once()
+
+
+async def test_reload_serving_targets_returns_503_when_provider_missing() -> None:
+    from src.api.v1.routers.internal import router
+
+    app = FastAPI()
+    app.state.container = _FakeContainer(serving_target_provider=None)
+    register_exception_handlers(app)
+    app.include_router(router)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app, raise_app_exceptions=False),
+        base_url="https://testserver",
+    ) as client:
+        response = await client.post(
+            "/internal/reload-serving-targets",
+            json={},
+        )
+
+    assert response.status_code == 503

--- a/services/search-service/tests/api/test_search.py
+++ b/services/search-service/tests/api/test_search.py
@@ -33,6 +33,7 @@ from src.middlewares.error_handler import (
 from src.middlewares.trace import TraceIdMiddleware
 from src.schemas.search_dto import EMPTY_ANSWER
 from src.services.search_orchestrator import SearchOrchestrator
+from src.services.serving_targets import ServingSearchTargetProvider
 
 TEST_SECRET = "test-secret-key-for-search-service-32b"
 TEST_USER_ID = uuid4()
@@ -111,12 +112,13 @@ def _make_orchestrator(
     repo.fts_search.return_value = fts_results or []
     repo.ann_search.return_value = []
     repo.sot_gate.return_value = sot_records or []
-    repo.get_serving_search_targets.return_value = ServingSearchTargets(
+    serving_targets = ServingSearchTargets(
         active=ServingSearchTarget(
             model_version="embedding-v1",
             index_name="active-index",
         )
     )
+    repo.get_serving_search_targets.return_value = serving_targets
 
     embedding_client = AsyncMock(spec=EmbeddingClient)
     if embedding_error is not None:
@@ -138,6 +140,10 @@ def _make_orchestrator(
 
     return SearchOrchestrator(
         repo=repo,
+        serving_target_provider=ServingSearchTargetProvider(
+            repo,
+            loaded_targets=serving_targets,
+        ),
         embedding_client=embedding_client,
         llm_adapter=llm_adapter,
     )

--- a/services/search-service/tests/api/test_search.py
+++ b/services/search-service/tests/api/test_search.py
@@ -21,6 +21,8 @@ from src.infra.db.search_repository import (
     CorpusReadiness,
     FTSCandidate,
     SearchRepository,
+    ServingSearchTarget,
+    ServingSearchTargets,
 )
 from src.infra.embedding.client import EmbeddingClient, EmbeddingResult
 from src.infra.llm.base import LLMAdapter, LLMAdapterError, LLMGenerationResult
@@ -109,6 +111,12 @@ def _make_orchestrator(
     repo.fts_search.return_value = fts_results or []
     repo.ann_search.return_value = []
     repo.sot_gate.return_value = sot_records or []
+    repo.get_serving_search_targets.return_value = ServingSearchTargets(
+        active=ServingSearchTarget(
+            model_version="embedding-v1",
+            index_name="active-index",
+        )
+    )
 
     embedding_client = AsyncMock(spec=EmbeddingClient)
     if embedding_error is not None:

--- a/services/search-service/tests/integration/test_search_repository.py
+++ b/services/search-service/tests/integration/test_search_repository.py
@@ -12,7 +12,14 @@ import pytest_asyncio
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
-from src.infra.db.models import Base, ChunkModel, ProjectModel, VectorIndexEntryModel, VideoModel
+from src.infra.db.models import (
+    Base,
+    ChunkModel,
+    ModelReleaseModel,
+    ProjectModel,
+    VectorIndexEntryModel,
+    VideoModel,
+)
 from src.infra.db.search_repository import SearchRepository, SearchResponseSnapshotWrite
 
 # Testcontainers import is optional; skip all tests if unavailable
@@ -360,6 +367,35 @@ class TestANNSearch:
 
         results = await repo.ann_search(user, project_id, [0.0, 1.0, 0.0], top_k=3)
         assert len(results) == 3
+
+
+class TestServingSearchTargets:
+    async def test_reads_active_and_previous_targets_from_model_release(
+        self,
+        session_factory,
+        repo,
+    ) -> None:
+        async with session_factory() as session:
+            session.add(
+                ModelReleaseModel(
+                    singleton_key=1,
+                    release_status="STABLE",
+                    active_model_version="embedding-v2",
+                    active_index_name="active-index-v2",
+                    previous_model_version="embedding-v1",
+                    previous_index_name="previous-index-v1",
+                )
+            )
+            await session.commit()
+
+        targets = await repo.get_serving_search_targets()
+
+        assert targets is not None
+        assert targets.active.model_version == "embedding-v2"
+        assert targets.active.index_name == "active-index-v2"
+        assert targets.previous is not None
+        assert targets.previous.model_version == "embedding-v1"
+        assert targets.previous.index_name == "previous-index-v1"
 
 
 class TestSOTGate:

--- a/services/search-service/tests/unit/test_config.py
+++ b/services/search-service/tests/unit/test_config.py
@@ -39,7 +39,6 @@ class TestSettingsDefaults:
             FINAL_TOP_K="10",
             RRF_K="80",
             SEARCH_SNAPSHOT_TTL_HOURS="12",
-            SEARCH_TARGET_CACHE_TTL_SEC="30",
         ))
         assert settings.llm_provider == "mock"
         assert settings.llm_temperature == pytest.approx(0.5)
@@ -48,4 +47,3 @@ class TestSettingsDefaults:
         assert settings.final_top_k == 10
         assert settings.rrf_k == 80
         assert settings.search_snapshot_ttl_hours == 12
-        assert settings.search_target_cache_ttl_sec == 30

--- a/services/search-service/tests/unit/test_config.py
+++ b/services/search-service/tests/unit/test_config.py
@@ -39,6 +39,7 @@ class TestSettingsDefaults:
             FINAL_TOP_K="10",
             RRF_K="80",
             SEARCH_SNAPSHOT_TTL_HOURS="12",
+            SEARCH_TARGET_CACHE_TTL_SEC="30",
         ))
         assert settings.llm_provider == "mock"
         assert settings.llm_temperature == pytest.approx(0.5)
@@ -47,3 +48,4 @@ class TestSettingsDefaults:
         assert settings.final_top_k == 10
         assert settings.rrf_k == 80
         assert settings.search_snapshot_ttl_hours == 12
+        assert settings.search_target_cache_ttl_sec == 30

--- a/services/search-service/tests/unit/test_config.py
+++ b/services/search-service/tests/unit/test_config.py
@@ -38,6 +38,7 @@ class TestSettingsDefaults:
             SEARCH_TOP_K="30",
             FINAL_TOP_K="10",
             RRF_K="80",
+            SEARCH_SNAPSHOT_TTL_HOURS="12",
         ))
         assert settings.llm_provider == "mock"
         assert settings.llm_temperature == pytest.approx(0.5)
@@ -45,3 +46,4 @@ class TestSettingsDefaults:
         assert settings.search_top_k == 30
         assert settings.final_top_k == 10
         assert settings.rrf_k == 80
+        assert settings.search_snapshot_ttl_hours == 12

--- a/services/search-service/tests/unit/test_embedding_client.py
+++ b/services/search-service/tests/unit/test_embedding_client.py
@@ -24,7 +24,11 @@ class TestEmbedQuery:
             return httpx.Response(200, json={"embeddings": [[0.1, 0.2, 0.3]]})
 
         client = _make_client(httpx.MockTransport(handler))
-        result = await client.embed_query("test query", trace_id=TRACE_ID)
+        result = await client.embed_query(
+            "test query",
+            trace_id=TRACE_ID,
+            model_version="embedding-v1",
+        )
         assert result.embedding == [0.1, 0.2, 0.3]
 
     async def test_sends_trace_id_header(self) -> None:
@@ -35,7 +39,11 @@ class TestEmbedQuery:
             return httpx.Response(200, json={"embeddings": [[0.1]]})
 
         client = _make_client(httpx.MockTransport(handler))
-        await client.embed_query("test", trace_id=TRACE_ID)
+        await client.embed_query(
+            "test",
+            trace_id=TRACE_ID,
+            model_version="embedding-v1",
+        )
         assert captured_headers["x-trace-id"] == TRACE_ID
 
     async def test_sends_single_text(self) -> None:
@@ -47,8 +55,15 @@ class TestEmbedQuery:
             return httpx.Response(200, json={"embeddings": [[0.1]]})
 
         client = _make_client(httpx.MockTransport(handler))
-        await client.embed_query("my query", trace_id=TRACE_ID)
-        assert captured_body == {"texts": ["my query"]}
+        await client.embed_query(
+            "my query",
+            trace_id=TRACE_ID,
+            model_version="embedding-v1",
+        )
+        assert captured_body == {
+            "texts": ["my query"],
+            "model_version": "embedding-v1",
+        }
 
     async def test_empty_embeddings_raises_503(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
@@ -56,7 +71,11 @@ class TestEmbedQuery:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(ServiceUnavailableError):
-            await client.embed_query("test", trace_id=TRACE_ID)
+            await client.embed_query(
+                "test",
+                trace_id=TRACE_ID,
+                model_version="embedding-v1",
+            )
 
     async def test_length_mismatch_raises_503(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
@@ -64,7 +83,11 @@ class TestEmbedQuery:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(ServiceUnavailableError):
-            await client.embed_query("test", trace_id=TRACE_ID)
+            await client.embed_query(
+                "test",
+                trace_id=TRACE_ID,
+                model_version="embedding-v1",
+            )
 
     async def test_non_numeric_vector_raises_503(self) -> None:
         def handler(request: httpx.Request) -> httpx.Response:
@@ -72,7 +95,11 @@ class TestEmbedQuery:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(ServiceUnavailableError):
-            await client.embed_query("test", trace_id=TRACE_ID)
+            await client.embed_query(
+                "test",
+                trace_id=TRACE_ID,
+                model_version="embedding-v1",
+            )
 
     async def test_503_retries_then_raises(self) -> None:
         call_count = 0
@@ -84,7 +111,11 @@ class TestEmbedQuery:
 
         client = _make_client(httpx.MockTransport(handler))
         with pytest.raises(ServiceUnavailableError):
-            await client.embed_query("test", trace_id=TRACE_ID)
+            await client.embed_query(
+                "test",
+                trace_id=TRACE_ID,
+                model_version="embedding-v1",
+            )
         assert call_count == 2  # 1 initial + 1 retry
 
     async def test_503_then_success(self) -> None:
@@ -98,6 +129,10 @@ class TestEmbedQuery:
             return httpx.Response(200, json={"embeddings": [[0.5]]})
 
         client = _make_client(httpx.MockTransport(handler))
-        result = await client.embed_query("test", trace_id=TRACE_ID)
+        result = await client.embed_query(
+            "test",
+            trace_id=TRACE_ID,
+            model_version="embedding-v1",
+        )
         assert result.embedding == [0.5]
         assert call_count == 2

--- a/services/search-service/tests/unit/test_main_lifecycle.py
+++ b/services/search-service/tests/unit/test_main_lifecycle.py
@@ -20,6 +20,11 @@ def _make_settings() -> Settings:
 class _FakeContainer:
     settings: Settings
     closed: bool = False
+    started: bool = False
+
+    async def astart(self) -> None:
+        self.started = True
+        await asyncio.sleep(0)
 
     async def aclose(self) -> None:
         self.closed = True
@@ -38,6 +43,7 @@ class TestAppLifecycle:
             ) as client:
                 response = await client.get("/health")
                 assert response.status_code == 200
+                assert container.started is True
                 assert container.closed is False
 
         assert container.closed is True

--- a/services/search-service/tests/unit/test_search_orchestrator_answer.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_answer.py
@@ -17,6 +17,7 @@ from src.infra.embedding.client import EmbeddingClient, EmbeddingResult
 from src.infra.llm.base import LLMAdapter, LLMAdapterError, LLMGenerationResult
 from src.middlewares.error_handler import ApiError, ServiceUnavailableError
 from src.services.search_orchestrator import SearchOrchestrator
+from src.services.serving_targets import ServingSearchTargetProvider
 
 USER_ID = uuid4()
 PROJECT_ID = uuid4()
@@ -58,12 +59,13 @@ def _make_orchestrator(
     ]
     repo.ann_search.return_value = []
     repo.sot_gate.return_value = records
-    repo.get_serving_search_targets.return_value = ServingSearchTargets(
+    serving_targets = ServingSearchTargets(
         active=ServingSearchTarget(
             model_version="embedding-v1",
             index_name="active-index",
         )
     )
+    repo.get_serving_search_targets.return_value = serving_targets
 
     embedding_client = AsyncMock(spec=EmbeddingClient)
     embedding_client.embed_query.return_value = EmbeddingResult(
@@ -81,6 +83,10 @@ def _make_orchestrator(
 
     return SearchOrchestrator(
         repo=repo,
+        serving_target_provider=ServingSearchTargetProvider(
+            repo,
+            loaded_targets=serving_targets,
+        ),
         embedding_client=embedding_client,
         llm_adapter=llm_adapter,
     )

--- a/services/search-service/tests/unit/test_search_orchestrator_answer.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_answer.py
@@ -10,6 +10,8 @@ from src.infra.db.search_repository import (
     FTSCandidate,
     ChunkRecord,
     SearchRepository,
+    ServingSearchTarget,
+    ServingSearchTargets,
 )
 from src.infra.embedding.client import EmbeddingClient, EmbeddingResult
 from src.infra.llm.base import LLMAdapter, LLMAdapterError, LLMGenerationResult
@@ -56,6 +58,12 @@ def _make_orchestrator(
     ]
     repo.ann_search.return_value = []
     repo.sot_gate.return_value = records
+    repo.get_serving_search_targets.return_value = ServingSearchTargets(
+        active=ServingSearchTarget(
+            model_version="embedding-v1",
+            index_name="active-index",
+        )
+    )
 
     embedding_client = AsyncMock(spec=EmbeddingClient)
     embedding_client.embed_query.return_value = EmbeddingResult(

--- a/services/search-service/tests/unit/test_search_orchestrator_empty.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_empty.py
@@ -29,6 +29,7 @@ from src.middlewares.error_handler import (
 )
 from src.schemas.search_dto import EMPTY_ANSWER
 from src.services.search_orchestrator import SearchOrchestrator
+from src.services.serving_targets import ServingSearchTargetProvider
 
 USER_ID = uuid4()
 PROJECT_ID = uuid4()
@@ -48,6 +49,7 @@ def _make_orchestrator(
     final_top_k: int = 5,
     rrf_k: int = 60,
     snapshot_ttl_hours: int = 168,
+    serving_targets: ServingSearchTargets | None = None,
 ) -> SearchOrchestrator:
     repo = AsyncMock(spec=SearchRepository)
     repo.check_corpus_readiness.return_value = CorpusReadiness(
@@ -56,14 +58,13 @@ def _make_orchestrator(
     repo.fts_search.return_value = fts_results or []
     repo.ann_search.return_value = ann_results or []
     repo.sot_gate.return_value = sot_records or []
-    repo.get_serving_search_targets = AsyncMock(
-        return_value=ServingSearchTargets(
-            active=ServingSearchTarget(
-                model_version="embedding-v1",
-                index_name="active-index",
-            )
+    loaded_targets = serving_targets or ServingSearchTargets(
+        active=ServingSearchTarget(
+            model_version="embedding-v1",
+            index_name="active-index",
         )
     )
+    repo.get_serving_search_targets = AsyncMock(return_value=loaded_targets)
     repo.save_search_response_snapshot = AsyncMock()
 
     embedding_client = AsyncMock(spec=EmbeddingClient)
@@ -74,8 +75,14 @@ def _make_orchestrator(
     llm_adapter = AsyncMock(spec=LLMAdapter)
     llm_adapter.generate.return_value = LLMGenerationResult(text=llm_text)
 
+    serving_target_provider = ServingSearchTargetProvider(
+        repo,
+        loaded_targets=loaded_targets,
+    )
+
     return SearchOrchestrator(
         repo=repo,
+        serving_target_provider=serving_target_provider,
         embedding_client=embedding_client,
         llm_adapter=llm_adapter,
         search_top_k=search_top_k,
@@ -236,7 +243,7 @@ class TestRetrievalFlow:
             model_version="embedding-v1",
         )
 
-    async def test_active_target_is_loaded_before_retrieval(self) -> None:
+    async def test_active_target_uses_startup_loaded_targets(self) -> None:
         cid = uuid4()
         orch = _make_orchestrator(
             fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
@@ -250,72 +257,15 @@ class TestRetrievalFlow:
             trace_id=TRACE_ID,
         )
 
-        orch._repo.get_serving_search_targets.assert_called_once()
+        orch._repo.get_serving_search_targets.assert_not_called()
 
-    async def test_target_failure_refreshes_model_release_and_retries_once(
+    async def test_target_failure_does_not_refresh_model_release(
         self,
     ) -> None:
-        cid = uuid4()
-        orch = _make_orchestrator(
-            fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
-            sot_records=[_chunk_record(chunk_id=cid)],
-        )
-        orch._repo.get_serving_search_targets.side_effect = [
-            ServingSearchTargets(
-                active=ServingSearchTarget(
-                    model_version="embedding-v1",
-                    index_name="stale-index",
-                )
-            ),
-            ServingSearchTargets(
-                active=ServingSearchTarget(
-                    model_version="embedding-v2",
-                    index_name="fresh-index",
-                )
-            ),
-        ]
-        orch._embedding_client.embed_query.side_effect = [
-            ServiceUnavailableError("Embedding endpoint returned 404"),
-            EmbeddingResult(embedding=[2.0, 0.0, 0.0]),
-        ]
-
-        await orch.execute(
-            user_id=USER_ID,
-            project_id=PROJECT_ID,
-            query="search term",
-            trace_id=TRACE_ID,
-        )
-
-        assert orch._repo.get_serving_search_targets.await_count == 2
-        _, retry_embedding_call = orch._embedding_client.embed_query.await_args_list
-        assert retry_embedding_call.kwargs == {
-            "trace_id": TRACE_ID,
-            "model_version": "embedding-v2",
-        }
-        ann_args = orch._repo.ann_search.call_args
-        _, _, _, retry_index_name = ann_args.args
-        assert retry_index_name == "fresh-index"
-
-    async def test_target_failure_is_not_retried_more_than_once(self) -> None:
         orch = _make_orchestrator()
-        orch._repo.get_serving_search_targets.side_effect = [
-            ServingSearchTargets(
-                active=ServingSearchTarget(
-                    model_version="embedding-v1",
-                    index_name="stale-index",
-                )
-            ),
-            ServingSearchTargets(
-                active=ServingSearchTarget(
-                    model_version="embedding-v2",
-                    index_name="fresh-index",
-                )
-            ),
-        ]
-        orch._embedding_client.embed_query.side_effect = [
-            ServiceUnavailableError("Embedding endpoint returned 404"),
-            ServiceUnavailableError("Embedding endpoint returned 404"),
-        ]
+        orch._embedding_client.embed_query.side_effect = ServiceUnavailableError(
+            "Embedding endpoint returned 404"
+        )
 
         with pytest.raises(ServiceUnavailableError):
             await orch.execute(
@@ -325,8 +275,8 @@ class TestRetrievalFlow:
                 trace_id=TRACE_ID,
             )
 
-        assert orch._repo.get_serving_search_targets.await_count == 2
-        assert orch._embedding_client.embed_query.await_count == 2
+        orch._repo.get_serving_search_targets.assert_not_called()
+        orch._embedding_client.embed_query.assert_awaited_once()
 
     async def test_active_and_previous_targets_use_separate_embeddings_and_ann(
         self,
@@ -338,15 +288,15 @@ class TestRetrievalFlow:
                 _chunk_record(chunk_id=active_chunk_id),
                 _chunk_record(chunk_id=previous_chunk_id),
             ],
-        )
-        orch._repo.get_serving_search_targets.return_value = ServingSearchTargets(
-            active=ServingSearchTarget(
-                model_version="embedding-v2",
-                index_name="active-index-v2",
-            ),
-            previous=ServingSearchTarget(
-                model_version="embedding-v1",
-                index_name="previous-index-v1",
+            serving_targets=ServingSearchTargets(
+                active=ServingSearchTarget(
+                    model_version="embedding-v2",
+                    index_name="active-index-v2",
+                ),
+                previous=ServingSearchTarget(
+                    model_version="embedding-v1",
+                    index_name="previous-index-v1",
+                ),
             ),
         )
         orch._embedding_client.embed_query.side_effect = [
@@ -390,15 +340,15 @@ class TestRetrievalFlow:
                 _chunk_record(chunk_id=shared_chunk_id),
                 _chunk_record(chunk_id=fts_only_chunk_id),
             ],
-        )
-        orch._repo.get_serving_search_targets.return_value = ServingSearchTargets(
-            active=ServingSearchTarget(
-                model_version="embedding-v2",
-                index_name="active-index-v2",
-            ),
-            previous=ServingSearchTarget(
-                model_version="embedding-v1",
-                index_name="previous-index-v1",
+            serving_targets=ServingSearchTargets(
+                active=ServingSearchTarget(
+                    model_version="embedding-v2",
+                    index_name="active-index-v2",
+                ),
+                previous=ServingSearchTarget(
+                    model_version="embedding-v1",
+                    index_name="previous-index-v1",
+                ),
             ),
         )
         orch._embedding_client.embed_query.side_effect = [
@@ -648,15 +598,15 @@ class TestSnapshotPersistence:
         orch = _make_orchestrator(
             fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
             sot_records=[_chunk_record(chunk_id=cid)],
-        )
-        orch._repo.get_serving_search_targets.return_value = ServingSearchTargets(
-            active=ServingSearchTarget(
-                model_version="embedding-v2",
-                index_name="active-index-v2",
-            ),
-            previous=ServingSearchTarget(
-                model_version="embedding-v1",
-                index_name="previous-index-v1",
+            serving_targets=ServingSearchTargets(
+                active=ServingSearchTarget(
+                    model_version="embedding-v2",
+                    index_name="active-index-v2",
+                ),
+                previous=ServingSearchTarget(
+                    model_version="embedding-v1",
+                    index_name="previous-index-v1",
+                ),
             ),
         )
         orch._embedding_client.embed_query.side_effect = [

--- a/services/search-service/tests/unit/test_search_orchestrator_empty.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_empty.py
@@ -6,7 +6,6 @@ LLM 응답 파싱 및 used_refs는 Task 5 (test_search_orchestrator_answer.py).
 """
 
 from datetime import UTC, datetime, timedelta
-from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
@@ -18,6 +17,8 @@ from src.infra.db.search_repository import (
     CorpusReadiness,
     FTSCandidate,
     SearchRepository,
+    ServingSearchTarget,
+    ServingSearchTargets,
 )
 from src.infra.embedding.client import EmbeddingClient, EmbeddingResult
 from src.infra.llm.base import LLMAdapter, LLMGenerationResult
@@ -51,10 +52,12 @@ def _make_orchestrator(
     repo.fts_search.return_value = fts_results or []
     repo.ann_search.return_value = ann_results or []
     repo.sot_gate.return_value = sot_records or []
-    repo.get_active_search_target = AsyncMock(
-        return_value=SimpleNamespace(
-            model_version="embedding-v1",
-            index_name="active-index",
+    repo.get_serving_search_targets = AsyncMock(
+        return_value=ServingSearchTargets(
+            active=ServingSearchTarget(
+                model_version="embedding-v1",
+                index_name="active-index",
+            )
         )
     )
     repo.save_search_response_snapshot = AsyncMock()
@@ -224,7 +227,9 @@ class TestRetrievalFlow:
         )
 
         orch._embedding_client.embed_query.assert_called_once_with(
-            "search term", trace_id=TRACE_ID
+            "search term",
+            trace_id=TRACE_ID,
+            model_version="embedding-v1",
         )
 
     async def test_active_target_is_loaded_before_retrieval(self) -> None:
@@ -241,7 +246,98 @@ class TestRetrievalFlow:
             trace_id=TRACE_ID,
         )
 
-        orch._repo.get_active_search_target.assert_called_once()
+        orch._repo.get_serving_search_targets.assert_called_once()
+
+    async def test_active_and_previous_targets_use_separate_embeddings_and_ann(
+        self,
+    ) -> None:
+        active_chunk_id = uuid4()
+        previous_chunk_id = uuid4()
+        orch = _make_orchestrator(
+            sot_records=[
+                _chunk_record(chunk_id=active_chunk_id),
+                _chunk_record(chunk_id=previous_chunk_id),
+            ],
+        )
+        orch._repo.get_serving_search_targets.return_value = ServingSearchTargets(
+            active=ServingSearchTarget(
+                model_version="embedding-v2",
+                index_name="active-index-v2",
+            ),
+            previous=ServingSearchTarget(
+                model_version="embedding-v1",
+                index_name="previous-index-v1",
+            ),
+        )
+        orch._embedding_client.embed_query.side_effect = [
+            EmbeddingResult(embedding=[2.0, 0.0, 0.0]),
+            EmbeddingResult(embedding=[1.0, 0.0, 0.0]),
+        ]
+        orch._repo.ann_search.side_effect = [
+            [ANNCandidate(chunk_id=active_chunk_id, rank=1)],
+            [ANNCandidate(chunk_id=previous_chunk_id, rank=1)],
+        ]
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="search term",
+            trace_id=TRACE_ID,
+        )
+
+        assert orch._embedding_client.embed_query.await_args_list[0].kwargs == {
+            "trace_id": TRACE_ID,
+            "model_version": "embedding-v2",
+        }
+        assert orch._embedding_client.embed_query.await_args_list[1].kwargs == {
+            "trace_id": TRACE_ID,
+            "model_version": "embedding-v1",
+        }
+        ann_calls = orch._repo.ann_search.await_args_list
+        assert ann_calls[0].args[2] == [2.0, 0.0, 0.0]
+        assert ann_calls[0].args[3] == "active-index-v2"
+        assert ann_calls[1].args[2] == [1.0, 0.0, 0.0]
+        assert ann_calls[1].args[3] == "previous-index-v1"
+
+    async def test_same_chunk_from_active_and_previous_gets_rrf_score_boost(
+        self,
+    ) -> None:
+        shared_chunk_id = uuid4()
+        fts_only_chunk_id = uuid4()
+        orch = _make_orchestrator(
+            fts_results=[FTSCandidate(chunk_id=fts_only_chunk_id, rank=1)],
+            sot_records=[
+                _chunk_record(chunk_id=shared_chunk_id),
+                _chunk_record(chunk_id=fts_only_chunk_id),
+            ],
+        )
+        orch._repo.get_serving_search_targets.return_value = ServingSearchTargets(
+            active=ServingSearchTarget(
+                model_version="embedding-v2",
+                index_name="active-index-v2",
+            ),
+            previous=ServingSearchTarget(
+                model_version="embedding-v1",
+                index_name="previous-index-v1",
+            ),
+        )
+        orch._embedding_client.embed_query.side_effect = [
+            EmbeddingResult(embedding=[2.0]),
+            EmbeddingResult(embedding=[1.0]),
+        ]
+        orch._repo.ann_search.side_effect = [
+            [ANNCandidate(chunk_id=shared_chunk_id, rank=1)],
+            [ANNCandidate(chunk_id=shared_chunk_id, rank=1)],
+        ]
+
+        result = await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="search term",
+            trace_id=TRACE_ID,
+        )
+
+        assert result.chunks[0].chunk_id == shared_chunk_id
 
     async def test_sot_gate_receives_rrf_merged_ids(self) -> None:
         """SOT gate should receive chunk_ids from RRF merge output."""
@@ -466,3 +562,51 @@ class TestSnapshotPersistence:
         )
 
         assert result.chunks
+
+    async def test_snapshot_records_active_and_previous_vector_paths(self) -> None:
+        cid = uuid4()
+        orch = _make_orchestrator(
+            fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
+            sot_records=[_chunk_record(chunk_id=cid)],
+        )
+        orch._repo.get_serving_search_targets.return_value = ServingSearchTargets(
+            active=ServingSearchTarget(
+                model_version="embedding-v2",
+                index_name="active-index-v2",
+            ),
+            previous=ServingSearchTarget(
+                model_version="embedding-v1",
+                index_name="previous-index-v1",
+            ),
+        )
+        orch._embedding_client.embed_query.side_effect = [
+            EmbeddingResult(embedding=[2.0]),
+            EmbeddingResult(embedding=[1.0]),
+        ]
+        orch._repo.ann_search.side_effect = [
+            [],
+            [],
+        ]
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="test",
+            trace_id=TRACE_ID,
+        )
+
+        snapshot = orch._repo.save_search_response_snapshot.call_args.args[0]
+        assert snapshot.active_model_version == "embedding-v2"
+        assert snapshot.active_index_name == "active-index-v2"
+        assert snapshot.served_vector_paths == [
+            {
+                "role": "active",
+                "model_version": "embedding-v2",
+                "index_name": "active-index-v2",
+            },
+            {
+                "role": "previous",
+                "model_version": "embedding-v1",
+                "index_name": "previous-index-v1",
+            },
+        ]

--- a/services/search-service/tests/unit/test_search_orchestrator_empty.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_empty.py
@@ -5,6 +5,8 @@ Tests: no-videos 409, readiness gate 409, final-empty return,
 LLM 응답 파싱 및 used_refs는 Task 5 (test_search_orchestrator_answer.py).
 """
 
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from uuid import UUID, uuid4
 
@@ -40,6 +42,7 @@ def _make_orchestrator(
     search_top_k: int = 20,
     final_top_k: int = 5,
     rrf_k: int = 60,
+    snapshot_ttl_hours: int = 168,
 ) -> SearchOrchestrator:
     repo = AsyncMock(spec=SearchRepository)
     repo.check_corpus_readiness.return_value = CorpusReadiness(
@@ -48,6 +51,13 @@ def _make_orchestrator(
     repo.fts_search.return_value = fts_results or []
     repo.ann_search.return_value = ann_results or []
     repo.sot_gate.return_value = sot_records or []
+    repo.get_active_search_target = AsyncMock(
+        return_value=SimpleNamespace(
+            model_version="embedding-v1",
+            index_name="active-index",
+        )
+    )
+    repo.save_search_response_snapshot = AsyncMock()
 
     embedding_client = AsyncMock(spec=EmbeddingClient)
     embedding_client.embed_query.return_value = EmbeddingResult(
@@ -64,6 +74,7 @@ def _make_orchestrator(
         search_top_k=search_top_k,
         final_top_k=final_top_k,
         rrf_k=rrf_k,
+        snapshot_ttl_hours=snapshot_ttl_hours,
     )
 
 
@@ -200,6 +211,7 @@ class TestRetrievalFlow:
         call_args = orch._repo.ann_search.call_args
         assert call_args[0][0] == USER_ID
         assert call_args[0][1] == PROJECT_ID
+        assert call_args[0][3] == "active-index"
         assert call_args[1]["top_k"] == 15
 
     async def test_embedding_called_with_query(self) -> None:
@@ -214,6 +226,22 @@ class TestRetrievalFlow:
         orch._embedding_client.embed_query.assert_called_once_with(
             "search term", trace_id=TRACE_ID
         )
+
+    async def test_active_target_is_loaded_before_retrieval(self) -> None:
+        cid = uuid4()
+        orch = _make_orchestrator(
+            fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
+            sot_records=[_chunk_record(chunk_id=cid)],
+        )
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="search term",
+            trace_id=TRACE_ID,
+        )
+
+        orch._repo.get_active_search_target.assert_called_once()
 
     async def test_sot_gate_receives_rrf_merged_ids(self) -> None:
         """SOT gate should receive chunk_ids from RRF merge output."""
@@ -366,3 +394,75 @@ class TestReqId:
         orch = _make_orchestrator()
         result = await orch.execute(user_id=USER_ID, project_id=PROJECT_ID, query="test", trace_id=TRACE_ID)
         assert isinstance(result.req_id, UUID)
+
+
+class TestSnapshotPersistence:
+    async def test_success_with_chunks_saves_snapshot_before_return(self) -> None:
+        cid = uuid4()
+        orch = _make_orchestrator(
+            fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
+            sot_records=[_chunk_record(chunk_id=cid)],
+            llm_text=(
+                "<ANSWER>mock answer</ANSWER>\n"
+                '<USED_REFS_JSON>{"used_refs":[1]}</USED_REFS_JSON>'
+            ),
+            snapshot_ttl_hours=12,
+        )
+
+        result = await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="test",
+            trace_id=TRACE_ID,
+        )
+
+        orch._repo.save_search_response_snapshot.assert_called_once()
+        snapshot = orch._repo.save_search_response_snapshot.call_args.args[0]
+        assert snapshot.req_id == result.req_id
+        assert snapshot.user_id == USER_ID
+        assert snapshot.project_id == PROJECT_ID
+        assert snapshot.query_text == "test"
+        assert snapshot.topk_chunk_ids == [str(cid)]
+        assert snapshot.used_chunk_ids == [str(cid)]
+        assert snapshot.active_model_version == "embedding-v1"
+        assert snapshot.active_index_name == "active-index"
+        assert snapshot.served_vector_paths == [
+            {
+                "role": "active",
+                "model_version": "embedding-v1",
+                "index_name": "active-index",
+            }
+        ]
+        assert snapshot.project_serving_state == "SERVABLE"
+        assert snapshot.expires_at > datetime.now(UTC) + timedelta(hours=11)
+
+    async def test_empty_result_does_not_save_snapshot(self) -> None:
+        orch = _make_orchestrator(fts_results=[], ann_results=[])
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="test",
+            trace_id=TRACE_ID,
+        )
+
+        orch._repo.save_search_response_snapshot.assert_not_called()
+
+    async def test_snapshot_write_failure_does_not_block_search_response(self) -> None:
+        cid = uuid4()
+        orch = _make_orchestrator(
+            fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
+            sot_records=[_chunk_record(chunk_id=cid)],
+        )
+        orch._repo.save_search_response_snapshot.side_effect = RuntimeError(
+            "snapshot unavailable"
+        )
+
+        result = await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="test",
+            trace_id=TRACE_ID,
+        )
+
+        assert result.chunks

--- a/services/search-service/tests/unit/test_search_orchestrator_empty.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_empty.py
@@ -22,7 +22,11 @@ from src.infra.db.search_repository import (
 )
 from src.infra.embedding.client import EmbeddingClient, EmbeddingResult
 from src.infra.llm.base import LLMAdapter, LLMGenerationResult
-from src.middlewares.error_handler import NoVideosUploadedError, SearchNotReadyError
+from src.middlewares.error_handler import (
+    NoVideosUploadedError,
+    SearchNotReadyError,
+    ServiceUnavailableError,
+)
 from src.schemas.search_dto import EMPTY_ANSWER
 from src.services.search_orchestrator import SearchOrchestrator
 
@@ -247,6 +251,82 @@ class TestRetrievalFlow:
         )
 
         orch._repo.get_serving_search_targets.assert_called_once()
+
+    async def test_target_failure_refreshes_model_release_and_retries_once(
+        self,
+    ) -> None:
+        cid = uuid4()
+        orch = _make_orchestrator(
+            fts_results=[FTSCandidate(chunk_id=cid, rank=1)],
+            sot_records=[_chunk_record(chunk_id=cid)],
+        )
+        orch._repo.get_serving_search_targets.side_effect = [
+            ServingSearchTargets(
+                active=ServingSearchTarget(
+                    model_version="embedding-v1",
+                    index_name="stale-index",
+                )
+            ),
+            ServingSearchTargets(
+                active=ServingSearchTarget(
+                    model_version="embedding-v2",
+                    index_name="fresh-index",
+                )
+            ),
+        ]
+        orch._embedding_client.embed_query.side_effect = [
+            ServiceUnavailableError("Embedding endpoint returned 404"),
+            EmbeddingResult(embedding=[2.0, 0.0, 0.0]),
+        ]
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="search term",
+            trace_id=TRACE_ID,
+        )
+
+        assert orch._repo.get_serving_search_targets.await_count == 2
+        _, retry_embedding_call = orch._embedding_client.embed_query.await_args_list
+        assert retry_embedding_call.kwargs == {
+            "trace_id": TRACE_ID,
+            "model_version": "embedding-v2",
+        }
+        ann_args = orch._repo.ann_search.call_args
+        _, _, _, retry_index_name = ann_args.args
+        assert retry_index_name == "fresh-index"
+
+    async def test_target_failure_is_not_retried_more_than_once(self) -> None:
+        orch = _make_orchestrator()
+        orch._repo.get_serving_search_targets.side_effect = [
+            ServingSearchTargets(
+                active=ServingSearchTarget(
+                    model_version="embedding-v1",
+                    index_name="stale-index",
+                )
+            ),
+            ServingSearchTargets(
+                active=ServingSearchTarget(
+                    model_version="embedding-v2",
+                    index_name="fresh-index",
+                )
+            ),
+        ]
+        orch._embedding_client.embed_query.side_effect = [
+            ServiceUnavailableError("Embedding endpoint returned 404"),
+            ServiceUnavailableError("Embedding endpoint returned 404"),
+        ]
+
+        with pytest.raises(ServiceUnavailableError):
+            await orch.execute(
+                user_id=USER_ID,
+                project_id=PROJECT_ID,
+                query="search term",
+                trace_id=TRACE_ID,
+            )
+
+        assert orch._repo.get_serving_search_targets.await_count == 2
+        assert orch._embedding_client.embed_query.await_count == 2
 
     async def test_active_and_previous_targets_use_separate_embeddings_and_ann(
         self,

--- a/services/search-service/tests/unit/test_serving_targets.py
+++ b/services/search-service/tests/unit/test_serving_targets.py
@@ -21,87 +21,84 @@ def _targets(version: str = "embedding-v1") -> ServingSearchTargets:
     )
 
 
-class _Clock:
-    def __init__(self) -> None:
-        self.value = 100.0
-
-    def now(self) -> float:
-        return self.value
-
-    def advance(self, seconds: float) -> None:
-        self.value += seconds
-
-
 class TestServingSearchTargetProvider:
     
-    async def test_cache_hit_reuses_serving_targets_without_repo_round_trip(self) -> None:
+    async def test_load_reads_targets_once_and_get_reuses_loaded_targets(self) -> None:
         repo = AsyncMock(spec=SearchRepository)
         repo.get_serving_search_targets.return_value = _targets()
-        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+        provider = ServingSearchTargetProvider(repo)
 
-        first = await provider.get()
-        second = await provider.get()
+        await provider.load()
+        first = provider.get()
+        second = provider.get()
 
         assert first is second
         repo.get_serving_search_targets.assert_awaited_once()
 
-    async def test_expired_cache_reloads_targets(self) -> None:
-        clock = _Clock()
+    async def test_second_load_is_noop(self) -> None:
         repo = AsyncMock(spec=SearchRepository)
-        repo.get_serving_search_targets.side_effect = [
-            _targets("embedding-v1"),
-            _targets("embedding-v2"),
-        ]
+        repo.get_serving_search_targets.return_value = _targets("embedding-v1")
+        provider = ServingSearchTargetProvider(repo)
+
+        await provider.load()
+        await provider.load()
+
+        assert provider.get().active.model_version == "embedding-v1"
+        repo.get_serving_search_targets.assert_awaited_once()
+
+    async def test_reload_replaces_loaded_targets(self) -> None:
+        repo = AsyncMock(spec=SearchRepository)
+        repo.get_serving_search_targets.return_value = _targets("embedding-v2")
         provider = ServingSearchTargetProvider(
             repo,
-            ttl_sec=60,
-            now_func=clock.now,
+            loaded_targets=_targets("embedding-v1"),
         )
 
-        first = await provider.get()
-        clock.advance(61)
-        second = await provider.get()
+        targets = await provider.reload()
 
-        assert first.active.model_version == "embedding-v1"
-        assert second.active.model_version == "embedding-v2"
-        assert repo.get_serving_search_targets.await_count == 2
-    # invalidate()를 호출 테스트
-    async def test_invalidate_forces_next_read_to_reload(self) -> None:
+        assert targets.active.model_version == "embedding-v2"
+        assert provider.get().active.model_version == "embedding-v2"
+        repo.get_serving_search_targets.assert_awaited_once()
+
+    async def test_failed_reload_keeps_existing_targets(self) -> None:
         repo = AsyncMock(spec=SearchRepository)
-        repo.get_serving_search_targets.side_effect = [
-            _targets("embedding-v1"),
-            _targets("embedding-v2"),
-        ]
-        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+        repo.get_serving_search_targets.return_value = None
+        provider = ServingSearchTargetProvider(
+            repo,
+            loaded_targets=_targets("embedding-v1"),
+        )
 
-        first = await provider.get()
-        provider.invalidate()
-        second = await provider.get()
+        with pytest.raises(ServiceUnavailableError, match="ModelRelease"):
+            await provider.reload()
 
-        assert first.active.model_version == "embedding-v1"
-        assert second.active.model_version == "embedding-v2"
-        assert repo.get_serving_search_targets.await_count == 2
+        assert provider.get().active.model_version == "embedding-v1"
+
+    async def test_concurrent_load_uses_single_repo_read(self) -> None:
+        repo = AsyncMock(spec=SearchRepository)
+        repo.get_serving_search_targets.return_value = _targets()
+        provider = ServingSearchTargetProvider(repo)
+
+        await asyncio.gather(
+            provider.load(),
+            provider.load(),
+            provider.load(),
+        )
+
+        assert provider.get().active.model_version == "embedding-v1"
+        repo.get_serving_search_targets.assert_awaited_once()
 
     async def test_missing_model_release_row_raises_service_unavailable(self) -> None:
         repo = AsyncMock(spec=SearchRepository)
         repo.get_serving_search_targets.return_value = None
-        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+        provider = ServingSearchTargetProvider(repo)
 
         with pytest.raises(ServiceUnavailableError, match="ModelRelease"):
-            await provider.get()
+            await provider.load()
     
-    async def test_concurrent_cache_miss_uses_single_repo_read(self) -> None:
+    async def test_get_before_load_raises_service_unavailable(self) -> None:
         repo = AsyncMock(spec=SearchRepository)
-        repo.get_serving_search_targets.return_value = _targets()
-        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+        provider = ServingSearchTargetProvider(repo)
 
-        results = await asyncio.gather(
-            provider.get(),
-            provider.get(),
-            provider.get(),
-        )
-
-        first_result, second_result, third_result = results
-        assert first_result is second_result
-        assert second_result is third_result
-        repo.get_serving_search_targets.assert_awaited_once()
+        with pytest.raises(ServiceUnavailableError, match="not loaded"):
+            provider.get()
+        repo.get_serving_search_targets.assert_not_called()

--- a/services/search-service/tests/unit/test_serving_targets.py
+++ b/services/search-service/tests/unit/test_serving_targets.py
@@ -1,0 +1,107 @@
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from src.infra.db.search_repository import (
+    SearchRepository,
+    ServingSearchTarget,
+    ServingSearchTargets,
+)
+from src.middlewares.error_handler import ServiceUnavailableError
+from src.services.serving_targets import ServingSearchTargetProvider
+
+
+def _targets(version: str = "embedding-v1") -> ServingSearchTargets:
+    return ServingSearchTargets(
+        active=ServingSearchTarget(
+            model_version=version,
+            index_name=f"{version}-index",
+        )
+    )
+
+
+class _Clock:
+    def __init__(self) -> None:
+        self.value = 100.0
+
+    def now(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+class TestServingSearchTargetProvider:
+    
+    async def test_cache_hit_reuses_serving_targets_without_repo_round_trip(self) -> None:
+        repo = AsyncMock(spec=SearchRepository)
+        repo.get_serving_search_targets.return_value = _targets()
+        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+
+        first = await provider.get()
+        second = await provider.get()
+
+        assert first is second
+        repo.get_serving_search_targets.assert_awaited_once()
+
+    async def test_expired_cache_reloads_targets(self) -> None:
+        clock = _Clock()
+        repo = AsyncMock(spec=SearchRepository)
+        repo.get_serving_search_targets.side_effect = [
+            _targets("embedding-v1"),
+            _targets("embedding-v2"),
+        ]
+        provider = ServingSearchTargetProvider(
+            repo,
+            ttl_sec=60,
+            now_func=clock.now,
+        )
+
+        first = await provider.get()
+        clock.advance(61)
+        second = await provider.get()
+
+        assert first.active.model_version == "embedding-v1"
+        assert second.active.model_version == "embedding-v2"
+        assert repo.get_serving_search_targets.await_count == 2
+    # invalidate()를 호출 테스트
+    async def test_invalidate_forces_next_read_to_reload(self) -> None:
+        repo = AsyncMock(spec=SearchRepository)
+        repo.get_serving_search_targets.side_effect = [
+            _targets("embedding-v1"),
+            _targets("embedding-v2"),
+        ]
+        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+
+        first = await provider.get()
+        provider.invalidate()
+        second = await provider.get()
+
+        assert first.active.model_version == "embedding-v1"
+        assert second.active.model_version == "embedding-v2"
+        assert repo.get_serving_search_targets.await_count == 2
+
+    async def test_missing_model_release_row_raises_service_unavailable(self) -> None:
+        repo = AsyncMock(spec=SearchRepository)
+        repo.get_serving_search_targets.return_value = None
+        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+
+        with pytest.raises(ServiceUnavailableError, match="ModelRelease"):
+            await provider.get()
+    
+    async def test_concurrent_cache_miss_uses_single_repo_read(self) -> None:
+        repo = AsyncMock(spec=SearchRepository)
+        repo.get_serving_search_targets.return_value = _targets()
+        provider = ServingSearchTargetProvider(repo, ttl_sec=60)
+
+        results = await asyncio.gather(
+            provider.get(),
+            provider.get(),
+            provider.get(),
+        )
+
+        first_result, second_result, third_result = results
+        assert first_result is second_result
+        assert second_result is third_result
+        repo.get_serving_search_targets.assert_awaited_once()


### PR DESCRIPTION
 ## Summary

  - 임베딩 모델 배포를 위한 전환 중 `active` / `previous` 모델과 index를 함께 검색하도록 `search-service`를 보강 (active: 현재 버전, previous: 이전 버전) 
  - `managed-embedding-endpoint`가 `active` / `previous` / `candidate` 모델 runtime을 동시에 로드하고, 요청의 `model_version` 기준으로 라우팅하도록 변경
  - 모델 전환 전에 previous 모델로 색인한 legacy vector를 새 active index로 재색인하는 흐름 추가(백그라운드에서 주기적으로 체크)
  - legacy 재색인 상태를 추적하기 위한 `vector_index_catalog`, `legacy_reindex_item` DB schema 추가

  - `vector_index_catalog`: vector index별 metadata를 저장하는 테이블입니다. 각 index가 어떤 `model_version`으로 만들어졌는지, embedding dimension이 몇인지, 삭제/retire 대상인지 추적합니
  다.
  - `legacy_reindex_item`: legacy vector 재색인 작업 단위를 저장하는 테이블입니다. 어떤 video를 어느 source index에서 어느 target index로 옮겨야 하는지, 현재 상태가 `PENDING`, `RUNNING`,
  `SUCCEEDED`, `FAILED`, `SKIPPED` 중 무엇인지 추적합니다.


  ## active/previous 인덱스 동시 검색

  기존 검색은 `ModelRelease`의 active model/index 하나만 기준으로 동작했습니다.
  검색 요청이 들어오면 active model로 query embedding을 만들고, active index에서만 ANN 검색을 수행했습니다.

  이번 변경 후에는 `search-service`가 active index와 previous index를 함께 검색할 수 있습니다.
  목적은 임베딩 모델 전환 직후에도 이전 index에만 남아 있는 vector를 검색 결과에서 놓치지 않기 위함입니다.

  동작 흐름은 다음과 같습니다.

  1. 검색 요청이 들어오면 `search-service`가 `ModelRelease`를 읽습니다.
  2. `active_model_version` / `active_index_name`을 기본 검색 target으로 사용합니다.
  3. `previous_model_version` / `previous_index_name`이 있으면 previous target도 함께 사용합니다.
  4. 각 target의 `model_version`으로 query embedding을 따로 생성합니다.
  5. active query embedding은 active index 검색에만 사용합니다.
  6. previous query embedding은 previous index 검색에만 사용합니다.
  7. active ANN 결과와 previous ANN 결과를 하나로 합칩니다.
  8. 합쳐진 ANN 결과를 기존 FTS 결과와 함께 rank merge합니다.
  9. 최종 검색 응답 snapshot에는 실제 검색에 사용한 model/index 경로를 `served_vector_paths`로 저장합니다.

  중요한 규칙은 다음과 같습니다.

  - `candidate` index는 검색에 사용하지 않습니다.
  - `candidate`는 배포 준비 중인 모델/index이며, 실제 검색 대상은 active와 previous입니다.
  - previous 정보가 없으면 기존처럼 active index만 검색합니다.
  - 서로 다른 model version의 embedding vector를 섞어 쓰지 않습니다.
  - query embedding은 반드시 같은 model version으로 만든 index에만 사용합니다.

  이 변경으로 검색 snapshot에는 “이 응답이 어떤 model/index 경로를 거쳐 만들어졌는지”가 남습니다.
  이 기록은 이후 모델 전환, rollback, 검색 품질 분석에서 기준 데이터로 사용할 수 있습니다.

## Managed Embedding Endpoint 다중 모델 런타임 로드 및 라우팅

  기존 `managed-embedding-endpoint`는 하나의 모델 runtime만 들고 있다고 가정했습니다.
  `/embed` 요청도 별도 `model_version`을 받지 않았고, `/health`도 단일 model version만 반환했습니다.

  이번 변경 후에는 endpoint가 여러 model version의 runtime을 동시에 들 수 있습니다.
  이 변경의 목적은 두 가지입니다.

  1. `search-service`가 active/previous index를 함께 검색할 때, 각 index에 맞는 model version으로 query embedding을 만들 수 있게 합니다.
  2. candidate release가 열린 뒤 cutover 전까지 ingest되는 video를 active index와 candidate index에 인덱싱할 수 있게 합니다.

  변경 후 endpoint가 다루는 runtime은 다음과 같습니다.

  - `active`: 현재 검색과 신규 video ingest를 위한모델입니다.
  - `previous`: 새모델 배포 이후 이전 index를 함께 검색하기 위한 모델입니다.
  - `candidate`: cutover 전 dual write와 배포 준비를 위한 모델입니다.

  동작 흐름은 다음과 같습니다.

  1. endpoint가 시작되면 기본 model artifact를 로드합니다.
  2. startup 과정에서 `ModelRelease`를 읽고 active/previous/candidate `model_version`을 확인합니다.
  3. 각 `model_version`을 `MODEL_ARTIFACT_ROOT/<model_version>` 경로로 해석해서 로드할 model artifact 위치를 찾습니다.
  4. 해당 경로의 artifact를 `ModelLoader`로 로드해서 runtime을 만듭니다.
  5. 이미 같은 `model_version`의 runtime이 로드되어 있으면 새로 로드하지 않고 재사용합니다.
  6. 로드가 끝나면 `RuntimeRegistry`에 준비된 runtime 목록을 교체합니다.
  7. `ModelState`에는 현재 준비된 model version 목록을 저장합니다.
  8. `/health`는 단일 `model_version` 대신 `ready_model_versions`를 반환합니다.
  9. `/embed` 요청은 body의 `model_version`을 보고 해당 runtime으로 라우팅합니다..

  요청 데이터 흐름은 다음과 같습니다.

  1. client가 `/embed`에 `texts`와 `model_version`을 보냅니다.
  2. endpoint는 `RuntimeRegistry`에서 해당 `model_version`의 runtime을 찾습니다.
  3. runtime이 있으면 그 모델로 embedding을 생성합니다.
  4. runtime이 없으면 `503`을 반환합니다.

  중요한 규칙은 다음과 같습니다.

  - active model 로드 실패는 서비스 제공에 영향을 주는 실패로 봅니다.
  - previous 또는 candidate model 로드 실패는 active model 제공을 막지 않습니다.
  - previous/candidate는 준비되면 사용할 수 있고, 실패하면 ready 목록에서 빠집니다.
  - `/embed`는 더 이상 “현재 모델 하나”에 의존하지 않습니다.
  - 호출자는 embedding을 만들 `model_version`을 명시해야 합니다.

## Legacy Vector 재색인 지원

  기존에는 새 모델로 전환하기 전에 두 가지만 확인했습니다. candidate 모델이 요청을 처리할 수 있는지, 그리고 candidate index에 전환 이후 필요한 vector가 들어 있는지입니다.
   하지만 이전 index에만 남아 있고 새 active index에는 없는 legacy vector를 찾아서 새 index에 채우는 흐름은 아직 없었습니다.

 재색인 대상 생성 흐름은 다음과 같습니다.

  1. 백그라운드 scheduler가 정해진 주기마다 재색인이 필요한 대상이 있는지 확인합니다.
     - 기본 주기는 `LEGACY_REINDEX_SCAN_INTERVAL_SEC`로 설정합니다.
     - 여러 worker가 동시에 떠 있어도 하나만 처리하도록 lock을 먼저 잡습니다.
     - lock을 잡지 못한 worker는 이번 주기 작업을 건너뜁니다.

  2. 현재 기준이 되는 모델과 index를 확인합니다.
     - 현재 active model version으로 새 embedding을 만듭니다.
     - 현재 active index에 새 vector를 저장합니다.

  3. 그 다음 재색인이 필요한 과거 index를 찾습니다.
     - 현재 active index는 제외합니다.
     - 배포 준비 중인 candidate index가 있으면 제외합니다.
     - 남은 과거 index가 재색인 source 후보가 됩니다.

  4. 과거 index마다 video 단위로 재색인이 필요한 대상을 찾습니다.
     - 과거 index에는 해당 video의 vector가 있어야 합니다.
     - 현재 active index에는 아직 해당 video의 vector가 없어야 합니다.
     - video 자체는 전처리가 끝난 `READY` 상태여야 합니다.

  5. 조건을 만족한 video는 재색인 대상으로 등록합니다.

  6. 재색인 대상 video마다 `legacy_reindex_item`을 생성합니다.
     - 어떤 video를 재색인할지 저장합니다.
     - 어느 과거 index에서 발견된 video인지 저장합니다.
     - 어느 active index로 새 vector를 넣을지 저장합니다.
     - 어떤 모델 버전으로 새 embedding을 만들지 저장합니다.

  7. 새 작업의 상태는 `PENDING`입니다.
     - `PENDING`은 재색인 대상으로 등록됐지만 아직 처리 시작 전이라는 뜻입니다.

  8. 같은 video를 같은 과거 index에서 같은 active index로 옮기는 작업이 이미 있으면 새로 만들지 않습니다.
     - worker가 여러 개 떠 있어도 같은 재색인 작업이 중복으로 쌓이지 않게 하기 위한 규칙입니다.

  배포와 연관되는 규칙은 다음과 같습니다.

  - 배포 전에 아직 색인 되지 않은 벡터가 남아 있는지 확인합니다.
  - 남아 있으면 `legacy_reindex_item`을 생성하고 배포를 막습니다.
    => a->b->c 순으로 배포가 이루어지면 버전업이 될때 a모델로 인덱싱한 데이터는 더이상 검색범위에 포함되지 않기 때문에 c 모델이 배포되기전 a모델로 인덱싱한 데이터를 모두 재색인 해야합니다.
  - 이때 배포 결과는 `blocked_legacy_vectors_remain`으로 반환됩니다.
  - 오래된 벡터가 가 모두 target active index에 들어간 뒤에야 배포가 진행될 수 있습니다.

  ## Review scope

  ### 핵심 비즈니스 로직

  search-service — active/previous 검색 경로
  - `services/search-service/src/infra/db/search_repository.py`
  - `services/search-service/src/infra/embedding/client.py`
  - `services/search-service/src/services/search_orchestrator.py`

  managed-embedding-endpoint — 모델 runtime reload 및 routing
  - `services/managed-embedding-endpoint/src/core/bootstrap.py`
  - `services/managed-embedding-endpoint/src/core/model_state.py`
  - `services/managed-embedding-endpoint/src/core/runtime_registry.py`
  - `services/managed-embedding-endpoint/src/core/artifact_resolver.py`
  - `services/managed-embedding-endpoint/src/infra/release_repository.py`
  - `services/managed-embedding-endpoint/src/services/inference_service.py`
  - `services/managed-embedding-endpoint/src/services/model_reloader.py`
  - `services/managed-embedding-endpoint/src/api/v1/routers/embed.py`
  - `services/managed-embedding-endpoint/src/api/v1/routers/internal.py`

  feedback-loop-pipeline — legacy 재색인 및 cutover gate
  - `services/feedback-loop-pipeline/src/release/legacy_reindex.py`
  - `services/feedback-loop-pipeline/src/release/transition.py`
  - `services/feedback-loop-pipeline/src/infra/db/legacy_reindex_store.py`
  - `services/feedback-loop-pipeline/src/infra/db/legacy_reindex_lock.py`

  core-api / feedback-loop-pipeline — 재색인 metadata schema
  - `services/core-api/alembic/versions/0005_legacy_reindex_metadata.py`
  - `services/core-api/src/models/admin_ops.py`
  - `services/feedback-loop-pipeline/src/infra/db/models.py`

  ### 핵심 로직 검증 테스트

  search-service
  - `services/search-service/tests/api/test_search.py`
  - `services/search-service/tests/integration/test_search_repository.py`
  - `services/search-service/tests/unit/test_embedding_client.py`
  - `services/search-service/tests/unit/test_search_orchestrator_answer.py`
  - `services/search-service/tests/unit/test_search_orchestrator_empty.py`

  managed-embedding-endpoint
  - `services/managed-embedding-endpoint/tests/api/test_embed.py`
  - `services/managed-embedding-endpoint/tests/api/test_health.py`
  - `services/managed-embedding-endpoint/tests/api/test_reload_models.py`
  - `services/managed-embedding-endpoint/tests/unit/test_artifact_resolver.py`
  - `services/managed-embedding-endpoint/tests/unit/test_embed_dto.py`
  - `services/managed-embedding-endpoint/tests/unit/test_inference_service.py`
  - `services/managed-embedding-endpoint/tests/unit/test_model_release_seed.py`
  - `services/managed-embedding-endpoint/tests/unit/test_model_runtime_reloader.py`
  - `services/managed-embedding-endpoint/tests/unit/test_model_state.py`
  - `services/managed-embedding-endpoint/tests/unit/test_startup_reload.py`

  feedback-loop-pipeline
  - `services/feedback-loop-pipeline/tests/integration/test_candidate_release_flow.py`
  - `services/feedback-loop-pipeline/tests/integration/test_legacy_reindex_flow.py`
  - `services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_lock.py`
  - `services/feedback-loop-pipeline/tests/unit/test_legacy_reindex_scheduler.py`
  - `services/feedback-loop-pipeline/tests/unit/test_settings.py`

  core-api
  - `services/core-api/tests/integration/test_admin_ops_foundation_schema.py`

  ### 보조 구현 및 운영 파일

  managed-embedding-endpoint
  - `services/managed-embedding-endpoint/src/main.py`
  - `services/managed-embedding-endpoint/src/api/v1/router.py`
  - `services/managed-embedding-endpoint/src/core/settings.py`
  - `services/managed-embedding-endpoint/src/infra/model_loader.py`
  - `services/managed-embedding-endpoint/src/schemas/embed_dto.py`
  - `services/managed-embedding-endpoint/pyproject.toml`
  - `services/managed-embedding-endpoint/poetry.lock`

  feedback-loop-pipeline
  - `services/feedback-loop-pipeline/src/config/settings.py`
  - `services/feedback-loop-pipeline/pyproject.toml`
  - `services/feedback-loop-pipeline/poetry.lock`

  pipeline-worker — endpoint health 계약 변경 반영
  - `services/pipeline-worker/src/infra/ai/embedding_client.py`
  - `services/pipeline-worker/tools/fake_embedding_server.py`
  - `services/pipeline-worker/tests/support.py`
  - `services/pipeline-worker/tests/unit/test_embedding_client.py`

  ## Note

- 재색인 대상 탐색과 처리 로직은 추가했습니다.
 - 하지만 서비스가 뜰 때 이 재색인 scheduler를 자동으로 켜는 연결 코드는 아직 후속 작업으로 남아 있습니다.
  ## Issue

  Closes #88