### PR TITLE
fix(repo): 영상 실패 사유를 저장하고 화면에 표시 [#100]

### DIFF
--- a/frontend/src/components/SearchPanel.tsx
+++ b/frontend/src/components/SearchPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
+import { userMessageFor } from "@/lib/api/error-message";
 import type {
   FeedbackRating,
   SearchChunk,
@@ -55,13 +56,6 @@ function feedbackErrorMessage(error: unknown): string {
     return "이 답변에는 지금 피드백을 남길 수 없습니다.";
   }
   return "피드백 전송에 실패했습니다.";
-}
-
-function searchErrorMessage(error: unknown): string {
-  if (typeof error === "object" && error !== null && "status" in error && error.status === 503) {
-    return "검색 요청이 몰리고 있습니다. 잠시 후 다시 시도해 주세요.";
-  }
-  return "검색에 실패했습니다.";
 }
 
 function FeedbackButtons({
@@ -296,7 +290,7 @@ export function SearchPanel({
       setTurns((prev) => prev.map((t) => (t.id === turnId ? { ...t, result } : t)));
     } catch (error) {
       setTurns((prev) =>
-        prev.map((t) => (t.id === turnId ? { ...t, error: searchErrorMessage(error) } : t))
+        prev.map((t) => (t.id === turnId ? { ...t, error: userMessageFor(error, "search") } : t))
       );
     } finally {
       setLoading(false);

--- a/frontend/src/components/VideoSourcePanel.tsx
+++ b/frontend/src/components/VideoSourcePanel.tsx
@@ -1,13 +1,19 @@
 "use client";
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useVideoStatusPolling } from "@/hooks/useVideoStatusPolling";
 import { api } from "@/lib/api";
-import { userMessageFor } from "@/lib/api/error-message";
+import { userMessageFor, videoFailureMessage } from "@/lib/api/error-message";
 import { HttpError } from "@/lib/api/http";
 import {
   SUPPORTED_VIDEO_EXTENSIONS,
   validateUploadFile,
 } from "@/lib/api/upload-constraints";
+import {
+  forgetUploadCompletion,
+  pendingUploadCompletionIds,
+  rememberUploadCompletion,
+} from "@/lib/upload-completion-store";
 import type { FormEvent } from "react";
 import type { UploadVideoInput, Video, VideoStatus } from "@/lib/api/types";
 
@@ -39,7 +45,7 @@ function isYoutubeUrl(value: string) {
 type UploadState = {
   video: Video;
   progress: number;
-  phase: "uploading" | "failed";
+  phase: "uploading" | "checking" | "failed";
 };
 
 type UploadPreparation =
@@ -48,6 +54,28 @@ type UploadPreparation =
 
 function upsertVideo(videos: Video[], nextVideo: Video) {
   return [nextVideo, ...videos.filter((video) => video.id !== nextVideo.id)];
+}
+
+function isCompletionRetryable(error: unknown): boolean {
+  return !(error instanceof HttpError) || error.status >= 500;
+}
+
+function videoStatusLabel(video: Video): string {
+  if (video.status !== "FAILED") return STATUS_LABEL[video.status];
+  if (video.failureCode) {
+    return videoFailureMessage(video.failureCode, video.failureTraceId);
+  }
+  return video.failedStage === "DOWNLOAD"
+    ? "다운로드 실패 · 파일 업로드를 이용해 주세요"
+    : STATUS_LABEL.FAILED;
+}
+
+function needsStatusPolling(videos: Video[], uploadStates: Record<string, UploadState>): boolean {
+  if (Object.values(uploadStates).some((state) => state.phase === "checking")) return true;
+  return videos.some((video) => {
+    if (video.status === "UPLOADED" || video.status === "PROCESSING") return true;
+    return video.status === "PENDING" && !uploadStates[video.id];
+  });
 }
 
 function prepareUploadInput(
@@ -83,9 +111,14 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
   const [selectedVideoIds, setSelectedVideoIds] = useState<Set<string>>(new Set());
   const [deleting, setDeleting] = useState(false);
   const [creating, setCreating] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
   const mountedRef = useRef(true);
   const creatingRef = useRef(false);
+  const uploadStatesRef = useRef<Record<string, UploadState>>({});
+  const requestSequenceRef = useRef(0);
+  const mutationVersionRef = useRef(0);
+  const completionRequestsRef = useRef(new Set<string>());
 
   useEffect(() => {
     mountedRef.current = true;
@@ -94,20 +127,138 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
     };
   }, []);
 
-  const refresh = useCallback(() => {
-    api
-      .listVideos(projectId)
-      .then((nextVideos) => {
-        if (mountedRef.current) setVideos(nextVideos);
-      })
-      .catch(() => {
-        if (mountedRef.current) setError("영상을 불러오지 못했습니다.");
+  const updateUploadStates = useCallback(
+    (updater: (current: Record<string, UploadState>) => Record<string, UploadState>) => {
+      setUploadStates((current) => {
+        const next = updater(current);
+        uploadStatesRef.current = next;
+        return next;
       });
-  }, [projectId]);
+    },
+    []
+  );
+
+  const removeUploadState = useCallback(
+    (videoId: string) => {
+      updateUploadStates((current) => {
+        if (!current[videoId]) return current;
+        const next = { ...current };
+        delete next[videoId];
+        return next;
+      });
+    },
+    [updateUploadStates]
+  );
+
+  const markUploadFailed = useCallback(
+    (videoId: string, uploadError: unknown) => {
+      updateUploadStates((current) => {
+        const uploadState = current[videoId];
+        if (!uploadState) return current;
+        if (uploadError instanceof HttpError && uploadError.code === "FILE_TOO_LARGE") {
+          const next = { ...current };
+          delete next[videoId];
+          return next;
+        }
+        return { ...current, [videoId]: { ...uploadState, phase: "failed" } };
+      });
+    },
+    [updateUploadStates]
+  );
+
+  const recoverCompletion = useCallback(
+    async (videoId: string) => {
+      if (completionRequestsRef.current.has(videoId)) return;
+      completionRequestsRef.current.add(videoId);
+      try {
+        const completion = await api.completeVideo(videoId);
+        forgetUploadCompletion(projectId, videoId);
+        if (!mountedRef.current) return;
+        const localVideo = uploadStatesRef.current[videoId]?.video;
+        removeUploadState(videoId);
+        if (localVideo) {
+          mutationVersionRef.current += 1;
+          setVideos((current) =>
+            upsertVideo(current, { ...localVideo, status: completion.status })
+          );
+        } else {
+          setVideos((current) =>
+            current.map((video) =>
+              video.id === videoId ? { ...video, status: completion.status } : video
+            )
+          );
+        }
+      } catch (completionError) {
+        if (isCompletionRetryable(completionError)) return;
+        forgetUploadCompletion(projectId, videoId);
+        if (!mountedRef.current) return;
+        markUploadFailed(videoId, completionError);
+        setActionError(userMessageFor(completionError, "upload"));
+      } finally {
+        completionRequestsRef.current.delete(videoId);
+      }
+    },
+    [markUploadFailed, projectId, removeUploadState]
+  );
+
+  const reconcileUploadCompletions = useCallback(
+    async (nextVideos: Video[]) => {
+      const listedById = new Map(nextVideos.map((video) => [video.id, video]));
+      const checkingIds = Object.values(uploadStatesRef.current)
+        .filter((state) => state.phase === "checking")
+        .map((state) => state.video.id);
+      const completionIds = new Set([
+        ...pendingUploadCompletionIds(projectId),
+        ...checkingIds,
+      ]);
+      const recoveries: Promise<void>[] = [];
+      for (const videoId of completionIds) {
+        const listedVideo = listedById.get(videoId);
+        if (listedVideo && !["PENDING", "UPLOADED"].includes(listedVideo.status)) {
+          forgetUploadCompletion(projectId, videoId);
+          removeUploadState(videoId);
+          continue;
+        }
+        recoveries.push(recoverCompletion(videoId));
+      }
+      await Promise.all(recoveries);
+    },
+    [projectId, recoverCompletion, removeUploadState]
+  );
+
+  const refresh = useCallback(async () => {
+    const requestSequence = ++requestSequenceRef.current;
+    const mutationVersion = mutationVersionRef.current;
+    try {
+      const nextVideos = await api.listVideos(projectId);
+      if (
+        !mountedRef.current ||
+        requestSequence !== requestSequenceRef.current ||
+        mutationVersion !== mutationVersionRef.current
+      ) {
+        return;
+      }
+      setVideos(nextVideos);
+      setRefreshError(null);
+      await reconcileUploadCompletions(nextVideos);
+    } catch {
+      if (mountedRef.current && requestSequence === requestSequenceRef.current) {
+        setRefreshError("영상 상태를 갱신하지 못했습니다. 잠시 후 다시 시도합니다.");
+      }
+    }
+  }, [projectId, reconcileUploadCompletions]);
 
   useEffect(() => {
-    refresh();
+    const timer = setTimeout(() => void refresh(), 0);
+    return () => clearTimeout(timer);
   }, [refresh]);
+
+  const hasPendingUploadCompletion = pendingUploadCompletionIds(projectId).length > 0;
+  const pollingEnabled = useMemo(
+    () => hasPendingUploadCompletion || needsStatusPolling(videos, uploadStates),
+    [hasPendingUploadCompletion, uploadStates, videos]
+  );
+  useVideoStatusPolling({ enabled: pollingEnabled, refresh });
 
   const displayVideos = useMemo(() => {
     const listedVideoIds = new Set(videos.map((video) => video.id));
@@ -137,58 +288,60 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
     setFileInputKey((prev) => prev + 1);
   }
 
-  function removeUploadState(videoId: string) {
-    setUploadStates((prev) => {
-      if (!prev[videoId]) return prev;
-      const next = { ...prev };
-      delete next[videoId];
-      return next;
-    });
-  }
-
-  function markUploadFailed(videoId: string, uploadError: unknown) {
-    setUploadStates((prev) => {
-      const current = prev[videoId];
-      if (!current) return prev;
-      if (uploadError instanceof HttpError && uploadError.code === "FILE_TOO_LARGE") {
-        const next = { ...prev };
-        delete next[videoId];
-        return next;
-      }
-      return { ...prev, [videoId]: { ...current, phase: "failed" } };
-    });
-  }
-
   async function uploadFile(input: Extract<UploadVideoInput, { kind: "file" }>) {
     let createdVideoId: string | null = null;
+    let uploadTransferred = false;
     try {
       const video = await api.uploadVideo(projectId, input, {
         onUploadCreated: (createdVideo) => {
           createdVideoId = createdVideo.id;
+          mutationVersionRef.current += 1;
           finishVideoCreate();
           if (!mountedRef.current) return;
-          setUploadStates((prev) => ({
-            ...prev,
+          updateUploadStates((current) => ({
+            ...current,
             [createdVideo.id]: { video: createdVideo, progress: 0, phase: "uploading" },
           }));
         },
         onProgress: (percent) => {
           const videoId = createdVideoId;
           if (!videoId || !mountedRef.current) return;
-          setUploadStates((prev) => {
-            const current = prev[videoId];
-            if (!current) return prev;
+          updateUploadStates((current) => {
+            const uploadState = current[videoId];
+            if (!uploadState) return current;
             return {
-              ...prev,
-              [videoId]: { ...current, progress: percent, phase: "uploading" },
+              ...current,
+              [videoId]: { ...uploadState, progress: percent, phase: "uploading" },
+            };
+          });
+        },
+        onUploadTransferred: (createdVideo) => {
+          uploadTransferred = true;
+          rememberUploadCompletion(projectId, createdVideo.id);
+          if (!mountedRef.current) return;
+          updateUploadStates((current) => {
+            const uploadState = current[createdVideo.id];
+            if (!uploadState) return current;
+            return {
+              ...current,
+              [createdVideo.id]: { ...uploadState, progress: 100, phase: "checking" },
             };
           });
         },
       });
       if (!mountedRef.current) return;
-      if (createdVideoId) removeUploadState(createdVideoId);
+      if (createdVideoId) {
+        forgetUploadCompletion(projectId, createdVideoId);
+        removeUploadState(createdVideoId);
+      }
+      mutationVersionRef.current += 1;
       setVideos((prev) => upsertVideo(prev, video));
     } catch (uploadError) {
+      if (uploadTransferred && isCompletionRetryable(uploadError)) {
+        await refresh();
+        return;
+      }
+      if (createdVideoId) forgetUploadCompletion(projectId, createdVideoId);
       if (mountedRef.current && createdVideoId) markUploadFailed(createdVideoId, uploadError);
       throw uploadError;
     }
@@ -200,15 +353,18 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
       return;
     }
     const video = await api.uploadVideo(projectId, input);
-    if (mountedRef.current) setVideos((prev) => upsertVideo(prev, video));
+    if (mountedRef.current) {
+      mutationVersionRef.current += 1;
+      setVideos((prev) => upsertVideo(prev, video));
+    }
   }
 
   async function onUpload(e: FormEvent) {
     e.preventDefault();
-    setError(null);
+    setActionError(null);
     const preparation = prepareUploadInput(tab, title, sourceUrl, file);
     if (!preparation.ok) {
-      if (preparation.error) setError(preparation.error);
+      if (preparation.error) setActionError(preparation.error);
       return;
     }
     if (!beginVideoCreate()) return;
@@ -217,14 +373,14 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
     try {
       await runUpload(preparation.input);
     } catch (uploadError) {
-      if (mountedRef.current) setError(userMessageFor(uploadError, "upload"));
+      if (mountedRef.current) setActionError(userMessageFor(uploadError, "upload"));
     } finally {
       finishVideoCreate();
     }
   }
 
   function toggleVideo(videoId: string) {
-    if (uploadStates[videoId]?.phase === "uploading") return;
+    if (["uploading", "checking"].includes(uploadStates[videoId]?.phase ?? "")) return;
     setSelectedVideoIds((prev) => {
       const next = new Set(prev);
       if (next.has(videoId)) {
@@ -242,17 +398,19 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
     setDeleting(true);
     try {
       await api.deleteVideos(targets);
+      mutationVersionRef.current += 1;
       setVideos((prev) => prev.filter((video) => !selectedVideoIds.has(video.id)));
-      setUploadStates((prev) => {
-        const next = { ...prev };
+      updateUploadStates((current) => {
+        const next = { ...current };
         for (const videoId of targets) {
           delete next[videoId];
+          forgetUploadCompletion(projectId, videoId);
         }
         return next;
       });
       setSelectedVideoIds(new Set());
     } catch {
-      setError("영상 삭제 요청에 실패했습니다.");
+      setActionError("영상 삭제 요청에 실패했습니다.");
     } finally {
       setDeleting(false);
     }
@@ -271,7 +429,11 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
           >
             삭제
           </button>
-          <button type="button" onClick={refresh} className="text-xs text-gray-500 underline">
+          <button
+            type="button"
+            onClick={() => void refresh()}
+            className="text-xs text-gray-500 underline"
+          >
             새로고침
           </button>
         </div>
@@ -347,26 +509,30 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
         </button>
       </form>
 
-      {error && <p className="text-sm text-red-600">{error}</p>}
+      {actionError && <p className="text-sm text-red-600">{actionError}</p>}
+      {refreshError && <p className="text-xs text-amber-700">{refreshError}</p>}
 
       <ul className="flex flex-col gap-2 overflow-auto">
         {displayVideos.map((video) => {
           const uploadState = uploadStates[video.id];
           const isUploading = uploadState?.phase === "uploading";
+          const isUploadBusy = isUploading || uploadState?.phase === "checking";
           return (
-            <li key={video.id} className="flex items-center gap-2 rounded border p-2 text-sm">
+            <li key={video.id} className="flex items-start gap-2 rounded border p-2 text-sm">
               <input
                 type="checkbox"
                 aria-label={`${video.title} 선택`}
-                checked={!isUploading && selectedVideoIds.has(video.id)}
-                disabled={isUploading}
+                checked={!isUploadBusy && selectedVideoIds.has(video.id)}
+                disabled={isUploadBusy}
                 onChange={() => toggleVideo(video.id)}
-                className="size-4 shrink-0"
+                className="mt-0.5 size-4 shrink-0"
               />
-              <span className="min-w-0 flex-1 truncate">{video.title}</span>
-              <span className="ml-2 shrink-0 text-xs text-gray-500">
+              <span className="min-w-0 flex-1 break-words">{video.title}</span>
+              <span className="ml-2 max-w-[55%] break-all text-right text-xs text-gray-500">
                 {uploadState?.phase === "uploading" ? (
                   `업로드 중 ${uploadState.progress}%`
+                ) : uploadState?.phase === "checking" ? (
+                  "업로드 완료 확인 중"
                 ) : uploadState?.phase === "failed" ? (
                   "업로드 실패"
                 ) : video.status === "PROCESSING" ? (
@@ -377,10 +543,8 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
                     />
                     처리중
                   </span>
-                ) : video.status === "FAILED" && video.failedStage === "DOWNLOAD" ? (
-                  "다운로드 실패 · 파일 업로드를 이용해 주세요"
                 ) : (
-                  STATUS_LABEL[video.status]
+                  videoStatusLabel(video)
                 )}
               </span>
             </li>

--- a/frontend/src/components/VideoSourcePanel.tsx
+++ b/frontend/src/components/VideoSourcePanel.tsx
@@ -2,6 +2,12 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "@/lib/api";
+import { userMessageFor } from "@/lib/api/error-message";
+import { HttpError } from "@/lib/api/http";
+import {
+  SUPPORTED_VIDEO_EXTENSIONS,
+  validateUploadFile,
+} from "@/lib/api/upload-constraints";
 import type { FormEvent } from "react";
 import type { UploadVideoInput, Video, VideoStatus } from "@/lib/api/types";
 
@@ -36,8 +42,34 @@ type UploadState = {
   phase: "uploading" | "failed";
 };
 
+type UploadPreparation =
+  | { ok: true; input: UploadVideoInput }
+  | { ok: false; error?: string };
+
 function upsertVideo(videos: Video[], nextVideo: Video) {
   return [nextVideo, ...videos.filter((video) => video.id !== nextVideo.id)];
+}
+
+function prepareUploadInput(
+  tab: "file" | "url",
+  title: string,
+  sourceUrl: string,
+  file: File | null
+): UploadPreparation {
+  const name = title.trim();
+  if (!name) return { ok: false };
+  if (tab === "url") {
+    const url = sourceUrl.trim();
+    if (!url) return { ok: false };
+    return isYoutubeUrl(url)
+      ? { ok: true, input: { kind: "url", sourceUrl: url, title: name } }
+      : { ok: false, error: "YouTube URL만 등록할 수 있습니다." };
+  }
+  if (!file) return { ok: false };
+  const validation = validateUploadFile(file);
+  return validation.ok
+    ? { ok: true, input: { kind: "file", file, title: name } }
+    : { ok: false, error: userMessageFor(validation.code, "upload") };
 }
 
 export function VideoSourcePanel({ projectId }: { projectId: string }) {
@@ -50,8 +82,10 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
   const [fileInputKey, setFileInputKey] = useState(0);
   const [selectedVideoIds, setSelectedVideoIds] = useState<Set<string>>(new Set());
   const [deleting, setDeleting] = useState(false);
+  const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const mountedRef = useRef(true);
+  const creatingRef = useRef(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -83,40 +117,55 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
     return [...localUploadVideos, ...videos];
   }, [uploadStates, videos]);
 
-  async function onUpload(e: FormEvent) {
-    e.preventDefault();
-    setError(null);
-    const name = title.trim();
-    if (!name) return;
-    let input: UploadVideoInput;
-    if (tab === "url") {
-      const url = sourceUrl.trim();
-      if (!url) return;
-      if (!isYoutubeUrl(url)) {
-        setError("YouTube URL만 등록할 수 있습니다.");
-        return;
-      }
-      input = { kind: "url", sourceUrl: url, title: name };
-    } else {
-      if (!file) return;
-      input = { kind: "file", file, title: name };
-    }
+  function beginVideoCreate(): boolean {
+    if (creatingRef.current) return false;
+    creatingRef.current = true;
+    setCreating(true);
+    return true;
+  }
+
+  function finishVideoCreate() {
+    if (!creatingRef.current) return;
+    creatingRef.current = false;
+    if (mountedRef.current) setCreating(false);
+  }
+
+  function resetUploadForm() {
     setTitle("");
     setSourceUrl("");
     setFile(null);
     setFileInputKey((prev) => prev + 1);
+  }
 
+  function removeUploadState(videoId: string) {
+    setUploadStates((prev) => {
+      if (!prev[videoId]) return prev;
+      const next = { ...prev };
+      delete next[videoId];
+      return next;
+    });
+  }
+
+  function markUploadFailed(videoId: string, uploadError: unknown) {
+    setUploadStates((prev) => {
+      const current = prev[videoId];
+      if (!current) return prev;
+      if (uploadError instanceof HttpError && uploadError.code === "FILE_TOO_LARGE") {
+        const next = { ...prev };
+        delete next[videoId];
+        return next;
+      }
+      return { ...prev, [videoId]: { ...current, phase: "failed" } };
+    });
+  }
+
+  async function uploadFile(input: Extract<UploadVideoInput, { kind: "file" }>) {
     let createdVideoId: string | null = null;
     try {
-      if (input.kind === "url") {
-        const video = await api.uploadVideo(projectId, input);
-        if (mountedRef.current) setVideos((prev) => upsertVideo(prev, video));
-        return;
-      }
-
       const video = await api.uploadVideo(projectId, input, {
         onUploadCreated: (createdVideo) => {
           createdVideoId = createdVideo.id;
+          finishVideoCreate();
           if (!mountedRef.current) return;
           setUploadStates((prev) => ({
             ...prev,
@@ -137,27 +186,40 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
         },
       });
       if (!mountedRef.current) return;
-      setUploadStates((prev) => {
-        if (!createdVideoId) return prev;
-        const next = { ...prev };
-        delete next[createdVideoId];
-        return next;
-      });
+      if (createdVideoId) removeUploadState(createdVideoId);
       setVideos((prev) => upsertVideo(prev, video));
-    } catch {
-      if (!mountedRef.current) return;
-      if (createdVideoId) {
-        const videoId = createdVideoId;
-        setUploadStates((prev) => {
-          const current = prev[videoId];
-          if (!current) return prev;
-          return {
-            ...prev,
-            [videoId]: { ...current, phase: "failed" },
-          };
-        });
-      }
-      setError("업로드에 실패했습니다.");
+    } catch (uploadError) {
+      if (mountedRef.current && createdVideoId) markUploadFailed(createdVideoId, uploadError);
+      throw uploadError;
+    }
+  }
+
+  async function runUpload(input: UploadVideoInput) {
+    if (input.kind === "file") {
+      await uploadFile(input);
+      return;
+    }
+    const video = await api.uploadVideo(projectId, input);
+    if (mountedRef.current) setVideos((prev) => upsertVideo(prev, video));
+  }
+
+  async function onUpload(e: FormEvent) {
+    e.preventDefault();
+    setError(null);
+    const preparation = prepareUploadInput(tab, title, sourceUrl, file);
+    if (!preparation.ok) {
+      if (preparation.error) setError(preparation.error);
+      return;
+    }
+    if (!beginVideoCreate()) return;
+    resetUploadForm();
+
+    try {
+      await runUpload(preparation.input);
+    } catch (uploadError) {
+      if (mountedRef.current) setError(userMessageFor(uploadError, "upload"));
+    } finally {
+      finishVideoCreate();
     }
   }
 
@@ -267,7 +329,7 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
               <input
                 key={fileInputKey}
                 type="file"
-                accept="video/*"
+                accept={SUPPORTED_VIDEO_EXTENSIONS.join(",")}
                 aria-label="영상 파일"
                 onChange={(e) => setFile(e.target.files?.[0] ?? null)}
                 className="sr-only"
@@ -276,7 +338,11 @@ export function VideoSourcePanel({ projectId }: { projectId: string }) {
           </div>
         )}
 
-        <button type="submit" className="rounded bg-black px-3 py-1 text-sm text-white">
+        <button
+          type="submit"
+          disabled={creating}
+          className="rounded bg-black px-3 py-1 text-sm text-white disabled:opacity-50"
+        >
           업로드
         </button>
       </form>

--- a/frontend/src/components/__tests__/SearchPanel.test.tsx
+++ b/frontend/src/components/__tests__/SearchPanel.test.tsx
@@ -15,6 +15,7 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import { SearchPanel } from "@/components/SearchPanel";
+import { HttpError } from "@/lib/api/http";
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -69,6 +70,19 @@ describe("SearchPanel", () => {
     expect(
       await screen.findByText("검색 요청이 몰리고 있습니다. 잠시 후 다시 시도해 주세요.")
     ).toBeInTheDocument();
+  });
+
+  it.each([
+    ["SEARCH_NOT_READY", "영상 처리가 끝난 뒤 검색할 수 있습니다."],
+    ["NO_VIDEOS_UPLOADED", "먼저 검색할 영상을 등록해 주세요."],
+  ])("shows the message for %s on its search turn", async (code, expected) => {
+    search.mockRejectedValue(new HttpError("server detail", 409, code));
+    render(<SearchPanel projectId="p1" onPlay={vi.fn()} />);
+
+    await userEvent.type(screen.getByLabelText("검색어"), "검색 질문");
+    await userEvent.click(screen.getByRole("button", { name: "검색" }));
+
+    expect(await screen.findByText(expected)).toBeInTheDocument();
   });
 
   it("restores history on project entry and keeps live search append", async () => {

--- a/frontend/src/components/__tests__/VideoSourcePanel.test.tsx
+++ b/frontend/src/components/__tests__/VideoSourcePanel.test.tsx
@@ -1,15 +1,17 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { act, render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const listVideos = vi.fn();
 const uploadVideo = vi.fn();
 const deleteVideos = vi.fn();
+const completeVideo = vi.fn();
 vi.mock("@/lib/api", () => ({
   api: {
     listVideos: (p: string) => listVideos(p),
     uploadVideo: (p: string, i: unknown, options?: unknown) => uploadVideo(p, i, options),
     deleteVideos: (ids: string[]) => deleteVideos(ids),
+    completeVideo: (videoId: string) => completeVideo(videoId),
   },
 }));
 
@@ -32,7 +34,11 @@ describe("VideoSourcePanel", () => {
     listVideos.mockReset();
     uploadVideo.mockReset();
     deleteVideos.mockReset();
+    completeVideo.mockReset();
+    localStorage.clear();
   });
+
+  afterEach(() => vi.useRealTimers());
 
   it("lists videos with a status label", async () => {
     listVideos.mockResolvedValue([
@@ -274,5 +280,239 @@ describe("VideoSourcePanel", () => {
     expect(deleteVideos).toHaveBeenCalledWith(["v1"]);
     expect(screen.queryByText("강의1")).not.toBeInTheDocument();
     expect(screen.getByText("강의2")).toBeInTheDocument();
+  });
+
+  it("polls active videos and shows the final failure message", async () => {
+    vi.useFakeTimers();
+    listVideos
+      .mockResolvedValueOnce([
+        { id: "v1", title: "강의1", status: "PROCESSING", inputType: "LOCAL_FILE", createdAt: "" },
+      ])
+      .mockResolvedValueOnce([
+        {
+          id: "v1",
+          title: "강의1",
+          status: "FAILED",
+          failedStage: "STT",
+          failureCode: "STT_FAILED",
+          failureTraceId: "trace-stt",
+          inputType: "LOCAL_FILE",
+          createdAt: "",
+        },
+      ]);
+
+    render(<VideoSourcePanel projectId="p1" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+    expect(screen.getByText("처리중")).toBeInTheDocument();
+
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+
+    expect(listVideos).toHaveBeenCalledTimes(2);
+    expect(
+      screen.getByText("음성 인식에 실패했습니다. 문의 코드: trace-stt")
+    ).toBeInTheDocument();
+
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+    expect(listVideos).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not poll when every video is terminal", async () => {
+    vi.useFakeTimers();
+    listVideos.mockResolvedValue([
+      { id: "v1", title: "강의1", status: "READY", inputType: "LOCAL_FILE", createdAt: "" },
+    ]);
+
+    render(<VideoSourcePanel projectId="p1" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+    await act(async () => vi.advanceTimersByTimeAsync(15_000));
+
+    expect(listVideos).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps an uploaded URL video when an older list response arrives", async () => {
+    const initialList = deferred<unknown[]>();
+    listVideos.mockReturnValue(initialList.promise);
+    uploadVideo.mockResolvedValue({
+      id: "v-new",
+      title: "새 영상",
+      status: "PENDING",
+      inputType: "EXTERNAL_URL",
+      createdAt: "",
+    });
+    render(<VideoSourcePanel projectId="p1" />);
+    await waitFor(() => expect(listVideos).toHaveBeenCalledTimes(1));
+
+    await userEvent.click(screen.getByRole("button", { name: "URL" }));
+    await userEvent.type(screen.getByLabelText("영상 제목"), "새 영상");
+    await userEvent.type(screen.getByLabelText("영상 URL"), "https://youtu.be/new");
+    await userEvent.click(screen.getByRole("button", { name: "업로드" }));
+    expect(await screen.findByText("새 영상")).toBeInTheDocument();
+
+    await act(async () => initialList.resolve([]));
+
+    expect(screen.getByText("새 영상")).toBeInTheDocument();
+  });
+
+  it("keeps checking after PUT succeeds and complete is temporarily unavailable", async () => {
+    const completion = deferred<{ id: string; status: string }>();
+    listVideos.mockResolvedValue([]);
+    completeVideo.mockReturnValue(completion.promise);
+    uploadVideo.mockImplementation((_projectId, _input, options) => {
+      const created = {
+        id: "v-check",
+        title: "확인 영상",
+        status: "PENDING",
+        inputType: "LOCAL_FILE",
+        createdAt: "",
+      };
+      options?.onUploadCreated?.(created);
+      options?.onUploadTransferred?.(created);
+      return Promise.reject(new Error("network unavailable"));
+    });
+    render(<VideoSourcePanel projectId="p1" />);
+
+    await userEvent.type(await screen.findByLabelText("영상 제목"), "확인 영상");
+    await userEvent.upload(
+      screen.getByLabelText("영상 파일"),
+      new File(["video"], "clip.mp4", { type: "video/mp4" })
+    );
+    await userEvent.click(screen.getByRole("button", { name: "업로드" }));
+
+    expect(await screen.findByText("업로드 완료 확인 중")).toBeInTheDocument();
+    expect(completeVideo).toHaveBeenCalledWith("v-check");
+
+    await act(async () => completion.resolve({ id: "v-check", status: "UPLOADED" }));
+    expect(await screen.findByText("업로드됨")).toBeInTheDocument();
+  });
+
+  it("recovers a stored completion marker after remount", async () => {
+    localStorage.setItem(
+      "biblio.uploadCompletions",
+      JSON.stringify([{ projectId: "p1", videoId: "v-stored" }])
+    );
+    listVideos.mockResolvedValue([]);
+    completeVideo.mockResolvedValue({ id: "v-stored", status: "UPLOADED" });
+
+    render(<VideoSourcePanel projectId="p1" />);
+
+    await waitFor(() => expect(completeVideo).toHaveBeenCalledWith("v-stored"));
+    expect(localStorage.getItem("biblio.uploadCompletions")).toBe("[]");
+  });
+
+  it("retries a stored completion marker when the first recovery is temporarily unavailable", async () => {
+    vi.useFakeTimers();
+    localStorage.setItem(
+      "biblio.uploadCompletions",
+      JSON.stringify([{ projectId: "p1", videoId: "v-stored" }])
+    );
+    listVideos.mockResolvedValue([]);
+    completeVideo
+      .mockRejectedValueOnce(new Error("temporary"))
+      .mockResolvedValueOnce({ id: "v-stored", status: "UPLOADED" });
+
+    render(<VideoSourcePanel projectId="p1" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+    expect(completeVideo).toHaveBeenCalledTimes(1);
+
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+
+    expect(completeVideo).toHaveBeenCalledTimes(2);
+    expect(localStorage.getItem("biblio.uploadCompletions")).toBe("[]");
+  });
+
+  it("does not restore a deleted video when stored completion recovery finishes late", async () => {
+    const completion = deferred<{ id: string; status: string }>();
+    localStorage.setItem(
+      "biblio.uploadCompletions",
+      JSON.stringify([{ projectId: "p1", videoId: "v-stored" }])
+    );
+    listVideos.mockResolvedValue([
+      {
+        id: "v-stored",
+        title: "삭제할 영상",
+        status: "UPLOADED",
+        inputType: "LOCAL_FILE",
+        createdAt: "",
+      },
+    ]);
+    completeVideo.mockReturnValue(completion.promise);
+    deleteVideos.mockResolvedValue(undefined);
+
+    render(<VideoSourcePanel projectId="p1" />);
+    await waitFor(() => expect(completeVideo).toHaveBeenCalledWith("v-stored"));
+    await userEvent.click(await screen.findByLabelText("삭제할 영상 선택"));
+    await userEvent.click(screen.getByRole("button", { name: "삭제" }));
+    expect(screen.queryByText("삭제할 영상")).not.toBeInTheDocument();
+
+    await act(async () => completion.resolve({ id: "v-stored", status: "UPLOADED" }));
+
+    expect(screen.queryByText("삭제할 영상")).not.toBeInTheDocument();
+    expect(localStorage.getItem("biblio.uploadCompletions")).toBe("[]");
+  });
+
+  it("keeps the current list and action error while a poll fails, then retries", async () => {
+    vi.useFakeTimers();
+    listVideos
+      .mockResolvedValueOnce([
+        { id: "v1", title: "강의1", status: "PROCESSING", inputType: "LOCAL_FILE", createdAt: "" },
+      ])
+      .mockRejectedValueOnce(new Error("temporary"))
+      .mockResolvedValueOnce([
+        { id: "v1", title: "강의1", status: "READY", inputType: "LOCAL_FILE", createdAt: "" },
+      ]);
+    render(<VideoSourcePanel projectId="p1" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    fireEvent.click(screen.getByRole("button", { name: "URL" }));
+    fireEvent.change(screen.getByLabelText("영상 제목"), { target: { value: "잘못된 URL" } });
+    fireEvent.change(screen.getByLabelText("영상 URL"), {
+      target: { value: "https://example.com/video" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "업로드" }));
+    expect(screen.getByText("YouTube URL만 등록할 수 있습니다.")).toBeInTheDocument();
+
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+    expect(screen.getByText("강의1")).toBeInTheDocument();
+    expect(screen.getByText("처리중")).toBeInTheDocument();
+    expect(
+      screen.getByText("영상 상태를 갱신하지 못했습니다. 잠시 후 다시 시도합니다.")
+    ).toBeInTheDocument();
+    expect(screen.getByText("YouTube URL만 등록할 수 있습니다.")).toBeInTheDocument();
+
+    await act(async () => vi.advanceTimersByTimeAsync(5000));
+    expect(screen.getByText("완료")).toBeInTheDocument();
+    expect(
+      screen.queryByText("영상 상태를 갱신하지 못했습니다. 잠시 후 다시 시도합니다.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("refreshes immediately when a background tab becomes visible", async () => {
+    vi.useFakeTimers();
+    listVideos.mockResolvedValue([
+      { id: "v1", title: "강의1", status: "PROCESSING", inputType: "LOCAL_FILE", createdAt: "" },
+    ]);
+    Object.defineProperty(document, "visibilityState", { configurable: true, value: "visible" });
+    render(<VideoSourcePanel projectId="p1" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    await act(async () => document.dispatchEvent(new Event("visibilitychange")));
+
+    expect(listVideos).toHaveBeenCalledTimes(2);
+    await act(async () => vi.advanceTimersByTimeAsync(4999));
+    expect(listVideos).toHaveBeenCalledTimes(2);
+  });
+
+  it("cleans up polling when the component unmounts", async () => {
+    vi.useFakeTimers();
+    listVideos.mockResolvedValue([
+      { id: "v1", title: "강의1", status: "PROCESSING", inputType: "LOCAL_FILE", createdAt: "" },
+    ]);
+    const { unmount } = render(<VideoSourcePanel projectId="p1" />);
+    await act(async () => vi.advanceTimersByTimeAsync(0));
+
+    unmount();
+    await act(async () => vi.advanceTimersByTimeAsync(10_000));
+
+    expect(listVideos).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/components/__tests__/VideoSourcePanel.test.tsx
+++ b/frontend/src/components/__tests__/VideoSourcePanel.test.tsx
@@ -14,6 +14,18 @@ vi.mock("@/lib/api", () => ({
 }));
 
 import { VideoSourcePanel } from "@/components/VideoSourcePanel";
+import { HttpError } from "@/lib/api/http";
+import { MAX_UPLOAD_SIZE_BYTES } from "@/lib/api/upload-constraints";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 describe("VideoSourcePanel", () => {
   beforeEach(() => {
@@ -122,6 +134,23 @@ describe("VideoSourcePanel", () => {
     expect(await screen.findByText("로컬 영상")).toBeInTheDocument();
     expect(screen.getByText("업로드 중 42%")).toBeInTheDocument();
     expect(screen.getByLabelText("로컬 영상 선택")).toBeDisabled();
+    expect(screen.getByRole("button", { name: "업로드" })).toBeEnabled();
+
+    await userEvent.type(screen.getByLabelText("영상 제목"), "잘못된 파일");
+    const userWithoutAcceptFilter = userEvent.setup({ applyAccept: false });
+    await userWithoutAcceptFilter.upload(
+      screen.getByLabelText("영상 파일"),
+      new File(["bad"], "bad.exe", { type: "application/octet-stream" })
+    );
+    await userEvent.click(screen.getByRole("button", { name: "업로드" }));
+
+    expect(uploadVideo).toHaveBeenCalledTimes(1);
+    expect(screen.getByText("업로드 중 42%")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "지원하지 않는 파일 형식입니다. MP4, WEBM, MOV, MKV, AVI, WMV 파일을 이용해 주세요."
+      )
+    ).toBeInTheDocument();
 
     listVideos.mockResolvedValueOnce([
       { id: "v3", title: "로컬 영상", status: "PENDING", inputType: "LOCAL_FILE", createdAt: "" },
@@ -136,6 +165,86 @@ describe("VideoSourcePanel", () => {
     });
 
     expect(await screen.findByText("업로드 실패")).toBeInTheDocument();
+  });
+
+  it("blocks a file larger than 500MiB before calling the API", async () => {
+    listVideos.mockResolvedValue([]);
+    render(<VideoSourcePanel projectId="p1" />);
+    const file = new File(["video"], "large.mp4", { type: "video/mp4" });
+    Object.defineProperty(file, "size", { value: MAX_UPLOAD_SIZE_BYTES + 1 });
+
+    await userEvent.type(await screen.findByLabelText("영상 제목"), "큰 영상");
+    await userEvent.upload(screen.getByLabelText("영상 파일"), file);
+    await userEvent.click(screen.getByRole("button", { name: "업로드" }));
+
+    expect(uploadVideo).not.toHaveBeenCalled();
+    expect(screen.getByText("파일은 최대 500MB까지 업로드할 수 있습니다.")).toBeInTheDocument();
+  });
+
+  it("removes the local upload row when completion returns FILE_TOO_LARGE", async () => {
+    listVideos.mockResolvedValue([]);
+    uploadVideo.mockImplementation((_projectId, _input, options) => {
+      options?.onUploadCreated?.({
+        id: "v-large",
+        title: "서버 확인 영상",
+        status: "PENDING",
+        inputType: "LOCAL_FILE",
+        createdAt: "",
+      });
+      return Promise.reject(new HttpError("server detail", 400, "FILE_TOO_LARGE", "trace-large"));
+    });
+    render(<VideoSourcePanel projectId="p1" />);
+
+    await userEvent.type(await screen.findByLabelText("영상 제목"), "서버 확인 영상");
+    await userEvent.upload(
+      screen.getByLabelText("영상 파일"),
+      new File(["video"], "clip.mp4", { type: "video/mp4" })
+    );
+    await userEvent.click(screen.getByRole("button", { name: "업로드" }));
+
+    expect(await screen.findByText("파일은 최대 500MB까지 업로드할 수 있습니다.")).toBeInTheDocument();
+    expect(screen.queryByText("서버 확인 영상")).not.toBeInTheDocument();
+  });
+
+  it("blocks duplicate create calls but allows a later URL submission", async () => {
+    listVideos.mockResolvedValue([]);
+    const firstUpload = deferred<{ id: string; title: string; status: string; inputType: string; createdAt: string }>();
+    uploadVideo
+      .mockReturnValueOnce(firstUpload.promise)
+      .mockResolvedValueOnce({
+        id: "v-next",
+        title: "다음 영상",
+        status: "PENDING",
+        inputType: "EXTERNAL_URL",
+        createdAt: "",
+      });
+    render(<VideoSourcePanel projectId="p1" />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "URL" }));
+    await userEvent.type(screen.getByLabelText("영상 제목"), "첫 영상");
+    await userEvent.type(screen.getByLabelText("영상 URL"), "https://youtu.be/first");
+    await userEvent.click(screen.getByRole("button", { name: "업로드" }));
+
+    expect(screen.getByRole("button", { name: "업로드" })).toBeDisabled();
+    expect(uploadVideo).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      firstUpload.resolve({
+        id: "v-first",
+        title: "첫 영상",
+        status: "PENDING",
+        inputType: "EXTERNAL_URL",
+        createdAt: "",
+      });
+    });
+    expect(await screen.findByText("첫 영상")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "업로드" })).toBeEnabled();
+
+    await userEvent.type(screen.getByLabelText("영상 제목"), "다음 영상");
+    await userEvent.type(screen.getByLabelText("영상 URL"), "https://youtu.be/next");
+    await userEvent.click(screen.getByRole("button", { name: "업로드" }));
+
+    expect(uploadVideo).toHaveBeenCalledTimes(2);
+    expect(await screen.findByText("다음 영상")).toBeInTheDocument();
   });
 
   it("does not upload a non-YouTube URL", async () => {

--- a/frontend/src/hooks/useVideoStatusPolling.ts
+++ b/frontend/src/hooks/useVideoStatusPolling.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+const POLLING_INTERVAL_MS = 5000;
+
+interface VideoStatusPollingOptions {
+  enabled: boolean;
+  refresh: () => Promise<void>;
+}
+
+export function useVideoStatusPolling({ enabled, refresh }: VideoStatusPollingOptions) {
+  const refreshRef = useRef(refresh);
+
+  useEffect(() => {
+    refreshRef.current = refresh;
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    let active = true;
+    let running = false;
+    let runAgain = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const schedule = () => {
+      timer = setTimeout(run, POLLING_INTERVAL_MS);
+    };
+
+    const run = async () => {
+      if (!active) return;
+      if (running) {
+        runAgain = true;
+        return;
+      }
+      if (timer) clearTimeout(timer);
+      running = true;
+      try {
+        await refreshRef.current();
+      } finally {
+        running = false;
+        if (!active) return;
+        if (runAgain) {
+          runAgain = false;
+          void run();
+          return;
+        }
+        schedule();
+      }
+    };
+
+    const onVisibilityChange = () => {
+      if (document.visibilityState !== "visible") return;
+      if (timer) clearTimeout(timer);
+      void run();
+    };
+
+    schedule();
+    document.addEventListener("visibilitychange", onVisibilityChange);
+    return () => {
+      active = false;
+      if (timer) clearTimeout(timer);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [enabled]);
+}

--- a/frontend/src/hooks/useVideoStatusPolling.ts
+++ b/frontend/src/hooks/useVideoStatusPolling.ts
@@ -40,13 +40,14 @@ export function useVideoStatusPolling({ enabled, refresh }: VideoStatusPollingOp
         await refreshRef.current();
       } finally {
         running = false;
-        if (!active) return;
-        if (runAgain) {
-          runAgain = false;
-          void run();
-          return;
+        if (active) {
+          if (runAgain) {
+            runAgain = false;
+            void run();
+          } else {
+            schedule();
+          }
         }
-        schedule();
       }
     };
 

--- a/frontend/src/lib/__tests__/upload-completion-store.test.ts
+++ b/frontend/src/lib/__tests__/upload-completion-store.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  forgetUploadCompletion,
+  pendingUploadCompletionIds,
+  rememberUploadCompletion,
+} from "@/lib/upload-completion-store";
+
+describe("upload completion store", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("stores unique video ids by project and removes one marker", () => {
+    rememberUploadCompletion("p1", "v1");
+    rememberUploadCompletion("p1", "v1");
+    rememberUploadCompletion("p2", "v2");
+
+    expect(pendingUploadCompletionIds("p1")).toEqual(["v1"]);
+    expect(pendingUploadCompletionIds("p2")).toEqual(["v2"]);
+
+    forgetUploadCompletion("p1", "v1");
+    expect(pendingUploadCompletionIds("p1")).toEqual([]);
+    expect(pendingUploadCompletionIds("p2")).toEqual(["v2"]);
+  });
+
+  it("falls back to an empty list for corrupted storage", () => {
+    localStorage.setItem("biblio.uploadCompletions", "not-json");
+
+    expect(pendingUploadCompletionIds("p1")).toEqual([]);
+    expect(localStorage.getItem("biblio.uploadCompletions")).toBeNull();
+  });
+
+  it("does not throw when localStorage writes are blocked", () => {
+    vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked");
+    });
+
+    expect(() => rememberUploadCompletion("p1", "v1")).not.toThrow();
+  });
+});

--- a/frontend/src/lib/api/__tests__/error-message.test.ts
+++ b/frontend/src/lib/api/__tests__/error-message.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { userMessageFor } from "@/lib/api/error-message";
+import { userMessageFor, videoFailureMessage } from "@/lib/api/error-message";
 import { HttpError } from "@/lib/api/http";
 
 describe("userMessageFor", () => {
@@ -21,6 +21,33 @@ describe("userMessageFor", () => {
   it("shows only the trace id for an unknown server error", () => {
     expect(userMessageFor(new HttpError("database detail", 500, "UNKNOWN", "trace-1"), "upload")).toBe(
       "처리에 실패했습니다. 문의 코드: trace-1"
+    );
+  });
+});
+
+describe("videoFailureMessage", () => {
+  it.each([
+    ["YOUTUBE_BLOCKED", "YouTube에서 영상 접근을 차단했습니다. 파일 업로드를 이용해 주세요."],
+    ["SOURCE_UNAVAILABLE", "영상 원본을 불러올 수 없습니다."],
+    [
+      "SOURCE_LIMIT_EXCEEDED",
+      "영상 원본이 처리 제한을 초과했습니다. 최대 길이는 60분, 최대 파일 크기는 500MB입니다.",
+    ],
+    ["AUDIO_EXTRACTION_FAILED", "영상에서 음성을 추출하지 못했습니다."],
+    ["STT_FAILED", "음성 인식에 실패했습니다."],
+    ["EMBEDDING_FAILED", "영상 내용을 검색 데이터로 변환하지 못했습니다."],
+    ["INDEX_WRITE_FAILED", "검색 데이터 저장에 실패했습니다."],
+    ["INTERNAL_PROCESSING_ERROR", "영상 처리 중 오류가 발생했습니다."],
+  ])("maps %s to a stable message", (code, expected) => {
+    expect(videoFailureMessage(code)).toBe(expected);
+  });
+
+  it("adds a trace id without exposing an exception message", () => {
+    expect(videoFailureMessage("STT_FAILED", "trace-1")).toBe(
+      "음성 인식에 실패했습니다. 문의 코드: trace-1"
+    );
+    expect(videoFailureMessage("UNKNOWN", "trace-2")).toBe(
+      "영상 처리 중 오류가 발생했습니다. 문의 코드: trace-2"
     );
   });
 });

--- a/frontend/src/lib/api/__tests__/error-message.test.ts
+++ b/frontend/src/lib/api/__tests__/error-message.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { userMessageFor } from "@/lib/api/error-message";
+import { HttpError } from "@/lib/api/http";
+
+describe("userMessageFor", () => {
+  it.each([
+    ["SEARCH_NOT_READY", "영상 처리가 끝난 뒤 검색할 수 있습니다."],
+    ["NO_VIDEOS_UPLOADED", "먼저 검색할 영상을 등록해 주세요."],
+    ["UNSUPPORTED_FILE_TYPE", "지원하지 않는 파일 형식입니다. MP4, WEBM, MOV, MKV, AVI, WMV 파일을 이용해 주세요."],
+    ["FILE_TOO_LARGE", "파일은 최대 500MB까지 업로드할 수 있습니다."],
+  ])("maps %s to a stable user message", (code, expected) => {
+    expect(userMessageFor(new HttpError("internal", 400, code), "upload")).toBe(expected);
+  });
+
+  it("keeps the search capacity message for a bodyless 503", () => {
+    expect(userMessageFor(new HttpError("request failed", 503), "search")).toBe(
+      "검색 요청이 몰리고 있습니다. 잠시 후 다시 시도해 주세요."
+    );
+  });
+
+  it("shows only the trace id for an unknown server error", () => {
+    expect(userMessageFor(new HttpError("database detail", 500, "UNKNOWN", "trace-1"), "upload")).toBe(
+      "처리에 실패했습니다. 문의 코드: trace-1"
+    );
+  });
+});

--- a/frontend/src/lib/api/__tests__/http-videos.test.ts
+++ b/frontend/src/lib/api/__tests__/http-videos.test.ts
@@ -38,6 +38,8 @@ describe("http videos", () => {
               title: "강의1",
               status: "FAILED",
               failed_stage: "DOWNLOAD",
+              failure_code: "YOUTUBE_BLOCKED",
+              failure_trace_id: "550e8400-e29b-41d4-a716-446655440000",
               input_type: "EXTERNAL_URL",
               source_url: "https://x",
               created_at: "2026-01-01T00:00:00Z",
@@ -57,6 +59,8 @@ describe("http videos", () => {
       title: "강의1",
       status: "FAILED",
       failedStage: "DOWNLOAD",
+      failureCode: "YOUTUBE_BLOCKED",
+      failureTraceId: "550e8400-e29b-41d4-a716-446655440000",
       inputType: "EXTERNAL_URL",
     });
     const [url, init] = fetchMock.mock.calls[0];

--- a/frontend/src/lib/api/__tests__/http-videos.test.ts
+++ b/frontend/src/lib/api/__tests__/http-videos.test.ts
@@ -64,7 +64,7 @@ describe("http videos", () => {
       inputType: "EXTERNAL_URL",
     });
     const [url, init] = fetchMock.mock.calls[0];
-    expect(url).toBe("https://api.test/api/v1/projects/proj-1/videos");
+    expect(url).toBe("https://api.test/api/v1/projects/proj-1/videos?limit=50");
     expect(init.credentials).toBe("include");
   });
 
@@ -138,6 +138,7 @@ describe("http videos", () => {
 
     const file = new File(["x"], "clip.MP4", { type: "video/mp4" });
     const onProgress = vi.fn();
+    const onUploadTransferred = vi.fn();
     const v = await createHttpApi("https://api.test").uploadVideo(
       "proj-1",
       {
@@ -145,11 +146,14 @@ describe("http videos", () => {
         file,
         title: "강의2",
       },
-      { onProgress }
+      { onProgress, onUploadTransferred }
     );
 
     expect(v.id).toBe("v3");
     expect(onProgress.mock.calls.map(([percent]) => percent)).toEqual([50, 100]);
+    expect(onUploadTransferred).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "v3", status: "PENDING" })
+    );
     expect(calls[0]).toBe("https://api.test/api/v1/projects/proj-1/videos");
     expect(calls[1]).toBe("https://api.test/api/v1/videos/v3/complete");
     expect(JSON.parse(fetchMock.mock.calls[0][1].body).extension).toBe(".mp4");
@@ -161,6 +165,23 @@ describe("http videos", () => {
     expect(xhrInstances[0].setRequestHeader).toHaveBeenCalledWith(
       "x-goog-content-length-range",
       "0,2147483648"
+    );
+  });
+
+  it("completeVideo POSTs the completion request and maps the status", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ video_id: "v3", status: "PROCESSING" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const completion = await createHttpApi("https://api.test").completeVideo("v/3");
+
+    expect(completion).toEqual({ id: "v3", status: "PROCESSING" });
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "https://api.test/api/v1/videos/v%2F3/complete"
     );
   });
 

--- a/frontend/src/lib/api/__tests__/http-videos.test.ts
+++ b/frontend/src/lib/api/__tests__/http-videos.test.ts
@@ -132,7 +132,7 @@ describe("http videos", () => {
       })
     );
 
-    const file = new File(["x"], "clip.mp4", { type: "video/mp4" });
+    const file = new File(["x"], "clip.MP4", { type: "video/mp4" });
     const onProgress = vi.fn();
     const v = await createHttpApi("https://api.test").uploadVideo(
       "proj-1",
@@ -148,6 +148,7 @@ describe("http videos", () => {
     expect(onProgress.mock.calls.map(([percent]) => percent)).toEqual([50, 100]);
     expect(calls[0]).toBe("https://api.test/api/v1/projects/proj-1/videos");
     expect(calls[1]).toBe("https://api.test/api/v1/videos/v3/complete");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body).extension).toBe(".mp4");
     expect(xhrInstances[0].open).toHaveBeenCalledWith("PUT", "https://gcs/upload");
     expect(xhrInstances[0].setRequestHeader).toHaveBeenCalledWith(
       "content-type",

--- a/frontend/src/lib/api/__tests__/http.test.ts
+++ b/frontend/src/lib/api/__tests__/http.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
-import { createHttpApi } from "@/lib/api/http";
+import { createHttpApi, HttpError } from "@/lib/api/http";
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -41,14 +41,58 @@ describe("http auth", () => {
     expect(init.credentials).toBe("include");
   });
 
-  it("throws on non-2xx", async () => {
+  it("preserves a structured API error response", async () => {
     vi.stubGlobal(
       "fetch",
-      vi.fn().mockResolvedValue(new Response("nope", { status: 401 }))
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: "UNAUTHENTICATED",
+            message: "Authentication credentials are invalid.",
+            trace_id: "trace-body",
+          }),
+          {
+            status: 401,
+            headers: {
+              "Content-Type": "application/json",
+              "X-Trace-Id": "trace-header",
+            },
+          }
+        )
+      )
     );
     const api = createHttpApi("https://api.test");
-    await expect(
-      api.login({ email: "a@b.com", password: "x" })
-    ).rejects.toThrow();
+    const error = await api.login({ email: "a@b.com", password: "x" }).catch((reason) => reason);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({
+      status: 401,
+      code: "UNAUTHENTICATED",
+      message: "Authentication credentials are invalid.",
+      traceId: "trace-body",
+    });
+  });
+
+  it.each([
+    ["an empty body", ""],
+    ["a non-JSON body", "nope"],
+    ["an invalid API error body", JSON.stringify({ code: "UNAUTHENTICATED" })],
+  ])("falls back to the existing message for %s", async (_label, body) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(body, { status: 401, headers: { "X-Trace-Id": "trace-header" } })
+      )
+    );
+    const api = createHttpApi("https://api.test");
+    const error = await api.login({ email: "a@b.com", password: "x" }).catch((reason) => reason);
+
+    expect(error).toBeInstanceOf(HttpError);
+    expect(error).toMatchObject({
+      status: 401,
+      message: "요청 실패 (401)",
+      traceId: "trace-header",
+    });
+    expect(error.code).toBeUndefined();
   });
 });

--- a/frontend/src/lib/api/error-message.ts
+++ b/frontend/src/lib/api/error-message.ts
@@ -14,6 +14,18 @@ const USER_MESSAGES: Record<string, string> = {
   FILE_TOO_LARGE: "파일은 최대 500MB까지 업로드할 수 있습니다.",
 };
 
+const VIDEO_FAILURE_MESSAGES: Record<string, string> = {
+  YOUTUBE_BLOCKED: "YouTube에서 영상 접근을 차단했습니다. 파일 업로드를 이용해 주세요.",
+  SOURCE_UNAVAILABLE: "영상 원본을 불러올 수 없습니다.",
+  SOURCE_LIMIT_EXCEEDED:
+    "영상 원본이 처리 제한을 초과했습니다. 최대 길이는 60분, 최대 파일 크기는 500MB입니다.",
+  AUDIO_EXTRACTION_FAILED: "영상에서 음성을 추출하지 못했습니다.",
+  STT_FAILED: "음성 인식에 실패했습니다.",
+  EMBEDDING_FAILED: "영상 내용을 검색 데이터로 변환하지 못했습니다.",
+  INDEX_WRITE_FAILED: "검색 데이터 저장에 실패했습니다.",
+  INTERNAL_PROCESSING_ERROR: "영상 처리 중 오류가 발생했습니다.",
+};
+
 function errorDetails(error: unknown): ErrorDetails {
   if (typeof error === "string") return { code: error };
   if (typeof error !== "object" || error === null) return {};
@@ -33,4 +45,11 @@ export function userMessageFor(error: unknown, context: ErrorContext): string {
     return "검색 요청이 몰리고 있습니다. 잠시 후 다시 시도해 주세요.";
   }
   return traceId ? `처리에 실패했습니다. 문의 코드: ${traceId}` : "처리에 실패했습니다.";
+}
+
+export function videoFailureMessage(failureCode?: string, failureTraceId?: string): string {
+  const message = failureCode
+    ? VIDEO_FAILURE_MESSAGES[failureCode] ?? "영상 처리 중 오류가 발생했습니다."
+    : "영상 처리에 실패했습니다.";
+  return failureTraceId ? `${message} 문의 코드: ${failureTraceId}` : message;
 }

--- a/frontend/src/lib/api/error-message.ts
+++ b/frontend/src/lib/api/error-message.ts
@@ -1,0 +1,36 @@
+export type ErrorContext = "search" | "upload";
+
+interface ErrorDetails {
+  code?: string;
+  status?: number;
+  traceId?: string;
+}
+
+const USER_MESSAGES: Record<string, string> = {
+  SEARCH_NOT_READY: "영상 처리가 끝난 뒤 검색할 수 있습니다.",
+  NO_VIDEOS_UPLOADED: "먼저 검색할 영상을 등록해 주세요.",
+  UNSUPPORTED_FILE_TYPE:
+    "지원하지 않는 파일 형식입니다. MP4, WEBM, MOV, MKV, AVI, WMV 파일을 이용해 주세요.",
+  FILE_TOO_LARGE: "파일은 최대 500MB까지 업로드할 수 있습니다.",
+};
+
+function errorDetails(error: unknown): ErrorDetails {
+  if (typeof error === "string") return { code: error };
+  if (typeof error !== "object" || error === null) return {};
+  const value = error as Record<string, unknown>;
+  return {
+    code: typeof value.code === "string" ? value.code : undefined,
+    status: typeof value.status === "number" ? value.status : undefined,
+    traceId: typeof value.traceId === "string" ? value.traceId : undefined,
+  };
+}
+
+export function userMessageFor(error: unknown, context: ErrorContext): string {
+  const { code, status, traceId } = errorDetails(error);
+  const knownMessage = code ? USER_MESSAGES[code] : undefined;
+  if (knownMessage) return knownMessage;
+  if (context === "search" && (code === "SERVICE_UNAVAILABLE" || status === 503)) {
+    return "검색 요청이 몰리고 있습니다. 잠시 후 다시 시도해 주세요.";
+  }
+  return traceId ? `처리에 실패했습니다. 문의 코드: ${traceId}` : "처리에 실패했습니다.";
+}

--- a/frontend/src/lib/api/http.ts
+++ b/frontend/src/lib/api/http.ts
@@ -137,6 +137,8 @@ export function createHttpApi(baseUrl: string): Api {
     title?: string;
     status: string;
     failed_stage?: string | null;
+    failure_code?: string | null;
+    failure_trace_id?: string | null;
     input_type?: string;
     source_url?: string | null;
     created_at?: string | null;
@@ -155,6 +157,8 @@ export function createHttpApi(baseUrl: string): Api {
       title: res.title ?? fallbackTitle,
       status: (res.status as VideoStatus) ?? "PENDING",
       failedStage: res.failed_stage ?? undefined,
+      failureCode: res.failure_code ?? undefined,
+      failureTraceId: res.failure_trace_id ?? undefined,
       inputType: (res.input_type as VideoInputType) ?? "LOCAL_FILE",
       sourceUrl: res.source_url ?? undefined,
       createdAt: res.created_at ?? new Date().toISOString(),

--- a/frontend/src/lib/api/http.ts
+++ b/frontend/src/lib/api/http.ts
@@ -17,6 +17,7 @@ import type {
   VideoStatus,
 } from "./types";
 import { getCsrfToken } from "@/lib/auth/token";
+import { normalizedFileExtension } from "./upload-constraints";
 
 export class HttpError extends Error {
   constructor(
@@ -160,11 +161,6 @@ export function createHttpApi(baseUrl: string): Api {
     };
   }
 
-  function fileExtension(name: string): string {
-    const dot = name.lastIndexOf(".");
-    return dot >= 0 ? name.slice(dot) : "";
-  }
-
   function uploadSignedUrl(
     signedUrl: string,
     headers: UploadHeaders,
@@ -206,7 +202,7 @@ export function createHttpApi(baseUrl: string): Api {
       input_type: "LOCAL_FILE",
       title,
       category: "GENERAL",
-      extension: fileExtension(file.name),
+      extension: normalizedFileExtension(file.name),
     });
     options?.onUploadCreated?.(mapVideo(created, title));
     if (created.signed_url) {

--- a/frontend/src/lib/api/http.ts
+++ b/frontend/src/lib/api/http.ts
@@ -21,11 +21,47 @@ import { getCsrfToken } from "@/lib/auth/token";
 export class HttpError extends Error {
   constructor(
     message: string,
-    public readonly status: number
+    public readonly status: number,
+    public readonly code?: string,
+    public readonly traceId?: string
   ) {
     super(message);
     this.name = "HttpError";
   }
+}
+
+interface ApiErrorPayload {
+  code: string;
+  message: string;
+  trace_id: string;
+}
+
+function isApiErrorPayload(value: unknown): value is ApiErrorPayload {
+  if (typeof value !== "object" || value === null) return false;
+  const payload = value as Record<string, unknown>;
+  return (
+    typeof payload.code === "string" &&
+    typeof payload.message === "string" &&
+    typeof payload.trace_id === "string"
+  );
+}
+
+async function readApiErrorPayload(response: Response): Promise<ApiErrorPayload | undefined> {
+  try {
+    const payload: unknown = await response.json();
+    return isApiErrorPayload(payload) ? payload : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+async function toHttpError(response: Response): Promise<HttpError> {
+  const payload = await readApiErrorPayload(response);
+  if (payload) {
+    return new HttpError(payload.message, response.status, payload.code, payload.trace_id);
+  }
+  const traceId = response.headers.get("X-Trace-Id") ?? undefined;
+  return new HttpError(`요청 실패 (${response.status})`, response.status, undefined, traceId);
 }
 
 let activeSignedUrlUploads = 0;
@@ -63,7 +99,7 @@ export function createHttpApi(baseUrl: string): Api {
   async function request<T>(path: string, init: RequestInit): Promise<T> {
     const res = await fetch(`${baseUrl}${path}`, { credentials: "include", ...init });
     if (!res.ok) {
-      throw new HttpError(`요청 실패 (${res.status})`, res.status);
+      throw await toHttpError(res);
     }
     if (res.status === 204) {
       return undefined as T;

--- a/frontend/src/lib/api/http.ts
+++ b/frontend/src/lib/api/http.ts
@@ -13,6 +13,7 @@ import type {
   UploadVideoInput,
   UploadVideoOptions,
   Video,
+  VideoCompletion,
   VideoInputType,
   VideoStatus,
 } from "./types";
@@ -165,6 +166,14 @@ export function createHttpApi(baseUrl: string): Api {
     };
   }
 
+  async function completeUpload(videoId: string): Promise<VideoCompletion> {
+    const completed = await post<VideoResponse>(
+      `/api/v1/videos/${encodeURIComponent(videoId)}/complete`,
+      {}
+    );
+    return { id: completed.video_id, status: completed.status as VideoStatus };
+  }
+
   function uploadSignedUrl(
     signedUrl: string,
     headers: UploadHeaders,
@@ -208,7 +217,8 @@ export function createHttpApi(baseUrl: string): Api {
       category: "GENERAL",
       extension: normalizedFileExtension(file.name),
     });
-    options?.onUploadCreated?.(mapVideo(created, title));
+    const createdVideo = mapVideo(created, title);
+    options?.onUploadCreated?.(createdVideo);
     if (created.signed_url) {
       registerUploadWarning();
       try {
@@ -218,13 +228,15 @@ export function createHttpApi(baseUrl: string): Api {
           file,
           options?.onProgress
         );
-        const completed = await post<VideoResponse>(`/api/v1/videos/${created.video_id}/complete`, {});
+        options?.onUploadTransferred?.(createdVideo);
+        const completed = await completeUpload(created.video_id);
         return mapVideo({ ...created, ...completed }, title);
       } finally {
         unregisterUploadWarning();
       }
     }
-    const completed = await post<VideoResponse>(`/api/v1/videos/${created.video_id}/complete`, {});
+    options?.onUploadTransferred?.(createdVideo);
+    const completed = await completeUpload(created.video_id);
     return mapVideo({ ...created, ...completed }, title);
   }
 
@@ -329,7 +341,7 @@ export function createHttpApi(baseUrl: string): Api {
     },
     async listVideos(projectId: string): Promise<Video[]> {
       const res = await get<VideoListResponse>(
-        `/api/v1/projects/${encodeURIComponent(projectId)}/videos`
+        `/api/v1/projects/${encodeURIComponent(projectId)}/videos?limit=50`
       );
       return res.items.map((item) => mapVideo(item, item.title ?? ""));
     },
@@ -344,6 +356,9 @@ export function createHttpApi(baseUrl: string): Api {
       return input.kind === "file"
         ? uploadFile(projectId, input.file, input.title, options)
         : uploadUrl(projectId, input.sourceUrl, input.title);
+    },
+    completeVideo(videoId: string): Promise<VideoCompletion> {
+      return completeUpload(videoId);
     },
     async search(projectId: string, query: string): Promise<SearchResult> {
       const res = await post<SearchResponse>("/api/v1/search", {

--- a/frontend/src/lib/api/mock.ts
+++ b/frontend/src/lib/api/mock.ts
@@ -8,7 +8,9 @@ import type {
   SearchResult,
   SignupRequest,
   UploadVideoInput,
+  UploadVideoOptions,
   Video,
+  VideoCompletion,
 } from "./types";
 
 interface MockUser {
@@ -229,7 +231,12 @@ export function createMockApi(): Api {
       }
     },
 
-    async uploadVideo(projectId: string, input: UploadVideoInput): Promise<Video> {
+    async uploadVideo(
+      projectId: string,
+      input: UploadVideoInput,
+      options?: UploadVideoOptions
+    ): Promise<Video> {
+      const createdAt = new Date().toISOString();
       const stored: StoredVideo = {
         id: crypto.randomUUID(),
         projectId,
@@ -237,13 +244,30 @@ export function createMockApi(): Api {
         status: "PROCESSING",
         inputType: input.kind === "file" ? "LOCAL_FILE" : "EXTERNAL_URL",
         sourceUrl: input.kind === "url" ? input.sourceUrl : undefined,
-        createdAt: new Date().toISOString(),
+        createdAt,
       };
+      if (input.kind === "file") {
+        const pendingVideo: Video = { ...stored, status: "PENDING" };
+        options?.onUploadCreated?.(pendingVideo);
+        options?.onProgress?.(100);
+        options?.onUploadTransferred?.(pendingVideo);
+      }
       const all = loadVideos();
       all.unshift(stored);
       saveVideos(all);
       incrementProjectVideoCount(projectId);
       return toVideo(stored);
+    },
+
+    async completeVideo(videoId: string): Promise<VideoCompletion> {
+      const videos = loadVideos();
+      const target = videos.find((video) => video.id === videoId);
+      if (!target) throw new Error("영상을 찾을 수 없습니다.");
+      if (target.status === "PENDING" || target.status === "UPLOADED") {
+        target.status = "PROCESSING";
+        saveVideos(videos);
+      }
+      return { id: target.id, status: target.status };
     },
 
     async search(projectId: string, query: string): Promise<SearchResult> {

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -58,7 +58,10 @@ export type UploadVideoInput =
 export interface UploadVideoOptions {
   onProgress?: (percent: number) => void;
   onUploadCreated?: (video: Video) => void;
+  onUploadTransferred?: (video: Video) => void;
 }
+
+export type VideoCompletion = Pick<Video, "id" | "status">;
 
 export type UploadHeaders = Record<string, string>;
 
@@ -102,6 +105,7 @@ export interface Api {
     input: UploadVideoInput,
     options?: UploadVideoOptions
   ): Promise<Video>;
+  completeVideo(videoId: string): Promise<VideoCompletion>;
   search(projectId: string, query: string): Promise<SearchResult>;
   getSearchHistory(projectId: string): Promise<SearchHistoryTurn[]>;
   submitFeedback(reqId: string, rating: FeedbackRating): Promise<void>;

--- a/frontend/src/lib/api/types.ts
+++ b/frontend/src/lib/api/types.ts
@@ -44,6 +44,8 @@ export interface Video {
   title: string;
   status: VideoStatus;
   failedStage?: string;
+  failureCode?: string;
+  failureTraceId?: string;
   inputType: VideoInputType;
   sourceUrl?: string;
   createdAt: string;

--- a/frontend/src/lib/api/upload-constraints.ts
+++ b/frontend/src/lib/api/upload-constraints.ts
@@ -1,0 +1,24 @@
+export const SUPPORTED_VIDEO_EXTENSIONS = [".mp4", ".webm", ".mov", ".mkv", ".avi", ".wmv"] as const;
+export const MAX_UPLOAD_SIZE_BYTES = 500 * 1024 * 1024;
+
+export type UploadConstraintCode = "UNSUPPORTED_FILE_TYPE" | "FILE_TOO_LARGE";
+
+export type UploadFileValidation =
+  | { ok: true; extension: string }
+  | { ok: false; code: UploadConstraintCode };
+
+export function normalizedFileExtension(fileName: string): string {
+  const dot = fileName.lastIndexOf(".");
+  return dot >= 0 ? fileName.slice(dot).toLowerCase() : "";
+}
+
+export function validateUploadFile(file: File): UploadFileValidation {
+  const extension = normalizedFileExtension(file.name);
+  if (!SUPPORTED_VIDEO_EXTENSIONS.some((supported) => supported === extension)) {
+    return { ok: false, code: "UNSUPPORTED_FILE_TYPE" };
+  }
+  if (file.size > MAX_UPLOAD_SIZE_BYTES) {
+    return { ok: false, code: "FILE_TOO_LARGE" };
+  }
+  return { ok: true, extension };
+}

--- a/frontend/src/lib/upload-completion-store.ts
+++ b/frontend/src/lib/upload-completion-store.ts
@@ -1,0 +1,60 @@
+const UPLOAD_COMPLETIONS_KEY = "biblio.uploadCompletions";
+
+interface UploadCompletionMarker {
+  projectId: string;
+  videoId: string;
+}
+
+function isUploadCompletionMarker(value: unknown): value is UploadCompletionMarker {
+  if (typeof value !== "object" || value === null) return false;
+  const marker = value as Record<string, unknown>;
+  return typeof marker.projectId === "string" && typeof marker.videoId === "string";
+}
+
+function readMarkers(): UploadCompletionMarker[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = window.localStorage.getItem(UPLOAD_COMPLETIONS_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed.filter(isUploadCompletionMarker) : [];
+  } catch {
+    try {
+      window.localStorage.removeItem(UPLOAD_COMPLETIONS_KEY);
+    } catch {
+      // 저장소가 차단된 경우 현재 화면의 상태만 사용한다.
+    }
+    return [];
+  }
+}
+
+function writeMarkers(markers: UploadCompletionMarker[]): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(UPLOAD_COMPLETIONS_KEY, JSON.stringify(markers));
+  } catch {
+    // 저장소 문제로 실제 업로드를 중단하지 않는다.
+  }
+}
+
+export function pendingUploadCompletionIds(projectId: string): string[] {
+  return readMarkers()
+    .filter((marker) => marker.projectId === projectId)
+    .map((marker) => marker.videoId);
+}
+
+export function rememberUploadCompletion(projectId: string, videoId: string): void {
+  const markers = readMarkers();
+  if (markers.some((marker) => marker.projectId === projectId && marker.videoId === videoId)) {
+    return;
+  }
+  writeMarkers([...markers, { projectId, videoId }]);
+}
+
+export function forgetUploadCompletion(projectId: string, videoId: string): void {
+  writeMarkers(
+    readMarkers().filter(
+      (marker) => marker.projectId !== projectId || marker.videoId !== videoId
+    )
+  );
+}

--- a/services/core-api/alembic/versions/0013_video_failure_metadata.py
+++ b/services/core-api/alembic/versions/0013_video_failure_metadata.py
@@ -1,0 +1,38 @@
+"""add video failure metadata
+
+Revision ID: 0013_video_failure_metadata
+Revises: 0012_processing_claimed_at
+Create Date: 2026-07-21
+"""
+
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision = "0013_video_failure_metadata"
+down_revision = "0012_processing_claimed_at"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "video",
+        sa.Column("failure_code", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "video",
+        sa.Column(
+            "failure_trace_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("video", "failure_trace_id")
+    op.drop_column("video", "failure_code")

--- a/services/core-api/src/middlewares/error_handler.py
+++ b/services/core-api/src/middlewares/error_handler.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI, Request, status
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from src.infra.db.cursor import CursorDecodeError
+from src.schemas.video_dto import UNSUPPORTED_FILE_TYPE_ERROR
 
 
 @dataclass(slots=True)
@@ -28,6 +29,18 @@ class InvalidArgumentError(ApiError):
     status_code = status.HTTP_400_BAD_REQUEST
     code = "INVALID_ARGUMENT"
     message = "The request arguments are invalid."
+
+
+class UnsupportedFileTypeError(ApiError):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "UNSUPPORTED_FILE_TYPE"
+    message = "The video file type is not supported."
+
+
+class FileTooLargeError(ApiError):
+    status_code = status.HTTP_400_BAD_REQUEST
+    code = "FILE_TOO_LARGE"
+    message = "The uploaded file exceeds the 500MB size limit."
 
 
 class AuthenticationError(ApiError):
@@ -85,7 +98,12 @@ async def validation_error_handler(
 ) -> JSONResponse:
     first_error = exc.errors()[0] if exc.errors() else None
     message = first_error.get("msg", "Request validation failed.") if first_error else "Request validation failed."
-    payload = _payload(request, InvalidArgumentError.code, message)
+    error_code = (
+        UnsupportedFileTypeError.code
+        if first_error and first_error.get("type") == UNSUPPORTED_FILE_TYPE_ERROR
+        else InvalidArgumentError.code
+    )
+    payload = _payload(request, error_code, message)
     response = JSONResponse(status_code=status.HTTP_400_BAD_REQUEST, content=asdict(payload))
     response.headers["X-Trace-Id"] = payload.trace_id
     return response

--- a/services/core-api/src/models/video.py
+++ b/services/core-api/src/models/video.py
@@ -57,6 +57,11 @@ class Video(Base):
         server_default=text("'PENDING'"),
     )
     failed_stage: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_code: Mapped[str | None] = mapped_column(Text, nullable=True)
+    failure_trace_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        nullable=True,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/services/core-api/src/schemas/video_dto.py
+++ b/services/core-api/src/schemas/video_dto.py
@@ -3,12 +3,14 @@ from typing import Annotated, Literal
 from uuid import UUID
 
 from pydantic import AnyHttpUrl, BaseModel, Field, field_validator
+from pydantic_core import PydanticCustomError
 
 Category = Literal["GENERAL", "IT", "MEDICAL", "LEGAL"]
 InputType = Literal["LOCAL_FILE", "EXTERNAL_URL"]
 VideoStatus = Literal["PENDING", "UPLOADED", "PROCESSING", "READY", "FAILED", "DELETING"]
 FailedStage = Literal["DOWNLOAD", "EXTRACT", "STT", "CHUNKING", "EMBEDDING", "VECTOR_UPSERT"]
-FileExtension = Literal[".mp4", ".webm", ".mov", ".mkv", ".avi", ".wmv"]
+SUPPORTED_FILE_EXTENSIONS = frozenset({".mp4", ".webm", ".mov", ".mkv", ".avi", ".wmv"})
+UNSUPPORTED_FILE_TYPE_ERROR = "unsupported_file_type"
 
 
 class VideoCreateBase(BaseModel):
@@ -18,7 +20,18 @@ class VideoCreateBase(BaseModel):
 
 class LocalFileVideoCreateRequest(VideoCreateBase):
     input_type: Literal["LOCAL_FILE"]
-    extension: FileExtension
+    extension: str
+
+    @field_validator("extension", mode="before")
+    @classmethod
+    def normalize_and_validate_extension(cls, value: object) -> str:
+        normalized = value.lower() if isinstance(value, str) else ""
+        if normalized not in SUPPORTED_FILE_EXTENSIONS:
+            raise PydanticCustomError(
+                UNSUPPORTED_FILE_TYPE_ERROR,
+                "Unsupported video file extension.",
+            )
+        return normalized
 
 
 class ExternalUrlVideoCreateRequest(VideoCreateBase):

--- a/services/core-api/src/schemas/video_dto.py
+++ b/services/core-api/src/schemas/video_dto.py
@@ -83,6 +83,8 @@ class VideoResponse(BaseModel):
     input_type: InputType
     source_url: AnyHttpUrl | None = None
     failed_stage: FailedStage | None = None
+    failure_code: str | None = None
+    failure_trace_id: UUID | None = None
     storage_path: str | None = None
     created_at: datetime | None = None
     updated_at: datetime | None = None

--- a/services/core-api/src/services/video_service.py
+++ b/services/core-api/src/services/video_service.py
@@ -41,6 +41,13 @@ class VideoActionResult:
     status_code: int
 
 
+@dataclass(frozen=True, slots=True)
+class VideoFailureSnapshot:
+    failed_stage: str | None
+    failure_code: str | None
+    failure_trace_id: UUID | None
+
+
 class VideoService:
     def __init__(
         self,
@@ -305,6 +312,7 @@ class VideoService:
         trace_id: UUID,
     ) -> VideoActionResult:
         self._ensure_db_session_factory()
+        self._ensure_broker_client()
 
         async with self._db_session_factory() as session:
             _, video = await self._get_video_for_requester(
@@ -315,11 +323,22 @@ class VideoService:
             if video.status != "FAILED":
                 raise ConflictError("Only failed videos can be retried.")
 
+            previous_failure = VideoFailureSnapshot(
+                failed_stage=video.failed_stage,
+                failure_code=video.failure_code,
+                failure_trace_id=video.failure_trace_id,
+            )
             video.status = "PENDING"
+            video.failed_stage = None
+            video.failure_code = None
+            video.failure_trace_id = None
             await session.commit()
 
-        self._ensure_broker_client()
-        await self._publish_message("PREPROCESS_REQUEST", video_ids=[video_id], trace_id=trace_id)
+        try:
+            await self._publish_message("PREPROCESS_REQUEST", video_ids=[video_id], trace_id=trace_id)
+        except ApiError:
+            await self._restore_video_failure(video_id, previous_failure)
+            raise
         return VideoActionResult(
             payload=RetryVideoResponse(video_id=video_id, status="PENDING"),
             status_code=202,
@@ -506,6 +525,22 @@ class VideoService:
                     video.status = status
             await session.commit()
 
+    async def _restore_video_failure(
+        self,
+        video_id: UUID,
+        failure: VideoFailureSnapshot,
+    ) -> None:
+        async with self._db_session_factory() as session:
+            repository = VideoRepository(session)
+            video = await repository.get_by_id(video_id)
+            if video is None or video.status != "PENDING":
+                return
+            video.status = "FAILED"
+            video.failed_stage = failure.failed_stage
+            video.failure_code = failure.failure_code
+            video.failure_trace_id = failure.failure_trace_id
+            await session.commit()
+
     @staticmethod
     def _require_storage_path(video: Video) -> str:
         if video.storage_path is None:
@@ -522,6 +557,8 @@ class VideoService:
             input_type=video.input_type,
             source_url=video.source_url,
             failed_stage=video.failed_stage,
+            failure_code=video.failure_code,
+            failure_trace_id=video.failure_trace_id,
             storage_path=video.storage_path,
             created_at=video.created_at,
             updated_at=video.updated_at,

--- a/services/core-api/src/services/video_service.py
+++ b/services/core-api/src/services/video_service.py
@@ -152,18 +152,20 @@ class VideoService:
 
             if video.input_type != "LOCAL_FILE":
                 raise InvalidArgumentError("Upload completion is only supported for LOCAL_FILE videos.")
-            if video.status in {"UPLOADED", "PROCESSING", "READY"}:
+            if video.status in {"PROCESSING", "READY"}:
                 return VideoActionResult(
                     payload=VideoCompleteResponse(video_id=video.id, status=video.status),
                     status_code=200,
                 )
-            if video.status != "PENDING":
+            if video.status not in {"PENDING", "UPLOADED"}:
                 raise ConflictError("Video upload cannot be completed from the current state.")
 
-            upload_size_bytes = self._get_upload_size_bytes(self._require_storage_path(video))
-            oversized = upload_size_bytes > MAX_UPLOAD_SIZE_BYTES
+            oversized = False
+            if video.status == "PENDING":
+                upload_size_bytes = self._get_upload_size_bytes(self._require_storage_path(video))
+                oversized = upload_size_bytes > MAX_UPLOAD_SIZE_BYTES
 
-            if not oversized:
+            if video.status == "PENDING" and not oversized:
                 video.status = "UPLOADED"
                 await session.commit()
 

--- a/services/core-api/src/services/video_service.py
+++ b/services/core-api/src/services/video_service.py
@@ -12,6 +12,7 @@ from src.infra.storage import MAX_UPLOAD_SIZE_BYTES, SignedUrlRequest, StorageCl
 from src.middlewares.error_handler import (
     ApiError,
     ConflictError,
+    FileTooLargeError,
     ForbiddenError,
     InvalidArgumentError,
     NotFoundError,
@@ -152,17 +153,20 @@ class VideoService:
             if video.status != "PENDING":
                 raise ConflictError("Video upload cannot be completed from the current state.")
 
-            object_name = self._require_storage_path(video)
-            metadata = self._storage_client.get_blob_metadata(object_name)
-            if not metadata.exists:
-                raise InvalidArgumentError("Uploaded object was not found in storage.")
-            if metadata.size_bytes is None:
-                raise ApiError("Uploaded object metadata is incomplete.")
-            if metadata.size_bytes > MAX_UPLOAD_SIZE_BYTES:
-                raise InvalidArgumentError("Uploaded object exceeds the 500MB size limit.")
+            upload_size_bytes = self._get_upload_size_bytes(self._require_storage_path(video))
+            oversized = upload_size_bytes > MAX_UPLOAD_SIZE_BYTES
 
-            video.status = "UPLOADED"
-            await session.commit()
+            if not oversized:
+                video.status = "UPLOADED"
+                await session.commit()
+
+        if oversized:
+            await self.delete_video(
+                video_id,
+                requester_user_id=requester_user_id,
+                trace_id=trace_id,
+            )
+            raise FileTooLargeError()
 
         self._ensure_broker_client()
         await self._publish_message("PREPROCESS_REQUEST", video_ids=[video_id], trace_id=trace_id)
@@ -374,6 +378,14 @@ class VideoService:
     def _ensure_broker_client(self) -> None:
         if self._broker_client is None:
             raise ApiError("Broker client is not configured.")
+
+    def _get_upload_size_bytes(self, object_name: str) -> int:
+        metadata = self._storage_client.get_blob_metadata(object_name)
+        if not metadata.exists:
+            raise InvalidArgumentError("Uploaded object was not found in storage.")
+        if metadata.size_bytes is None:
+            raise ApiError("Uploaded object metadata is incomplete.")
+        return metadata.size_bytes
 
     async def _get_video_for_requester(
         self,

--- a/services/core-api/tests/api/v1/test_video_complete.py
+++ b/services/core-api/tests/api/v1/test_video_complete.py
@@ -110,7 +110,18 @@ async def test_post_complete_rejects_oversized_blob(
     )
 
     assert response.status_code == 400
-    assert response.json()["code"] == "INVALID_ARGUMENT"
+    assert response.json()["code"] == "FILE_TOO_LARGE"
+    message_types = [
+        message["message_type"]
+        for message in app_context.app.state.container.broker_client.published_messages
+    ]
+    assert message_types == ["DELETE_REQUEST"]
+
+    async with app_context.session_factory() as session:
+        stored_video = await VideoRepository(session).get_by_id_for_user(video.id, UUID(requester_user_id))
+
+    assert stored_video is not None
+    assert stored_video.status == "DELETING"
 
 
 @pytest.mark.asyncio

--- a/services/core-api/tests/api/v1/test_video_complete.py
+++ b/services/core-api/tests/api/v1/test_video_complete.py
@@ -40,7 +40,7 @@ async def test_post_complete_returns_202_and_marks_video_uploaded(
 
 
 @pytest.mark.asyncio
-async def test_post_complete_is_idempotent_for_uploaded_video(
+async def test_post_complete_republishes_for_uploaded_video(
     app_context: AppContext,
     api_client: AsyncClient,
 ) -> None:
@@ -54,9 +54,11 @@ async def test_post_complete_is_idempotent_for_uploaded_video(
         json={},
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 202
     assert response.json()["status"] == "UPLOADED"
-    assert app_context.app.state.container.broker_client.published_messages == []
+    messages = app_context.app.state.container.broker_client.published_messages
+    assert len(messages) == 1
+    assert messages[0]["message_type"] == "PREPROCESS_REQUEST"
 
 
 @pytest.mark.asyncio

--- a/services/core-api/tests/api/v1/test_video_create.py
+++ b/services/core-api/tests/api/v1/test_video_create.py
@@ -23,7 +23,7 @@ async def test_post_videos_local_file_returns_201_and_persists_pending_video(
             "title": "Local upload",
             "category": "GENERAL",
             "input_type": "LOCAL_FILE",
-            "extension": ".mp4",
+            "extension": ".MP4",
         },
     )
 
@@ -94,7 +94,8 @@ async def test_post_videos_rejects_invalid_extension(
     app_context: AppContext,
     api_client: AsyncClient,
 ) -> None:
-    token = create_token(app_context.settings.jwt_secret_key, str(uuid4()))
+    requester_user_id = uuid4()
+    token = create_token(app_context.settings.jwt_secret_key, str(requester_user_id))
     response = await api_client.post(
         "/api/v1/videos",
         headers=auth_headers(token),
@@ -107,7 +108,13 @@ async def test_post_videos_rejects_invalid_extension(
     )
 
     assert response.status_code == 400
-    assert response.json()["code"] == "INVALID_ARGUMENT"
+    assert response.json()["code"] == "UNSUPPORTED_FILE_TYPE"
+    assert app_context.app.state.container.broker_client.published_messages == []
+
+    async with app_context.session_factory() as session:
+        page = await VideoRepository(session).list_for_user(requester_user_id, limit=20)
+
+    assert page.items == []
 
 
 @pytest.mark.asyncio

--- a/services/core-api/tests/api/v1/test_videos.py
+++ b/services/core-api/tests/api/v1/test_videos.py
@@ -17,6 +17,7 @@ async def test_get_videos_paginates_with_cursor_and_excludes_deleting(
     requester_user_id = UUID(str(uuid4()))
     token = create_token(app_context.settings.jwt_secret_key, str(requester_user_id))
     base_time = datetime(2026, 3, 12, 12, 0, tzinfo=UTC)
+    failure_trace_id = uuid4()
     ready_video = build_video(
         user_id=requester_user_id,
         status="READY",
@@ -34,6 +35,8 @@ async def test_get_videos_paginates_with_cursor_and_excludes_deleting(
         status="FAILED",
         title="Older visible",
         created_at=base_time,
+        failure_code="STT_FAILED",
+        failure_trace_id=failure_trace_id,
     )
     await seed_videos(app_context.session_factory, ready_video, deleting_video, failed_video)
 
@@ -54,6 +57,9 @@ async def test_get_videos_paginates_with_cursor_and_excludes_deleting(
 
     assert second_response.status_code == 200
     assert [item["title"] for item in second_response.json()["items"]] == ["Older visible"]
+    assert second_response.json()["items"][0]["failed_stage"] == "STT"
+    assert second_response.json()["items"][0]["failure_code"] == "STT_FAILED"
+    assert second_response.json()["items"][0]["failure_trace_id"] == str(failure_trace_id)
     assert second_response.json()["next_cursor"] is None
 
 
@@ -100,6 +106,8 @@ async def test_get_video_returns_owned_video_metadata(
     assert body["video_id"] == str(video.id)
     assert body["title"] == "Owned video"
     assert body["category"] == "IT"
+    assert body["failure_code"] is None
+    assert body["failure_trace_id"] is None
 
 
 @pytest.mark.asyncio
@@ -358,7 +366,13 @@ async def test_retry_video_requeues_failed_video(
 ) -> None:
     requester_user_id = UUID(str(uuid4()))
     token = create_token(app_context.settings.jwt_secret_key, str(requester_user_id))
-    video = build_video(user_id=requester_user_id, status="FAILED")
+    failure_trace_id = uuid4()
+    video = build_video(
+        user_id=requester_user_id,
+        status="FAILED",
+        failure_code="STT_FAILED",
+        failure_trace_id=failure_trace_id,
+    )
     await seed_videos(app_context.session_factory, video)
     response = await api_client.post(
         f"/api/v1/videos/{video.id}/retry",
@@ -375,7 +389,45 @@ async def test_retry_video_requeues_failed_video(
 
     assert stored_video is not None
     assert stored_video.status == "PENDING"
+    assert stored_video.failed_stage is None
+    assert stored_video.failure_code is None
+    assert stored_video.failure_trace_id is None
+
+
+@pytest.mark.asyncio
+async def test_retry_video_restores_failure_when_broker_publish_fails(
+    app_context: AppContext,
+    api_client: AsyncClient,
+) -> None:
+    requester_user_id = UUID(str(uuid4()))
+    token = create_token(app_context.settings.jwt_secret_key, str(requester_user_id))
+    failure_trace_id = uuid4()
+    video = build_video(
+        user_id=requester_user_id,
+        status="FAILED",
+        failure_code="STT_FAILED",
+        failure_trace_id=failure_trace_id,
+    )
+    await seed_videos(app_context.session_factory, video)
+    app_context.app.state.container.broker_client = InMemoryBrokerClient(
+        failures_before_success=3
+    )
+
+    response = await api_client.post(
+        f"/api/v1/videos/{video.id}/retry",
+        headers=auth_headers(token),
+    )
+
+    assert response.status_code == 500
+    async with app_context.session_factory() as session:
+        repository = VideoRepository(session)
+        stored_video = await repository.get_by_id(video.id)
+
+    assert stored_video is not None
+    assert stored_video.status == "FAILED"
     assert stored_video.failed_stage == "STT"
+    assert stored_video.failure_code == "STT_FAILED"
+    assert stored_video.failure_trace_id == failure_trace_id
 
 
 @pytest.mark.asyncio

--- a/services/core-api/tests/integration/test_video_repository.py
+++ b/services/core-api/tests/integration/test_video_repository.py
@@ -22,9 +22,28 @@ async def test_alembic_creates_video_table_and_indexes(session_factory: SessionF
             )
         )
         index_names = {row[0] for row in result.fetchall()}
+        column_result = await session.execute(
+            text(
+                """
+                SELECT column_name, data_type, udt_name, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'video'
+                  AND column_name IN ('failure_code', 'failure_trace_id')
+                """
+            )
+        )
+        columns = {
+            row.column_name: (row.data_type, row.udt_name, row.is_nullable)
+            for row in column_result
+        }
 
     assert "idx_video_user_created" in index_names
     assert "idx_video_user_status" in index_names
+    assert columns == {
+        "failure_code": ("text", "text", "YES"),
+        "failure_trace_id": ("uuid", "uuid", "YES"),
+    }
 
 
 @pytest.mark.asyncio

--- a/services/core-api/tests/support.py
+++ b/services/core-api/tests/support.py
@@ -66,6 +66,8 @@ def build_video(
     created_at: datetime | None = None,
     source_url: str | None = None,
     failed_stage: str | None = None,
+    failure_code: str | None = None,
+    failure_trace_id: UUID | None = None,
 ) -> Video:
     video_id = uuid4()
     if source_url is None and input_type == "EXTERNAL_URL":
@@ -90,5 +92,7 @@ def build_video(
         storage_path=f"videos/{user_id}/{video_id}/{path_suffix}",
         status=status,
         failed_stage=failed_stage,
+        failure_code=failure_code,
+        failure_trace_id=failure_trace_id,
         **kwargs,
     )

--- a/services/core-api/tests/unit/test_error_handler.py
+++ b/services/core-api/tests/unit/test_error_handler.py
@@ -50,6 +50,19 @@ def test_validation_error_handler_sets_header_and_invalid_argument() -> None:
     assert '"code":"INVALID_ARGUMENT"' in body
 
 
+def test_validation_error_handler_maps_unsupported_file_type() -> None:
+    class DummyValidationError(Exception):
+        def errors(self) -> list[dict[str, object]]:
+            return [{"type": "unsupported_file_type", "msg": "Unsupported video file extension."}]
+
+    request = _build_request()
+    response = asyncio.run(validation_error_handler(request, DummyValidationError()))  # type: ignore[arg-type]
+    body = response.body.decode("utf-8")
+
+    assert response.status_code == 400
+    assert '"code":"UNSUPPORTED_FILE_TYPE"' in body
+
+
 def test_cursor_decode_error_maps_to_400() -> None:
     request = _build_request()
     response = asyncio.run(cursor_decode_error_handler(request, CursorDecodeError("Invalid cursor token.")))
@@ -58,4 +71,3 @@ def test_cursor_decode_error_maps_to_400() -> None:
     assert response.status_code == 400
     assert response.headers.get("X-Trace-Id") is not None
     assert '"code":"INVALID_ARGUMENT"' in body
-

--- a/services/core-api/tests/unit/test_video_dto.py
+++ b/services/core-api/tests/unit/test_video_dto.py
@@ -1,4 +1,5 @@
 from typing import Any
+from uuid import uuid4
 
 import pytest
 from pydantic import TypeAdapter, ValidationError
@@ -8,6 +9,7 @@ from src.schemas.video_dto import (
     LocalFileVideoCreateRequest,
     VideoCreateRequest,
     VideoMutationRequest,
+    VideoResponse,
 )
 
 video_create_adapter = TypeAdapter(VideoCreateRequest)
@@ -113,3 +115,35 @@ def test_video_mutation_request_allows_partial_updates() -> None:
 
     assert payload.title == "Updated title"
     assert payload.category is None
+
+
+def test_video_response_includes_failure_metadata() -> None:
+    failure_trace_id = uuid4()
+
+    payload = VideoResponse(
+        video_id=uuid4(),
+        status="FAILED",
+        title="Failed video",
+        category="GENERAL",
+        input_type="LOCAL_FILE",
+        failed_stage="STT",
+        failure_code="STT_FAILED",
+        failure_trace_id=failure_trace_id,
+    )
+
+    assert payload.failure_code == "STT_FAILED"
+    assert payload.failure_trace_id == failure_trace_id
+
+
+def test_video_response_allows_missing_failure_metadata() -> None:
+    payload = VideoResponse(
+        video_id=uuid4(),
+        status="READY",
+        title="Ready video",
+        category="GENERAL",
+        input_type="LOCAL_FILE",
+    )
+
+    assert payload.failed_stage is None
+    assert payload.failure_code is None
+    assert payload.failure_trace_id is None

--- a/services/core-api/tests/unit/test_video_dto.py
+++ b/services/core-api/tests/unit/test_video_dto.py
@@ -27,6 +27,34 @@ def test_local_file_video_create_request_accepts_supported_extension() -> None:
     assert validated.extension == ".mp4"
 
 
+def test_local_file_video_create_request_normalizes_uppercase_extension() -> None:
+    payload: Any = {
+        "title": "Video title",
+        "category": "IT",
+        "input_type": "LOCAL_FILE",
+        "extension": ".MP4",
+    }
+
+    validated = video_create_adapter.validate_python(payload)
+
+    assert isinstance(validated, LocalFileVideoCreateRequest)
+    assert validated.extension == ".mp4"
+
+
+def test_local_file_video_create_request_marks_unsupported_extension() -> None:
+    payload: Any = {
+        "title": "Video title",
+        "category": "IT",
+        "input_type": "LOCAL_FILE",
+        "extension": ".exe",
+    }
+
+    with pytest.raises(ValidationError) as exc_info:
+        video_create_adapter.validate_python(payload)
+
+    assert exc_info.value.errors()[0]["type"] == "unsupported_file_type"
+
+
 def test_external_url_video_create_request_accepts_youtube_url() -> None:
     payload: Any = {
         "title": "Video title",

--- a/services/core-api/tests/unit/test_video_service_complete.py
+++ b/services/core-api/tests/unit/test_video_service_complete.py
@@ -61,7 +61,7 @@ async def test_complete_video_transitions_pending_local_file_and_publishes(
 
 
 @pytest.mark.asyncio
-async def test_complete_video_is_idempotent_for_uploaded_processing_or_ready(
+async def test_complete_video_is_idempotent_for_processing_or_ready(
     session_factory: SessionFactory,
 ) -> None:
     requester_user_id = uuid4()
@@ -85,6 +85,33 @@ async def test_complete_video_is_idempotent_for_uploaded_processing_or_ready(
     assert result.status_code == 200
     assert result.payload.status == "PROCESSING"
     assert broker_client.published_messages == []
+
+
+@pytest.mark.asyncio
+async def test_complete_video_republishes_for_uploaded_video(
+    session_factory: SessionFactory,
+) -> None:
+    requester_user_id = uuid4()
+    video = build_video(user_id=requester_user_id, status="UPLOADED")
+    broker_client = InMemoryBrokerClient()
+    service = VideoService(
+        db_session_factory=session_factory,
+        storage_client=InMemoryStorageClient(),
+        broker_client=broker_client,
+    )
+    await seed_video(session_factory, video)
+
+    result = await service.complete_video(
+        video.id,
+        VideoCompleteRequest(),
+        requester_user_id=requester_user_id,
+        trace_id=uuid4(),
+    )
+
+    assert result.status_code == 202
+    assert result.payload.status == "UPLOADED"
+    assert len(broker_client.published_messages) == 1
+    assert broker_client.published_messages[0]["message_type"] == "PREPROCESS_REQUEST"
 
 
 @pytest.mark.asyncio
@@ -237,10 +264,11 @@ async def test_complete_video_keeps_uploaded_status_when_broker_publish_fails(
     await seed_video(session_factory, video)
     storage_client = InMemoryStorageClient()
     storage_client.put_object(video.storage_path, b"video-bytes")
+    broker_client = InMemoryBrokerClient(failures_before_success=3)
     service = VideoService(
         db_session_factory=session_factory,
         storage_client=storage_client,
-        broker_client=InMemoryBrokerClient(failures_before_success=3),
+        broker_client=broker_client,
     )
 
     with pytest.raises(ApiError) as exc_info:
@@ -259,3 +287,13 @@ async def test_complete_video_keeps_uploaded_status_when_broker_publish_fails(
 
     assert stored_video is not None
     assert stored_video.status == "UPLOADED"
+
+    retry_result = await service.complete_video(
+        video.id,
+        VideoCompleteRequest(),
+        requester_user_id=requester_user_id,
+        trace_id=uuid4(),
+    )
+
+    assert retry_result.status_code == 202
+    assert len(broker_client.published_messages) == 1

--- a/services/core-api/tests/unit/test_video_service_complete.py
+++ b/services/core-api/tests/unit/test_video_service_complete.py
@@ -6,7 +6,13 @@ from src.infra.db.video_repository import VideoRepository
 from src.infra.inmemory_broker import InMemoryBrokerClient
 from src.infra.inmemory_storage import InMemoryStorageClient
 from src.infra.storage import MAX_UPLOAD_SIZE_BYTES
-from src.middlewares.error_handler import ApiError, ForbiddenError, InvalidArgumentError, NotFoundError
+from src.middlewares.error_handler import (
+    ApiError,
+    FileTooLargeError,
+    ForbiddenError,
+    InvalidArgumentError,
+    NotFoundError,
+)
 from src.schemas.video_dto import VideoCompleteRequest
 from src.services.video_service import VideoService
 from tests.support import SessionFactory, build_video, seed_video
@@ -111,6 +117,7 @@ async def test_complete_video_rejects_object_larger_than_500mb(session_factory: 
     storage_client = InMemoryStorageClient()
     storage_client.put_object(video.storage_path, b"x" * 8)
     storage_client.get_blob_metadata(video.storage_path)
+    broker_client = InMemoryBrokerClient()
     service = VideoService(
         db_session_factory=session_factory,
         storage_client=type(
@@ -128,10 +135,10 @@ async def test_complete_video_rejects_object_larger_than_500mb(session_factory: 
                 ),
             },
         )(),
-        broker_client=InMemoryBrokerClient(),
+        broker_client=broker_client,
     )
 
-    with pytest.raises(InvalidArgumentError) as exc_info:
+    with pytest.raises(FileTooLargeError):
         await service.complete_video(
             video.id,
             VideoCompleteRequest(),
@@ -139,7 +146,48 @@ async def test_complete_video_rejects_object_larger_than_500mb(session_factory: 
             trace_id=uuid4(),
         )
 
-    assert "500mb" in str(exc_info.value).lower()
+    assert [message["message_type"] for message in broker_client.published_messages] == ["DELETE_REQUEST"]
+
+    async with session_factory() as session:
+        stored_video = await VideoRepository(session).get_by_id_for_user(video.id, requester_user_id)
+
+    assert stored_video is not None
+    assert stored_video.status == "DELETING"
+
+
+@pytest.mark.asyncio
+async def test_complete_video_restores_pending_when_oversized_delete_publish_fails(
+    session_factory: SessionFactory,
+) -> None:
+    requester_user_id = uuid4()
+    video = build_video(user_id=requester_user_id)
+    await seed_video(session_factory, video)
+    storage_client = InMemoryStorageClient()
+    storage_client.put_object(video.storage_path, b"x" * 8)
+    storage_client.get_blob_metadata = lambda object_name: type(
+        "BlobMetadataLike",
+        (),
+        {"exists": True, "size_bytes": MAX_UPLOAD_SIZE_BYTES + 1, "etag": "etag"},
+    )()
+    service = VideoService(
+        db_session_factory=session_factory,
+        storage_client=storage_client,
+        broker_client=InMemoryBrokerClient(failures_before_success=3),
+    )
+
+    with pytest.raises(ApiError):
+        await service.complete_video(
+            video.id,
+            VideoCompleteRequest(),
+            requester_user_id=requester_user_id,
+            trace_id=uuid4(),
+        )
+
+    async with session_factory() as session:
+        stored_video = await VideoRepository(session).get_by_id_for_user(video.id, requester_user_id)
+
+    assert stored_video is not None
+    assert stored_video.status == "PENDING"
 
 
 @pytest.mark.asyncio

--- a/services/pipeline-worker/src/infra/db/artifact_repository.py
+++ b/services/pipeline-worker/src/infra/db/artifact_repository.py
@@ -293,6 +293,8 @@ class ArtifactRepository:
                     .values(
                         status="READY",
                         failed_stage=None,
+                        failure_code=None,
+                        failure_trace_id=None,
                         processing_claimed_at=None,
                     )
                 )

--- a/services/pipeline-worker/src/infra/db/models.py
+++ b/services/pipeline-worker/src/infra/db/models.py
@@ -57,6 +57,8 @@ class VideoModel(Base):
     storage_path: Mapped[str | None] = mapped_column(Text(), nullable=True)
     status: Mapped[str] = mapped_column(Text(), nullable=False, default="PENDING")
     failed_stage: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    failure_code: Mapped[str | None] = mapped_column(Text(), nullable=True)
+    failure_trace_id: Mapped[UUID | None] = mapped_column(Uuid(), nullable=True)
     processing_claimed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True),
         nullable=True,

--- a/services/pipeline-worker/src/infra/db/video_repository.py
+++ b/services/pipeline-worker/src/infra/db/video_repository.py
@@ -188,7 +188,7 @@ class VideoRepository:
             else:
                 statement = statement.where(
                     or_(
-                        VideoModel.status.in_(("PENDING", "UPLOADED", "FAILED")),
+                        VideoModel.status.in_(("PENDING", "UPLOADED")),
                         and_(
                             VideoModel.status == "PROCESSING",
                             VideoModel.processing_claimed_at < stale_cutoff,

--- a/services/pipeline-worker/src/infra/db/video_repository.py
+++ b/services/pipeline-worker/src/infra/db/video_repository.py
@@ -23,6 +23,8 @@ class VideoRecord:
     storage_path: str | None = None
     status: VideoStatus = "PENDING"
     failed_stage: str | None = None
+    failure_code: str | None = None
+    failure_trace_id: UUID | str | None = None
     processing_claimed_at: datetime | None = None
 
 
@@ -64,6 +66,12 @@ class VideoRepository:
                     storage_path=video.storage_path,
                     status=video.status,
                     failed_stage=video.failed_stage,
+                    failure_code=video.failure_code,
+                    failure_trace_id=(
+                        self._normalize_uuid(video.failure_trace_id)
+                        if video.failure_trace_id is not None
+                        else None
+                    ),
                 )
             )
             await session.commit()
@@ -189,6 +197,8 @@ class VideoRepository:
                 ).values(
                     status="PROCESSING",
                     failed_stage=None,
+                    failure_code=None,
+                    failure_trace_id=None,
                     processing_claimed_at=func.now(),
                 )
             result = await session.execute(statement)
@@ -254,10 +264,17 @@ class VideoRepository:
         video_id: UUID | str,
         *,
         failed_stage: str,
+        failure_code: str | None = None,
+        failure_trace_id: UUID | str | None = None,
         error_message: str | None = None,
     ) -> bool:
         del error_message
         normalized_video_id = self._normalize_uuid(video_id)
+        normalized_trace_id = (
+            self._normalize_uuid(failure_trace_id)
+            if failure_trace_id is not None
+            else None
+        )
         async with self._session_factory() as session:
             failed_result = await session.execute(
                 update(VideoModel)
@@ -270,6 +287,8 @@ class VideoRepository:
                 .values(
                     status="FAILED",
                     failed_stage=failed_stage,
+                    failure_code=failure_code,
+                    failure_trace_id=normalized_trace_id,
                     processing_claimed_at=None,
                 )
             )
@@ -299,7 +318,12 @@ class VideoRepository:
     ) -> None:
         normalized_video_id = self._normalize_uuid(video_id)
         async with self._session_factory() as session:
-            values = {"status": status, "failed_stage": failed_stage}
+            values = {
+                "status": status,
+                "failed_stage": failed_stage,
+                "failure_code": None,
+                "failure_trace_id": None,
+            }
             if clear_processing_claim:
                 values["processing_claimed_at"] = None
             await session.execute(
@@ -340,6 +364,8 @@ class VideoRepository:
             storage_path=model.storage_path,
             status=model.status,
             failed_stage=model.failed_stage,
+            failure_code=model.failure_code,
+            failure_trace_id=model.failure_trace_id,
             processing_claimed_at=model.processing_claimed_at,
         )
 

--- a/services/pipeline-worker/src/infra/db/video_repository.py
+++ b/services/pipeline-worker/src/infra/db/video_repository.py
@@ -266,9 +266,7 @@ class VideoRepository:
         failed_stage: str,
         failure_code: str | None = None,
         failure_trace_id: UUID | str | None = None,
-        error_message: str | None = None,
     ) -> bool:
-        del error_message
         normalized_video_id = self._normalize_uuid(video_id)
         normalized_trace_id = (
             self._normalize_uuid(failure_trace_id)

--- a/services/pipeline-worker/src/infra/media/youtube_downloader.py
+++ b/services/pipeline-worker/src/infra/media/youtube_downloader.py
@@ -2,11 +2,9 @@ import asyncio
 from pathlib import Path
 from typing import Any, Callable, Literal, Protocol
 
-from src.utils.logging import get_logger
-
-
 DownloadFailureCategory = Literal[
     "proxy_error",
+    "source_limit_exceeded",
     "youtube_block",
     "video_unavailable",
     "unknown",
@@ -87,11 +85,6 @@ class YtDlpYoutubeDownloader:
             raise
         except Exception as exc:
             error = self._classify_download_error(exc)
-            get_logger().bind(video_id=destination.parent.name).warning(
-                "youtube download failed category={} original_error={}",
-                error.category,
-                str(exc),
-            )
             raise error from exc
 
     def _download_sync(self, source_url: str, destination: Path) -> Path:
@@ -142,15 +135,24 @@ class YtDlpYoutubeDownloader:
     def _validate_metadata(self, info: dict[str, Any]) -> None:
         duration = info.get("duration")
         if duration is not None and float(duration) > self._max_duration_sec:
-            raise DownloadError(f"YouTube video duration exceeds {self._max_duration_sec} seconds.")
+            raise DownloadError(
+                f"YouTube video duration exceeds {self._max_duration_sec} seconds.",
+                category="source_limit_exceeded",
+            )
 
         filesize = info.get("filesize") or info.get("filesize_approx")
         if filesize is not None and int(filesize) > self._max_filesize_bytes:
-            raise DownloadError(f"YouTube video size exceeds {self._max_filesize_bytes} bytes.")
+            raise DownloadError(
+                f"YouTube video size exceeds {self._max_filesize_bytes} bytes.",
+                category="source_limit_exceeded",
+            )
 
     def _validate_downloaded_file(self, destination: Path) -> None:
         if destination.stat().st_size > self._max_filesize_bytes:
-            raise DownloadError(f"YouTube video size exceeds {self._max_filesize_bytes} bytes.")
+            raise DownloadError(
+                f"YouTube video size exceeds {self._max_filesize_bytes} bytes.",
+                category="source_limit_exceeded",
+            )
 
     @staticmethod
     def _classify_download_error(exc: Exception) -> DownloadError:

--- a/services/pipeline-worker/src/services/failure_classifier.py
+++ b/services/pipeline-worker/src/services/failure_classifier.py
@@ -1,0 +1,103 @@
+from src.infra.ai.google_stt_adapter import ExternalAIAdapterError
+from src.infra.media.youtube_downloader import DownloadError
+from src.services.pipeline_errors import (
+    AudioPreparationError,
+    FailureCode,
+    PipelineFailure,
+    PipelineStage,
+    PipelineStageError,
+    SourceLimitExceededError,
+)
+
+
+_DOWNLOAD_FAILURE_CODE_BY_CATEGORY: dict[str, FailureCode] = {
+    "youtube_block": "YOUTUBE_BLOCKED",
+    "source_limit_exceeded": "SOURCE_LIMIT_EXCEEDED",
+    "proxy_error": "SOURCE_UNAVAILABLE",
+    "video_unavailable": "SOURCE_UNAVAILABLE",
+    "unknown": "SOURCE_UNAVAILABLE",
+}
+
+
+def classify_pipeline_failure(exception: Exception) -> PipelineFailure:
+    failed_stage, cause = _unwrap_stage_error(exception)
+
+    if failed_stage == "DOWNLOAD" and isinstance(cause, DownloadError):
+        return PipelineFailure(
+            failed_stage="DOWNLOAD",
+            failure_code=_DOWNLOAD_FAILURE_CODE_BY_CATEGORY[cause.category],
+            provider="youtube",
+            exception=cause,
+        )
+    if failed_stage == "DOWNLOAD" and isinstance(cause, FileNotFoundError):
+        return PipelineFailure(
+            failed_stage="DOWNLOAD",
+            failure_code="SOURCE_UNAVAILABLE",
+            exception=cause,
+        )
+    if isinstance(cause, SourceLimitExceededError):
+        return PipelineFailure(
+            failed_stage=failed_stage,
+            failure_code="SOURCE_LIMIT_EXCEEDED",
+            exception=cause,
+        )
+    if isinstance(cause, AudioPreparationError):
+        return PipelineFailure(
+            failed_stage=failed_stage,
+            failure_code="AUDIO_EXTRACTION_FAILED",
+            exception=cause,
+        )
+    if isinstance(cause, ExternalAIAdapterError):
+        return _classify_provider_failure(cause, failed_stage)
+    if isinstance(exception, PipelineStageError) and failed_stage == "VECTOR_UPSERT":
+        return PipelineFailure(
+            failed_stage=failed_stage,
+            failure_code="INDEX_WRITE_FAILED",
+            exception=cause,
+        )
+    return PipelineFailure(
+        failed_stage=failed_stage,
+        failure_code="INTERNAL_PROCESSING_ERROR",
+        exception=cause,
+    )
+
+
+def _unwrap_stage_error(exception: Exception) -> tuple[PipelineStage, Exception]:
+    if isinstance(exception, PipelineStageError):
+        return exception.failed_stage, exception.cause
+    if isinstance(exception, (DownloadError, FileNotFoundError)):
+        return "DOWNLOAD", exception
+    if isinstance(exception, AudioPreparationError):
+        return "EXTRACT", exception
+    if isinstance(exception, ExternalAIAdapterError):
+        if exception.provider == "google-stt":
+            return "STT", exception
+        if exception.provider == "embedding-endpoint":
+            return "EMBEDDING", exception
+    return "VECTOR_UPSERT", exception
+
+
+def _classify_provider_failure(
+    exception: ExternalAIAdapterError,
+    failed_stage: PipelineStage,
+) -> PipelineFailure:
+    if exception.provider == "google-stt":
+        return PipelineFailure(
+            failed_stage="STT",
+            failure_code="STT_FAILED",
+            provider=exception.provider,
+            exception=exception,
+        )
+    if exception.provider == "embedding-endpoint":
+        return PipelineFailure(
+            failed_stage="EMBEDDING",
+            failure_code="EMBEDDING_FAILED",
+            provider=exception.provider,
+            exception=exception,
+        )
+    return PipelineFailure(
+        failed_stage=failed_stage,
+        failure_code="INTERNAL_PROCESSING_ERROR",
+        provider=exception.provider,
+        exception=exception,
+    )

--- a/services/pipeline-worker/src/services/pipeline_errors.py
+++ b/services/pipeline-worker/src/services/pipeline_errors.py
@@ -1,6 +1,50 @@
+from dataclasses import dataclass
+from typing import Literal
+
+
+PipelineStage = Literal[
+    "DOWNLOAD",
+    "EXTRACT",
+    "STT",
+    "CHUNKING",
+    "EMBEDDING",
+    "VECTOR_UPSERT",
+]
+
+FailureCode = Literal[
+    "YOUTUBE_BLOCKED",
+    "SOURCE_UNAVAILABLE",
+    "SOURCE_LIMIT_EXCEEDED",
+    "AUDIO_EXTRACTION_FAILED",
+    "STT_FAILED",
+    "EMBEDDING_FAILED",
+    "INDEX_WRITE_FAILED",
+    "INTERNAL_PROCESSING_ERROR",
+]
+
+
 class AudioPreparationError(Exception):
     """Raised when audio validation, splitting, or upload cannot complete."""
 
 
+class SourceLimitExceededError(AudioPreparationError):
+    """Raised when the source exceeds a configured size or duration limit."""
+
+
 class DeleteRequested(Exception):
     """Raised when a processing worker observes a pending video deletion."""
+
+
+class PipelineStageError(Exception):
+    def __init__(self, failed_stage: PipelineStage, cause: Exception) -> None:
+        super().__init__(str(cause))
+        self.failed_stage = failed_stage
+        self.cause = cause
+
+
+@dataclass(frozen=True, slots=True)
+class PipelineFailure:
+    failed_stage: PipelineStage
+    failure_code: FailureCode
+    exception: Exception
+    provider: str | None = None

--- a/services/pipeline-worker/src/services/pipeline_orchestrator.py
+++ b/services/pipeline-worker/src/services/pipeline_orchestrator.py
@@ -1,7 +1,9 @@
 import asyncio
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from time import perf_counter
+from typing import Iterator
 
 from loguru import logger
 
@@ -22,7 +24,13 @@ from src.infra.media.youtube_downloader import DownloadError, YoutubeDownloader
 from src.infra.storage.client import StorageClient
 from src.services.chunking_service import ChunkingService
 from src.services.long_audio_transcription import LongAudioTranscriptionService
-from src.services.pipeline_errors import AudioPreparationError, DeleteRequested
+from src.services.pipeline_errors import (
+    AudioPreparationError,
+    DeleteRequested,
+    PipelineStage,
+    PipelineStageError,
+    SourceLimitExceededError,
+)
 from src.services.text_normalizer import normalize_enriched_text
 from src.utils.workdir import WorkdirManager
 
@@ -40,6 +48,16 @@ class PipelineArtifacts:
     transcript_segments: list[TranscriptSegmentRecord]
     chunks: list[ChunkRecord]
     embeddings: list[list[float]]
+
+
+@contextmanager
+def _pipeline_stage(failed_stage: PipelineStage) -> Iterator[None]:
+    try:
+        yield
+    except (DeleteRequested, PipelineStageError):
+        raise
+    except Exception as exc:
+        raise PipelineStageError(failed_stage, exc) from exc
 
 
 class PipelineOrchestrator:
@@ -103,22 +121,25 @@ class PipelineOrchestrator:
         with self._workdir_manager.temporary(video.id) as workdir:
             try:
                 started_at = perf_counter()
-                with logger.contextualize(trace_id=trace_id, video_id=str(video.id)):
-                    original = await self._download_source(video, workdir)
+                with _pipeline_stage("DOWNLOAD"):
+                    with logger.contextualize(trace_id=trace_id, video_id=str(video.id)):
+                        original = await self._download_source(video, workdir)
+                    await self._assert_not_deleting(video.id)
                 record_timing("download", started_at)
-                await self._assert_not_deleting(video.id)
 
                 started_at = perf_counter()
-                audio_ref = await self._ensure_audio(video, workdir, original, state)
+                with _pipeline_stage("EXTRACT"):
+                    audio_ref = await self._ensure_audio(video, workdir, original, state)
+                    await self._assert_not_deleting(video.id)
                 record_timing("audio", started_at)
-                await self._assert_not_deleting(video.id)
 
                 started_at = perf_counter()
-                segments, stt_result = await self._ensure_transcript(
-                    video, audio_ref, state, self._stt_model_version, trace_id, workdir,
-                )
+                with _pipeline_stage("STT"):
+                    segments, stt_result = await self._ensure_transcript(
+                        video, audio_ref, state, self._stt_model_version, trace_id, workdir,
+                    )
+                    await self._assert_not_deleting(video.id)
                 record_timing("stt", started_at)
-                await self._assert_not_deleting(video.id)
 
                 if stt_result.stt_model_version != self._stt_model_version:
                     logger.warning(
@@ -127,31 +148,33 @@ class PipelineOrchestrator:
                         stt_result.stt_model_version,
                     )
 
-                release_target = await self._load_release_target()
-
                 started_at = perf_counter()
-                chunks = await self._build_enriched_chunks(
-                    video, workdir, original, stt_result, release_target.model_version, trace_id,
-                )
+                with _pipeline_stage("CHUNKING"):
+                    release_target = await self._load_release_target()
+                    chunks = await self._build_enriched_chunks(
+                        video, workdir, original, stt_result, release_target.model_version, trace_id,
+                    )
                 record_timing("chunk_enrichment", started_at)
 
                 started_at = perf_counter()
-                embeddings = await self._build_embeddings(
-                    chunks,
-                    trace_id=trace_id,
-                    release_target=release_target,
-                )
+                with _pipeline_stage("EMBEDDING"):
+                    embeddings = await self._build_embeddings(
+                        chunks,
+                        trace_id=trace_id,
+                        release_target=release_target,
+                    )
+                    await self._assert_not_deleting(video.id)
                 record_timing("embedding", started_at)
-                await self._assert_not_deleting(video.id)
 
                 started_at = perf_counter()
-                await self._persist_results(
-                    video.id,
-                    chunks,
-                    embeddings,
-                    index_name=release_target.index_name,
-                    set_ready=True,
-                )
+                with _pipeline_stage("VECTOR_UPSERT"):
+                    await self._persist_results(
+                        video.id,
+                        chunks,
+                        embeddings,
+                        index_name=release_target.index_name,
+                        set_ready=True,
+                    )
                 record_timing("persist", started_at)
 
                 artifacts = PipelineArtifacts(
@@ -172,15 +195,6 @@ class PipelineOrchestrator:
                     trace_id=trace_id,
                     video_id=str(video.id),
                     status="deleted",
-                    timings=timings,
-                    total_duration=perf_counter() - total_started_at,
-                )
-                raise
-            except Exception:
-                self._log_timings(
-                    trace_id=trace_id,
-                    video_id=str(video.id),
-                    status="failed",
                     timings=timings,
                     total_duration=perf_counter() - total_started_at,
                 )
@@ -293,7 +307,7 @@ class PipelineOrchestrator:
 
     async def _validate_source_before_extraction(self, source_path: Path) -> None:
         if source_path.stat().st_size > self._max_source_size_bytes:
-            raise AudioPreparationError(
+            raise SourceLimitExceededError(
                 f"Source size exceeds {self._max_source_size_bytes} bytes: {source_path}"
             )
         try:
@@ -304,7 +318,7 @@ class PipelineOrchestrator:
 
     def _validate_duration(self, duration_ms: int) -> None:
         if duration_ms > self._max_audio_duration_ms:
-            raise AudioPreparationError(
+            raise SourceLimitExceededError(
                 f"Audio duration exceeds {self._max_audio_duration_ms} milliseconds"
             )
 

--- a/services/pipeline-worker/src/usecases/process_video.py
+++ b/services/pipeline-worker/src/usecases/process_video.py
@@ -2,20 +2,11 @@ from dataclasses import dataclass
 
 from loguru import logger
 
-from src.infra.ai.google_stt_adapter import ExternalAIAdapterError
 from src.infra.db.video_repository import VideoRepository
-from src.infra.media.youtube_downloader import DownloadError
-from src.services.pipeline_errors import AudioPreparationError, DeleteRequested
+from src.services.failure_classifier import classify_pipeline_failure
+from src.services.pipeline_errors import DeleteRequested, PipelineFailure
 from src.services.pipeline_orchestrator import PipelineOrchestrator
 from src.usecases.delete_video import DeleteVideoUseCase
-
-
-FAILED_STAGE_BY_CODE = {
-    "TIMEOUT": "EMBEDDING",
-    "UNAVAILABLE": "EMBEDDING",
-    "RATE_LIMITED": "EMBEDDING",
-    "INTERNAL_ERROR": "VECTOR_UPSERT",
-}
 
 
 @dataclass(slots=True)
@@ -89,48 +80,11 @@ class ProcessVideoUseCase:
             await self._video_repository.release_processing_claim(video_id)
             await self._delete_video_use_case.execute(video_ids=[video_id], trace_id=trace_id)
             return ProcessVideoResult(action="deleted")
-        except DownloadError as exc:
-            return await self._fail_or_delete(
-                video_id=video_id,
-                trace_id=trace_id,
-                failed_stage="DOWNLOAD",
-                error_message=str(exc),
-            )
-        except FileNotFoundError as exc:
-            return await self._fail_or_delete(
-                video_id=video_id,
-                trace_id=trace_id,
-                failed_stage="DOWNLOAD",
-                error_message=str(exc),
-            )
-        except AudioPreparationError as exc:
-            logger.bind(trace_id=trace_id, video_id=video_id).error(
-                "Audio preparation failed failed_stage=EXTRACT error={}",
-                exc,
-            )
-            return await self._fail_or_delete(
-                video_id=video_id,
-                trace_id=trace_id,
-                failed_stage="EXTRACT",
-                error_message=str(exc),
-            )
-        except ExternalAIAdapterError as exc:
-            if exc.provider == "google-stt":
-                failed_stage = "STT"
-            else:
-                failed_stage = FAILED_STAGE_BY_CODE.get(exc.code, "VECTOR_UPSERT")
-            return await self._fail_or_delete(
-                video_id=video_id,
-                trace_id=trace_id,
-                failed_stage=failed_stage,
-                error_message=exc.message,
-            )
         except Exception as exc:
             return await self._fail_or_delete(
                 video_id=video_id,
                 trace_id=trace_id,
-                failed_stage="VECTOR_UPSERT",
-                error_message=str(exc),
+                failure=classify_pipeline_failure(exc),
             )
 
     async def _fail_or_delete(
@@ -138,15 +92,48 @@ class ProcessVideoUseCase:
         *,
         video_id: str,
         trace_id: str,
-        failed_stage: str,
-        error_message: str,
+        failure: PipelineFailure,
     ) -> ProcessVideoResult:
         marked_failed = await self._video_repository.set_failed(
             video_id,
-            failed_stage=failed_stage,
-            error_message=error_message,
+            failed_stage=failure.failed_stage,
+            failure_code=failure.failure_code,
+            failure_trace_id=trace_id,
         )
         if marked_failed:
-            return ProcessVideoResult(action="failed", failed_stage=failed_stage)
+            self._log_terminal_failure(
+                video_id=video_id,
+                trace_id=trace_id,
+                failure=failure,
+            )
+            return ProcessVideoResult(action="failed", failed_stage=failure.failed_stage)
         await self._delete_video_use_case.execute(video_ids=[video_id], trace_id=trace_id)
         return ProcessVideoResult(action="deleted")
+
+    @staticmethod
+    def _log_terminal_failure(
+        *,
+        video_id: str,
+        trace_id: str,
+        failure: PipelineFailure,
+    ) -> None:
+        failure_logger = logger.bind(
+            video_id=video_id,
+            trace_id=trace_id,
+            failed_stage=failure.failed_stage,
+            failure_code=failure.failure_code,
+        )
+        if failure.provider is not None:
+            failure_logger = failure_logger.bind(provider=failure.provider)
+            failure_logger.opt(exception=failure.exception).error(
+                "video.processing.failed failed_stage={} failure_code={} provider={}",
+                failure.failed_stage,
+                failure.failure_code,
+                failure.provider,
+            )
+            return
+        failure_logger.opt(exception=failure.exception).error(
+            "video.processing.failed failed_stage={} failure_code={}",
+            failure.failed_stage,
+            failure.failure_code,
+        )

--- a/services/pipeline-worker/tests/integration/test_repositories.py
+++ b/services/pipeline-worker/tests/integration/test_repositories.py
@@ -181,7 +181,7 @@ async def test_ready_persist_rolls_back_when_delete_wins_race(
 
 
 class TestProcessingClaimRecovery:
-    @pytest.mark.parametrize("status", ["PENDING", "UPLOADED", "FAILED"])
+    @pytest.mark.parametrize("status", ["PENDING", "UPLOADED"])
     @pytest.mark.asyncio
     async def test_existing_claimable_statuses_remain_claimable(
         self,
@@ -199,6 +199,23 @@ class TestProcessingClaimRecovery:
         )
 
         assert await video_repository.claim_processing(video_id) is True
+
+    @pytest.mark.asyncio
+    async def test_failed_status_requires_explicit_retry(
+        self,
+        video_repository,
+    ) -> None:
+        video_id = str(uuid4())
+        await video_repository.create_video(
+            VideoRecord(
+                id=video_id,
+                user_id=str(uuid4()),
+                storage_path="videos/source.mp4",
+                status="FAILED",
+            )
+        )
+
+        assert await video_repository.claim_processing(video_id) is False
 
     @pytest.mark.asyncio
     async def test_fresh_processing_claim_is_rejected(

--- a/services/pipeline-worker/tests/integration/test_repositories.py
+++ b/services/pipeline-worker/tests/integration/test_repositories.py
@@ -101,6 +101,50 @@ async def test_persist_chunks_and_vectors_stores_vector_entries_with_video_owner
 
 
 @pytest.mark.asyncio
+async def test_ready_persist_clears_previous_failure_metadata(
+    video_repository,
+    artifact_repository,
+) -> None:
+    video_id = uuid4()
+    await video_repository.create_video(
+        VideoRecord(
+            id=video_id,
+            user_id=uuid4(),
+            status="PROCESSING",
+            failed_stage="STT",
+            failure_code="STT_FAILED",
+            failure_trace_id=uuid4(),
+        )
+    )
+
+    persisted = await artifact_repository.persist_chunks_and_vectors(
+        video_id,
+        chunks=[
+            ChunkRecord(
+                chunk_index=0,
+                text="hello",
+                enriched_text="hello",
+                start_ms=0,
+                end_ms=1,
+                chunking_version="v1",
+                stt_model_version="google-stt-v1",
+                embedding_model_version="v001",
+            )
+        ],
+        embeddings=[[1.0, 2.0]],
+        set_ready=True,
+    )
+
+    video = await video_repository.get_video(video_id)
+    assert persisted is True
+    assert video is not None
+    assert video.status == "READY"
+    assert video.failed_stage is None
+    assert video.failure_code is None
+    assert video.failure_trace_id is None
+
+
+@pytest.mark.asyncio
 async def test_ready_persist_rolls_back_when_delete_wins_race(
     video_repository,
     artifact_repository,

--- a/services/pipeline-worker/tests/integration/test_resume_flow.py
+++ b/services/pipeline-worker/tests/integration/test_resume_flow.py
@@ -21,7 +21,7 @@ async def test_resume_flow_reuses_existing_transcript_and_audio(
             id=video_id,
             user_id=str(uuid4()),
             storage_path="videos/source.mp4",
-            status="FAILED",
+            status="PENDING",
             failed_stage="CHUNKING",
         )
     )
@@ -58,7 +58,7 @@ async def test_resume_flow_reuses_audio_asset_uri_without_ffmpeg(
             id=video_id,
             user_id=str(uuid4()),
             storage_path="videos/source.mp4",
-            status="FAILED",
+            status="PENDING",
             failed_stage="STT",
         )
     )

--- a/services/pipeline-worker/tests/unit/test_failure_classifier.py
+++ b/services/pipeline-worker/tests/unit/test_failure_classifier.py
@@ -1,0 +1,29 @@
+from src.services.failure_classifier import classify_pipeline_failure
+from src.services.pipeline_errors import AudioPreparationError, PipelineStageError
+
+
+def test_unknown_unwrapped_error_uses_internal_processing_code() -> None:
+    exception = RuntimeError("unexpected processing failure")
+
+    failure = classify_pipeline_failure(exception)
+
+    assert failure.failure_code == "INTERNAL_PROCESSING_ERROR"
+    assert failure.exception is exception
+
+
+def test_file_not_found_outside_download_keeps_actual_stage() -> None:
+    exception = FileNotFoundError("keyframe missing")
+
+    failure = classify_pipeline_failure(PipelineStageError("CHUNKING", exception))
+
+    assert failure.failed_stage == "CHUNKING"
+    assert failure.failure_code == "INTERNAL_PROCESSING_ERROR"
+
+
+def test_audio_preparation_error_uses_audio_extraction_code() -> None:
+    exception = AudioPreparationError("ffmpeg failed")
+
+    failure = classify_pipeline_failure(PipelineStageError("EXTRACT", exception))
+
+    assert failure.failed_stage == "EXTRACT"
+    assert failure.failure_code == "AUDIO_EXTRACTION_FAILED"

--- a/services/pipeline-worker/tests/unit/test_process_video.py
+++ b/services/pipeline-worker/tests/unit/test_process_video.py
@@ -110,6 +110,7 @@ async def test_process_video_fails_on_missing_storage_object(
     process_video_use_case,
 ) -> None:
     video_id = str(uuid4())
+    trace_id = uuid4()
     # storage_path DB에 있지만 storage_client에는 없음 → download에서 FileNotFoundError
     await video_repository.create_video(
         VideoRecord(id=video_id, user_id=str(uuid4()), storage_path="videos/missing.mp4", status="UPLOADED")
@@ -117,7 +118,7 @@ async def test_process_video_fails_on_missing_storage_object(
 
     result = await process_video_use_case.execute(
         video_id=video_id,
-        trace_id="trace-fail-dl",
+        trace_id=str(trace_id),
     )
 
     assert result.action == "failed"
@@ -125,6 +126,8 @@ async def test_process_video_fails_on_missing_storage_object(
     video = await video_repository.get_video(video_id)
     assert video.status == "FAILED"
     assert video.failed_stage == "DOWNLOAD"
+    assert video.failure_code == "SOURCE_UNAVAILABLE"
+    assert video.failure_trace_id == trace_id
 
 
 @pytest.mark.asyncio
@@ -134,6 +137,7 @@ async def test_process_video_fails_on_embedding_exhausted(
     storage_client,
 ) -> None:
     video_id = str(uuid4())
+    trace_id = uuid4()
     storage_client.objects["videos/source.mp4"] = b"video"
     await video_repository.create_video(
         VideoRecord(id=video_id, user_id=str(uuid4()), storage_path="videos/source.mp4", status="UPLOADED")
@@ -170,7 +174,7 @@ async def test_process_video_fails_on_embedding_exhausted(
 
     result = await use_case.execute(
         video_id=video_id,
-        trace_id="trace-embed-fail",
+        trace_id=str(trace_id),
     )
 
     assert result.action == "failed"
@@ -178,6 +182,8 @@ async def test_process_video_fails_on_embedding_exhausted(
     video = await video_repository.get_video(video_id)
     assert video.status == "FAILED"
     assert video.failed_stage == "EMBEDDING"
+    assert video.failure_code == "EMBEDDING_FAILED"
+    assert video.failure_trace_id == trace_id
 
 
 @pytest.mark.asyncio
@@ -187,6 +193,7 @@ async def test_process_video_fails_on_stt_exhausted(
     storage_client,
 ) -> None:
     video_id = str(uuid4())
+    trace_id = uuid4()
     storage_client.objects["videos/source.mp4"] = b"video"
     await video_repository.create_video(
         VideoRecord(id=video_id, user_id=str(uuid4()), storage_path="videos/source.mp4", status="UPLOADED")
@@ -222,7 +229,7 @@ async def test_process_video_fails_on_stt_exhausted(
 
     result = await use_case.execute(
         video_id=video_id,
-        trace_id="trace-stt-fail",
+        trace_id=str(trace_id),
     )
 
     assert result.action == "failed"
@@ -230,6 +237,8 @@ async def test_process_video_fails_on_stt_exhausted(
     video = await video_repository.get_video(video_id)
     assert video.status == "FAILED"
     assert video.failed_stage == "STT"
+    assert video.failure_code == "STT_FAILED"
+    assert video.failure_trace_id == trace_id
 
 
 @pytest.mark.asyncio
@@ -261,8 +270,12 @@ async def test_process_video_maps_download_error_to_download_stage(
     youtube_downloader,
 ) -> None:
     video_id = str(uuid4())
+    trace_id = uuid4()
     source_url = "https://youtu.be/private"
-    youtube_downloader.errors[source_url] = DownloadError("video is private")
+    youtube_downloader.errors[source_url] = DownloadError(
+        "Sign in to confirm you're not a bot",
+        category="youtube_block",
+    )
     await video_repository.create_video(
         VideoRecord(
             id=video_id,
@@ -274,16 +287,34 @@ async def test_process_video_maps_download_error_to_download_stage(
         )
     )
 
-    result = await process_video_use_case.execute(
-        video_id=video_id,
-        trace_id="trace-download-error",
+    failure_records = []
+    sink_id = logger.add(
+        lambda message: failure_records.append(message.record),
+        filter=lambda record: record["message"].startswith("video.processing.failed"),
     )
+    try:
+        result = await process_video_use_case.execute(
+            video_id=video_id,
+            trace_id=str(trace_id),
+        )
+    finally:
+        logger.remove(sink_id)
 
     video = await video_repository.get_video(video_id)
     assert result.action == "failed"
     assert result.failed_stage == "DOWNLOAD"
     assert video.status == "FAILED"
     assert video.failed_stage == "DOWNLOAD"
+    assert video.failure_code == "YOUTUBE_BLOCKED"
+    assert video.failure_trace_id == trace_id
+    assert len(failure_records) == 1
+    assert failure_records[0]["extra"] == {
+        "video_id": video_id,
+        "trace_id": str(trace_id),
+        "failed_stage": "DOWNLOAD",
+        "failure_code": "YOUTUBE_BLOCKED",
+        "provider": "youtube",
+    }
 
 
 @pytest.mark.asyncio
@@ -293,6 +324,7 @@ async def test_process_video_maps_source_limit_failure_to_extract_stage(
     storage_client,
 ) -> None:
     video_id = str(uuid4())
+    trace_id = uuid4()
     storage_client.objects["videos/source.mp4"] = b"too-large"
     await video_repository.create_video(
         VideoRecord(
@@ -334,7 +366,7 @@ async def test_process_video_maps_source_limit_failure_to_extract_stage(
     messages: list[str] = []
     sink_id = logger.add(messages.append, format="{message}")
     try:
-        result = await use_case.execute(video_id=video_id, trace_id="trace-extract-limit")
+        result = await use_case.execute(video_id=video_id, trace_id=str(trace_id))
     finally:
         logger.remove(sink_id)
 
@@ -342,10 +374,12 @@ async def test_process_video_maps_source_limit_failure_to_extract_stage(
     assert result.failed_stage == "EXTRACT"
     failed_video = await video_repository.get_video(video_id)
     assert failed_video.failed_stage == "EXTRACT"
+    assert failed_video.failure_code == "SOURCE_LIMIT_EXCEEDED"
+    assert failed_video.failure_trace_id == trace_id
     assert failed_video.processing_claimed_at is None
     assert any(
-        "Audio preparation failed failed_stage=EXTRACT" in message
-        and "Source size exceeds" in message
+        "video.processing.failed failed_stage=EXTRACT "
+        "failure_code=SOURCE_LIMIT_EXCEEDED" in message
         for message in messages
     )
 
@@ -357,6 +391,7 @@ async def test_terminal_failure_hands_off_when_delete_wins_race(
     storage_client,
 ) -> None:
     video_id = str(uuid4())
+    trace_id = uuid4()
     storage_client.objects["videos/delete-race.mp4"] = b"video"
     await video_repository.create_video(
         VideoRecord(
@@ -386,8 +421,102 @@ async def test_terminal_failure_hands_off_when_delete_wins_race(
         embedding_model_version="v001",
     )
 
-    result = await use_case.execute(video_id=video_id, trace_id="trace-delete-race")
+    result = await use_case.execute(video_id=video_id, trace_id=str(trace_id))
 
     assert result.action == "deleted"
     assert await video_repository.get_video(video_id) is None
     assert "videos/delete-race.mp4" not in storage_client.objects
+
+
+@pytest.mark.asyncio
+async def test_process_video_maps_index_write_failure(
+    video_repository,
+    process_video_use_case,
+    artifact_repository,
+    storage_client,
+    monkeypatch,
+) -> None:
+    video_id = str(uuid4())
+    trace_id = uuid4()
+    storage_client.objects["videos/source.mp4"] = b"video"
+    await video_repository.create_video(
+        VideoRecord(
+            id=video_id,
+            user_id=str(uuid4()),
+            storage_path="videos/source.mp4",
+            status="UPLOADED",
+        )
+    )
+    monkeypatch.setattr(
+        artifact_repository,
+        "persist_chunks_and_vectors",
+        AsyncMock(side_effect=RuntimeError("database unavailable")),
+    )
+
+    result = await process_video_use_case.execute(
+        video_id=video_id,
+        trace_id=str(trace_id),
+    )
+
+    failed_video = await video_repository.get_video(video_id)
+    assert result.action == "failed"
+    assert result.failed_stage == "VECTOR_UPSERT"
+    assert failed_video.failure_code == "INDEX_WRITE_FAILED"
+    assert failed_video.failure_trace_id == trace_id
+
+
+@pytest.mark.asyncio
+async def test_process_video_maps_unknown_chunking_failure_and_logs_once(
+    video_repository,
+    process_video_use_case,
+    pipeline_orchestrator,
+    storage_client,
+    monkeypatch,
+) -> None:
+    video_id = str(uuid4())
+    trace_id = uuid4()
+    storage_client.objects["videos/source.mp4"] = b"video"
+    await video_repository.create_video(
+        VideoRecord(
+            id=video_id,
+            user_id=str(uuid4()),
+            storage_path="videos/source.mp4",
+            status="UPLOADED",
+        )
+    )
+
+    def fail_chunking(_segments) -> None:
+        raise RuntimeError("unexpected chunk failure")
+
+    monkeypatch.setattr(
+        pipeline_orchestrator._chunking_service,
+        "chunk_segments",
+        fail_chunking,
+    )
+    failure_records = []
+    sink_id = logger.add(
+        lambda message: failure_records.append(message.record),
+        filter=lambda record: record["message"].startswith("video.processing.failed"),
+    )
+    try:
+        result = await process_video_use_case.execute(
+            video_id=video_id,
+            trace_id=str(trace_id),
+        )
+    finally:
+        logger.remove(sink_id)
+
+    failed_video = await video_repository.get_video(video_id)
+    assert result.action == "failed"
+    assert result.failed_stage == "CHUNKING"
+    assert failed_video.failure_code == "INTERNAL_PROCESSING_ERROR"
+    assert failed_video.failure_trace_id == trace_id
+    assert len(failure_records) == 1
+    assert failure_records[0]["extra"] == {
+        "video_id": video_id,
+        "trace_id": str(trace_id),
+        "failed_stage": "CHUNKING",
+        "failure_code": "INTERNAL_PROCESSING_ERROR",
+    }
+    assert failure_records[0]["exception"] is not None
+    assert str(failure_records[0]["exception"].value) == "unexpected chunk failure"

--- a/services/pipeline-worker/tests/unit/test_process_video.py
+++ b/services/pipeline-worker/tests/unit/test_process_video.py
@@ -250,7 +250,7 @@ async def test_process_video_claim_conflict_skips(
     await video_repository.create_video(
         VideoRecord(id=video_id, user_id=str(uuid4()), storage_path="videos/source.mp4", status="UPLOADED")
     )
-    # 다른 워커가 먼저 claim → PROCESSING 상태. claim_processing은 PENDING/UPLOADED/FAILED만 허용하므로 0 rows 반환
+    # 다른 워커가 먼저 claim → PROCESSING 상태. claim_processing은 PENDING/UPLOADED만 허용하므로 0 rows 반환
     await video_repository.set_status(video_id, "PROCESSING")
 
     result = await process_video_use_case.execute(

--- a/services/pipeline-worker/tests/unit/test_video_failure_metadata.py
+++ b/services/pipeline-worker/tests/unit/test_video_failure_metadata.py
@@ -36,7 +36,7 @@ async def test_claim_processing_clears_previous_failure(video_repository) -> Non
         VideoRecord(
             id=video_id,
             user_id=uuid4(),
-            status="FAILED",
+            status="PENDING",
             failed_stage="STT",
             failure_code="STT_FAILED",
             failure_trace_id=uuid4(),
@@ -52,6 +52,32 @@ async def test_claim_processing_clears_previous_failure(video_repository) -> Non
     assert video.failed_stage is None
     assert video.failure_code is None
     assert video.failure_trace_id is None
+
+
+@pytest.mark.asyncio
+async def test_claim_processing_rejects_failed_video(video_repository) -> None:
+    video_id = uuid4()
+    failure_trace_id = uuid4()
+    await video_repository.create_video(
+        VideoRecord(
+            id=video_id,
+            user_id=uuid4(),
+            status="FAILED",
+            failed_stage="STT",
+            failure_code="STT_FAILED",
+            failure_trace_id=failure_trace_id,
+        )
+    )
+
+    claimed = await video_repository.claim_processing(video_id)
+
+    video = await video_repository.get_video(video_id)
+    assert claimed is False
+    assert video is not None
+    assert video.status == "FAILED"
+    assert video.failed_stage == "STT"
+    assert video.failure_code == "STT_FAILED"
+    assert video.failure_trace_id == failure_trace_id
 
 
 @pytest.mark.asyncio

--- a/services/pipeline-worker/tests/unit/test_video_failure_metadata.py
+++ b/services/pipeline-worker/tests/unit/test_video_failure_metadata.py
@@ -1,0 +1,85 @@
+from uuid import uuid4
+
+import pytest
+
+from src.infra.db.video_repository import VideoRecord
+
+
+@pytest.mark.asyncio
+async def test_set_failed_stores_failure_metadata(video_repository) -> None:
+    video_id = uuid4()
+    failure_trace_id = uuid4()
+    await video_repository.create_video(
+        VideoRecord(id=video_id, user_id=uuid4(), status="UPLOADED")
+    )
+
+    stored = await video_repository.set_failed(
+        video_id,
+        failed_stage="STT",
+        failure_code="STT_FAILED",
+        failure_trace_id=failure_trace_id,
+    )
+
+    video = await video_repository.get_video(video_id)
+    assert stored is True
+    assert video is not None
+    assert video.status == "FAILED"
+    assert video.failed_stage == "STT"
+    assert video.failure_code == "STT_FAILED"
+    assert video.failure_trace_id == failure_trace_id
+
+
+@pytest.mark.asyncio
+async def test_claim_processing_clears_previous_failure(video_repository) -> None:
+    video_id = uuid4()
+    await video_repository.create_video(
+        VideoRecord(
+            id=video_id,
+            user_id=uuid4(),
+            status="FAILED",
+            failed_stage="STT",
+            failure_code="STT_FAILED",
+            failure_trace_id=uuid4(),
+        )
+    )
+
+    claimed = await video_repository.claim_processing(video_id)
+
+    video = await video_repository.get_video(video_id)
+    assert claimed is True
+    assert video is not None
+    assert video.status == "PROCESSING"
+    assert video.failed_stage is None
+    assert video.failure_code is None
+    assert video.failure_trace_id is None
+
+
+@pytest.mark.asyncio
+async def test_set_failed_does_not_overwrite_deleting_video(video_repository) -> None:
+    video_id = uuid4()
+    previous_trace_id = uuid4()
+    await video_repository.create_video(
+        VideoRecord(
+            id=video_id,
+            user_id=uuid4(),
+            status="DELETING",
+            failed_stage="DOWNLOAD",
+            failure_code="SOURCE_UNAVAILABLE",
+            failure_trace_id=previous_trace_id,
+        )
+    )
+
+    stored = await video_repository.set_failed(
+        video_id,
+        failed_stage="STT",
+        failure_code="STT_FAILED",
+        failure_trace_id=uuid4(),
+    )
+
+    video = await video_repository.get_video(video_id)
+    assert stored is False
+    assert video is not None
+    assert video.status == "DELETING"
+    assert video.failed_stage == "DOWNLOAD"
+    assert video.failure_code == "SOURCE_UNAVAILABLE"
+    assert video.failure_trace_id == previous_trace_id

--- a/services/pipeline-worker/tests/unit/test_youtube_downloader.py
+++ b/services/pipeline-worker/tests/unit/test_youtube_downloader.py
@@ -58,9 +58,10 @@ async def test_youtube_downloader_rejects_duration_over_limit_without_download(t
     FakeYoutubeDL.metadata = {"duration": 3601}
     downloader = build_downloader()
 
-    with pytest.raises(DownloadError):
+    with pytest.raises(DownloadError) as exc_info:
         await downloader.download("https://youtu.be/too-long", tmp_path / "source.mp4")
 
+    assert exc_info.value.category == "source_limit_exceeded"
     assert FakeYoutubeDL.calls == [False]
 
 
@@ -70,9 +71,10 @@ async def test_youtube_downloader_rejects_downloaded_file_over_limit(tmp_path) -
     FakeYoutubeDL.downloaded_content = b"x" * 501
     downloader = build_downloader()
 
-    with pytest.raises(DownloadError, match="size exceeds 500 bytes"):
+    with pytest.raises(DownloadError, match="size exceeds 500 bytes") as exc_info:
         await downloader.download("https://youtu.be/actual-too-large", tmp_path / "source.mp4")
 
+    assert exc_info.value.category == "source_limit_exceeded"
     assert FakeYoutubeDL.calls == [False, True]
 
 
@@ -95,9 +97,10 @@ async def test_youtube_downloader_rejects_filesize_over_limit(tmp_path) -> None:
     FakeYoutubeDL.metadata = {"duration": 30, "filesize": 501}
     downloader = build_downloader()
 
-    with pytest.raises(DownloadError):
+    with pytest.raises(DownloadError) as exc_info:
         await downloader.download("https://youtu.be/too-large", tmp_path / "source.mp4")
 
+    assert exc_info.value.category == "source_limit_exceeded"
     assert FakeYoutubeDL.calls == [False]
 
 


### PR DESCRIPTION
## 요약

영상 처리나 업로드가 실패해도 화면에는 "실패"만 뜨고 원인을 알 수 없는 문제를 해결한다.

실패 사유는 세 곳에서 사라지고 있었다.

1. frontend가 API 오류 응답 본문을 버리고 상태 코드만 남겼다
2. 비동기 전처리는 `failed_stage`만 저장하고 실제 실패 원인은 폐기했다
3. 처리 상태가 바뀌어도 새로고침해야 화면에 반영됐다

세 지점을 차례로 메워 사용자가 무엇이 왜 실패했는지 화면에서 바로 알 수 있게 한다.

- base: `fix/100-2-embedding-slot-limit` (스택 브랜치)

## 주요 작업 단위

### 1. API 오류 응답 정보 보존 (frontend)

- `HttpError`가 응답 본문의 `code`·`message`·`trace_id`를 안전한 범위에서 보존하도록 변경
- 오류 코드를 사용자 문구로 옮기는 `error-message` 모듈 분리

### 2. 업로드 제약 오류 코드 구분 (core-api)

- 업로드 제약 위반을 `UNSUPPORTED_FILE_TYPE`과 `FILE_TOO_LARGE`로 나눠 응답
- 오류 핸들러가 코드와 추적 번호를 함께 내려보냄

### 3. 검색·업로드 실패 사유 안내 (frontend)

- 검색 불가 조건(`SEARCH_NOT_READY`, `NO_VIDEOS_UPLOADED`)과 업로드 제약 오류를 사용자 문구로 연결
- 지원 확장자와 500MiB 제한을 API 호출 전에 확인해 불필요한 요청을 줄임
- 최종 판단 기준은 core-api 검사로 유지 (프론트 검사는 사전 안내 목적)

### 4. 영상 실패 코드와 추적 번호 저장

- video 테이블에 `failure_code`·`failure_trace_id` 추가 (migration `0013`)
- 목록·상세 응답에 실패 정보를 포함하고 화면에 사유와 문의용 추적 번호를 표시

### 5. 최종 실패 분류와 로그 통합 (pipeline-worker)

- 단계별 예외를 실패 코드로 옮기는 `failure_classifier`와 `pipeline_errors` 추가
- 예: ffprobe 실패는 `AUDIO_EXTRACTION_FAILED`, yt-dlp 다운로드 불가는 `SOURCE_UNAVAILABLE`
- 최종 실패 로그(`video.processing.failed`)와 DB의 `failure_trace_id`가 같은 trace ID를 사용해 로그와 화면을 이어서 추적할 수 있음

### 6. 업로드 완료 재호출로 처리 복구 (core-api)

- `/complete` 재호출 시 큐 메시지를 재발행
- DB는 `UPLOADED`로 커밋됐는데 발행만 실패해 영상이 멈추는 경우를 복구한다
- 응답이 유실돼 프론트가 실패로 처리한 영상도 재호출로 정상 진행 가능

### 7. 실패 영상의 자동 재처리 차단 (pipeline-worker)

- `FAILED` 영상은 명시적 재시도로 `PENDING`이 된 뒤에만 워커가 선점
- 늦게 도착한 중복 메시지가 실패 영상을 조용히 재처리하지 않게 함

### 8. 영상 상태와 실패 사유 자동 갱신 (frontend)

- 5초 간격 polling으로 `PROCESSING` → `READY`/`FAILED` 전환을 새로고침 없이 반영 (`useVideoStatusPolling`)
- 늦게 도착한 목록 응답이 최신 화면을 덮지 않도록 요청 세대를 확인
- 업로드 완료 표식을 localStorage에 남겨 전송 직후 새로고침해도 polling이 이어지게 함

## 검증

- core-api unit 97 / API 61
- pipeline-worker unit 139, 관련 integration 17
- frontend 136 + lint + production build
- gcp-perf 배포 후 실제 화면에서 `SOURCE_UNAVAILABLE`, `AUDIO_EXTRACTION_FAILED` 자동 표시 확인

## 후속

- 실패 코드별 자동 재시도 정책(재시도 대상 분류, 최대 횟수, 지연 재큐)은 별도로 결정한다. 사용자용 재시도 버튼은 그 뒤에 필요성을 다시 판단한다
- 브라우저 GCS 업로드 실패 시의 잔여 상태 정리는 이번 범위 밖

## 이슈

Ref #100
