### PR TITLE
feat(repo): 검색 단계 계측과 임베딩 자원 분리 [#103]

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -135,7 +135,8 @@ services:
       GCS_FEEDBACK_LOG_BUCKET_NAME: ${GCS_FEEDBACK_LOG_BUCKET_NAME}
       GOOGLE_APPLICATION_CREDENTIALS: /creds/adc.json
       LOCAL_ARTIFACT_ROOT: /var/lib/feedback-loop/artifacts
-      MANAGED_EMBEDDING_ENDPOINT_URL: http://managed-embedding-endpoint:8000
+      BATCH_EMBEDDING_ENDPOINT_URL: http://managed-embedding-endpoint:8000
+      SEARCH_EMBEDDING_ENDPOINT_URL: http://managed-embedding-endpoint:8000
       SEARCH_SERVICE_URL: http://search-service:8082
       LOCAL_TRAINING_MODEL_NAME: ${EMBEDDING_MODEL_VERSION:-BAAI/bge-m3}
       EMBEDDING_DIMENSION: ${EMBEDDING_DIMENSION:-1024}

--- a/docs/runbooks/gcp-performance-deployment.md
+++ b/docs/runbooks/gcp-performance-deployment.md
@@ -318,12 +318,13 @@ terraform -chdir=infra/terraform/envs/gcp-perf output
 - `core_api_url`
 - `search_service_url`
 - `fip_url`
-- `embedding_endpoint_url`
+- `batch_embedding_endpoint_url`
+- `search_embedding_endpoint_url`
 - `postgres_private_ip`
 - `embedding_vm_private_ip`
 - `bucket_names`
 
-`embedding_endpoint_url`은 Cloud Run URL이 아니다. 임베딩 VM private IP의 `http://<PRIVATE_IP>:8000` 주소다.
+두 embedding endpoint output은 Cloud Run URL이 아니다. 각 임베딩 VM private IP의 `http://<PRIVATE_IP>:8000` 주소다.
 
 ### 4.2 VM 상태 확인
 
@@ -337,9 +338,14 @@ gcloud compute instances describe "${NAME_PREFIX}-embedding" \
   --project="$GCP_PROJECT_ID" \
   --zone="$GCP_ZONE" \
   --format='value(status,networkInterfaces[0].networkIP)'
+
+gcloud compute instances describe "${NAME_PREFIX}-embedding-search" \
+  --project="$GCP_PROJECT_ID" \
+  --zone="$GCP_ZONE" \
+  --format='value(status,networkInterfaces[0].networkIP)'
 ```
 
-기대 결과는 두 VM 모두 `RUNNING`이고 private IP가 출력되는 것이다.
+기대 결과는 PostgreSQL과 두 임베딩 VM이 모두 `RUNNING`이고 private IP가 출력되는 것이다.
 
 ### 4.3 PostgreSQL 검증
 
@@ -374,6 +380,12 @@ DB 이름을 기본값 `app`에서 변경했다면 실제 `database_name`을 사
 
 ```bash
 gcloud compute ssh "${NAME_PREFIX}-embedding" \
+  --project="$GCP_PROJECT_ID" \
+  --zone="$GCP_ZONE" \
+  --tunnel-through-iap \
+  --command='curl -fsS http://127.0.0.1:8000/health'
+
+gcloud compute ssh "${NAME_PREFIX}-embedding-search" \
   --project="$GCP_PROJECT_ID" \
   --zone="$GCP_ZONE" \
   --tunnel-through-iap \
@@ -623,6 +635,17 @@ terraform -chdir=infra/terraform/envs/gcp-perf apply \
 ```
 
 DB schema가 변경됐다면 migration Job을 다시 실행한다.
+
+### 5.4 검색·배치 임베딩 VM 최초 분리
+
+기존 단일 임베딩 VM을 두 대로 나누는 최초 전환은 두 변경으로 나눠 적용한다.
+
+1. `search_embedding_cutover_enabled = false`로 적용한다. 검색 VM은 생성되지만 search-service와 feedback-loop 검색 주소는 기존 배치 VM을 유지한다.
+2. 검색 VM `/internal/reload-models`를 호출하고, DB의 현재 `active_model_version`이 `/health`의 `ready_model_versions`에 포함되는지 확인한다.
+3. 준비 확인 후 `search_embedding_cutover_enabled = true`로 바꾸고 두 번째 Terraform plan과 apply를 실행한다.
+4. 검색 1건과 영상 업로드 1건으로 요청이 각각 검색 VM과 배치 VM에 들어가는지 확인한다.
+
+검색 VM 생성과 서비스 주소 전환을 같은 Terraform 적용에 넣지 않는다. 전환 뒤 문제가 생기면 서비스 주소만 기존 배치 VM으로 되돌리고 검색 VM은 원인 확인을 위해 유지한다.
 
 ## 6. worker와 FIP 풀 가동
 

--- a/infra/terraform/envs/gcp-perf/main.tf
+++ b/infra/terraform/envs/gcp-perf/main.tf
@@ -21,7 +21,13 @@ locals {
 
   database_url = "postgresql+asyncpg://${urlencode(var.database_user)}:${urlencode(var.db_password)}@${module.postgres_vm.private_ip}:5432/${urlencode(var.database_name)}"
 
-  embedding_vm_url = "http://${module.embedding_vm.private_ip}:8000"
+  batch_embedding_vm_url  = "http://${module.embedding_vm.private_ip}:8000"
+  search_embedding_vm_url = "http://${module.embedding_search_vm.private_ip}:8000"
+  search_embedding_routing_url = (
+    var.search_embedding_cutover_enabled
+    ? local.search_embedding_vm_url
+    : local.batch_embedding_vm_url
+  )
 
   feedback_loop_worker_roles = {
     scheduler = {
@@ -45,23 +51,24 @@ locals {
   }
 
   feedback_loop_common_env = {
-    BROKER_TYPE                    = "pgmq"
-    ARTIFACT_STORE_BACKEND         = "gcs"
-    LOCAL_ARTIFACT_ROOT            = "/tmp/feedback-loop-artifacts"
-    GCS_FEEDBACK_LOG_BUCKET_NAME   = module.object_storage.bucket_names.feedback_log
-    GCS_ML_ARTIFACT_BUCKET_NAME    = module.object_storage.bucket_names.ml_artifact
-    RAW_FEEDBACK_LOG_PREFIX        = var.raw_feedback_log_prefix
-    DATASET_ARTIFACT_PREFIX        = var.dataset_artifact_prefix
-    MODEL_ARTIFACT_PREFIX          = var.model_artifact_prefix
-    MODEL_VERSION_PREFIX           = var.model_version_prefix
-    SERVING_MODEL_ARTIFACT_PREFIX  = var.serving_model_artifact_prefix
-    EVALUATION_ARTIFACT_PREFIX     = var.evaluation_artifact_prefix
-    MANAGED_EMBEDDING_ENDPOINT_URL = local.embedding_vm_url
-    SEARCH_SERVICE_URL             = module.search_service.url
-    LOCAL_TRAINING_MODEL_NAME      = var.local_training_model_name
-    EMBEDDING_DIMENSION            = tostring(var.embedding_dimension)
-    TRAINING_CONFIG_PATH           = var.training_config_path
-    EVALUATION_DATASET_REF         = var.evaluation_dataset_ref
+    BROKER_TYPE                   = "pgmq"
+    ARTIFACT_STORE_BACKEND        = "gcs"
+    LOCAL_ARTIFACT_ROOT           = "/tmp/feedback-loop-artifacts"
+    GCS_FEEDBACK_LOG_BUCKET_NAME  = module.object_storage.bucket_names.feedback_log
+    GCS_ML_ARTIFACT_BUCKET_NAME   = module.object_storage.bucket_names.ml_artifact
+    RAW_FEEDBACK_LOG_PREFIX       = var.raw_feedback_log_prefix
+    DATASET_ARTIFACT_PREFIX       = var.dataset_artifact_prefix
+    MODEL_ARTIFACT_PREFIX         = var.model_artifact_prefix
+    MODEL_VERSION_PREFIX          = var.model_version_prefix
+    SERVING_MODEL_ARTIFACT_PREFIX = var.serving_model_artifact_prefix
+    EVALUATION_ARTIFACT_PREFIX    = var.evaluation_artifact_prefix
+    BATCH_EMBEDDING_ENDPOINT_URL  = local.batch_embedding_vm_url
+    SEARCH_EMBEDDING_ENDPOINT_URL = local.search_embedding_routing_url
+    SEARCH_SERVICE_URL            = module.search_service.url
+    LOCAL_TRAINING_MODEL_NAME     = var.local_training_model_name
+    EMBEDDING_DIMENSION           = tostring(var.embedding_dimension)
+    TRAINING_CONFIG_PATH          = var.training_config_path
+    EVALUATION_DATASET_REF        = var.evaluation_dataset_ref
   }
 
   cloud_run_vpc_network_interfaces = [
@@ -267,6 +274,34 @@ module "embedding_vm" {
   depends_on = [google_secret_manager_secret_version.database_url, module.iam]
 }
 
+module "embedding_search_vm" {
+  source = "../../modules/embedding_vm"
+
+  project_id                        = var.project_id
+  zone                              = var.zone
+  instance_name                     = "${var.name_prefix}-embedding-search"
+  machine_type                      = var.embedding_vm_machine_type
+  network                           = module.network.network_self_link
+  subnetwork                        = module.network.embedding_subnet_self_link
+  network_tags                      = [module.network.embedding_network_tag]
+  internal_ip                       = "10.20.3.15"
+  service_account_email             = module.iam.service_account_emails["managed-embedding-endpoint"]
+  image_url                         = local.service_images["managed-embedding-endpoint"]
+  database_url_secret_name          = module.secrets.secret_names.database_url
+  gcs_ml_artifact_bucket_name       = module.object_storage.bucket_names.ml_artifact
+  model_artifact_path               = var.model_artifact_path
+  model_artifact_prefix             = var.embedding_model_artifact_prefix
+  local_model_cache_root            = var.local_model_cache_root
+  model_disk_size_gb                = var.embedding_vm_model_disk_size_gb
+  search_request_limit              = var.embedding_search_request_limit
+  video_preprocess_request_limit    = var.embedding_video_preprocess_request_limit
+  search_wait_timeout_sec           = var.embedding_search_wait_timeout_sec
+  video_preprocess_wait_timeout_sec = var.embedding_video_preprocess_wait_timeout_sec
+  enable_warp_proxy                 = false
+
+  depends_on = [google_secret_manager_secret_version.database_url, module.iam]
+}
+
 module "search_service" {
   source = "../../modules/cloud_run_service"
 
@@ -280,7 +315,7 @@ module "search_service" {
   vpc_network_interfaces = local.cloud_run_vpc_network_interfaces
 
   env_vars = {
-    EMBEDDING_API_URL     = local.embedding_vm_url
+    EMBEDDING_API_URL     = local.search_embedding_routing_url
     EMBEDDING_TIMEOUT_SEC = tostring(var.search_embedding_timeout_sec)
     GCP_LOCATION          = "us-central1"
     GCP_PROJECT_ID        = var.project_id
@@ -448,7 +483,7 @@ module "pipeline_worker" {
     # 임베딩 VM의 wireproxy(WARP) SOCKS5. YouTube 트래픽만 이 프록시로 우회한다.
     YOUTUBE_PROXY_URL     = "socks5://${module.embedding_vm.private_ip}:1080"
     GCS_VIDEO_BUCKET_NAME = module.object_storage.bucket_names.video
-    EMBEDDING_API_URL     = local.embedding_vm_url
+    EMBEDDING_API_URL     = local.batch_embedding_vm_url
     EMBEDDING_TIMEOUT_SEC = tostring(var.pipeline_embedding_timeout_sec)
     EMBEDDING_BATCH_SIZE  = tostring(var.pipeline_embedding_batch_size)
     CHUNK_MAX_TOKENS      = tostring(var.pipeline_chunk_max_tokens)

--- a/infra/terraform/envs/gcp-perf/outputs.tf
+++ b/infra/terraform/envs/gcp-perf/outputs.tf
@@ -10,8 +10,12 @@ output "frontend_url" {
   value = module.frontend.url
 }
 
-output "embedding_endpoint_url" {
-  value = local.embedding_vm_url
+output "batch_embedding_endpoint_url" {
+  value = local.batch_embedding_vm_url
+}
+
+output "search_embedding_endpoint_url" {
+  value = local.search_embedding_vm_url
 }
 
 output "managed_embedding_cloud_run_url" {

--- a/infra/terraform/envs/gcp-perf/terraform.tfvars.example
+++ b/infra/terraform/envs/gcp-perf/terraform.tfvars.example
@@ -23,6 +23,7 @@ embedding_subnet_cidr = "10.20.3.0/24"
 enable_managed_embedding_cloud_run = false
 embedding_vm_machine_type          = "e2-standard-4"
 embedding_vm_model_disk_size_gb    = 100
+search_embedding_cutover_enabled   = false
 pipeline_embedding_timeout_sec     = 180
 pipeline_embedding_batch_size      = 16
 

--- a/infra/terraform/envs/gcp-perf/variables.tf
+++ b/infra/terraform/envs/gcp-perf/variables.tf
@@ -261,6 +261,12 @@ variable "embedding_vm_model_disk_size_gb" {
   default = 100
 }
 
+variable "search_embedding_cutover_enabled" {
+  type        = bool
+  default     = false
+  description = "검색 VM 준비 확인 후 true로 바꿔 search-service와 feedback-loop 검색 경로를 전환한다."
+}
+
 variable "embedding_model_artifact_prefix" {
   type    = string
   default = "models"

--- a/infra/terraform/modules/embedding_vm/main.tf
+++ b/infra/terraform/modules/embedding_vm/main.tf
@@ -61,6 +61,8 @@ resource "google_compute_instance" "embedding" {
     local_model_cache_root            = var.local_model_cache_root
     model_artifact_path               = var.model_artifact_path
     model_artifact_prefix             = var.model_artifact_prefix
+    enable_warp_proxy                 = var.enable_warp_proxy
+    max_concurrency                   = var.max_concurrency
     search_request_limit              = var.search_request_limit
     video_preprocess_request_limit    = var.video_preprocess_request_limit
     search_wait_timeout_sec           = var.search_wait_timeout_sec

--- a/infra/terraform/modules/embedding_vm/startup-embedding.sh.tftpl
+++ b/infra/terraform/modules/embedding_vm/startup-embedding.sh.tftpl
@@ -74,6 +74,7 @@ MODEL_ARTIFACT_BACKEND=gcs
 GCS_ML_ARTIFACT_BUCKET_NAME=${gcs_ml_artifact_bucket_name}
 MODEL_ARTIFACT_PREFIX=${model_artifact_prefix}
 LOCAL_MODEL_CACHE_ROOT=${local_model_cache_root}
+MAX_CONCURRENCY=${max_concurrency}
 SEARCH_REQUEST_LIMIT=${search_request_limit}
 VIDEO_PREPROCESS_REQUEST_LIMIT=${video_preprocess_request_limit}
 SEARCH_WAIT_TIMEOUT_SEC=${search_wait_timeout_sec}
@@ -121,6 +122,7 @@ UNIT
 systemctl daemon-reload
 systemctl enable --now biblio-managed-embedding-endpoint.service
 
+%{ if enable_warp_proxy }
 # --- WARP egress proxy (wireproxy) for YouTube download ---
 # YouTube가 GCP 데이터센터 IP를 봇으로 차단하므로, yt-dlp 트래픽을 Cloudflare
 # WARP 터널로 우회시킨다. wireproxy가 WARP(WireGuard)를 SOCKS5로 노출하고,
@@ -175,3 +177,4 @@ UNIT
 
 systemctl daemon-reload
 systemctl enable --now biblio-warp-proxy.service
+%{ endif }

--- a/infra/terraform/modules/embedding_vm/variables.tf
+++ b/infra/terraform/modules/embedding_vm/variables.tf
@@ -64,6 +64,24 @@ variable "local_model_cache_root" {
   default = "/models"
 }
 
+variable "enable_warp_proxy" {
+  type    = bool
+  default = true
+}
+
+variable "max_concurrency" {
+  type    = number
+  default = 1
+
+  validation {
+    condition = (
+      var.max_concurrency > 0 &&
+      floor(var.max_concurrency) == var.max_concurrency
+    )
+    error_message = "max_concurrency must be a positive integer."
+  }
+}
+
 variable "search_request_limit" {
   type = number
 }

--- a/services/feedback-loop-pipeline/src/bootstrap.py
+++ b/services/feedback-loop-pipeline/src/bootstrap.py
@@ -36,8 +36,14 @@ from src.infra.storage.gcs import GCSArtifactStore
 from src.infra.storage.local import LocalArtifactStore
 from src.release.candidate_deployment import CandidateDeploymentService
 from src.release.legacy_reindex import LegacyReindexCoordinator, LegacyReindexScheduler
-from src.release.model_reload import ManagedEmbeddingModelReloadClient
-from src.release.readiness import ManagedEmbeddingReadinessClient
+from src.release.model_reload import (
+    ManagedEmbeddingModelReloadClient,
+    ManagedEmbeddingModelReloadFanout,
+)
+from src.release.readiness import (
+    ManagedEmbeddingReadinessClient,
+    ManagedEmbeddingReadinessFanout,
+)
 from src.release.rollback import RollbackRequestMessage, RollbackTransitionManager
 from src.release.serving_reload import (
     NoopServingTargetReloader,
@@ -162,9 +168,7 @@ async def bootstrap_train_release_worker(settings: Settings, *, run_once: bool) 
                 transition_manager = ServingTransitionManager(
                     run_store=MLPipelineRunStore(session),
                     release_store=release_store,
-                    readiness=ManagedEmbeddingReadinessClient(
-                        base_url=settings.managed_embedding_endpoint_url,
-                    ),
+                    readiness=_build_embedding_readiness(settings),
                     legacy_reindex_gate=LegacyReindexStore(session),
                     release_change_committer=SqlAlchemyReleaseChangeCommitter(session),
                     serving_target_reloader=_build_serving_target_reloader(settings),
@@ -202,10 +206,7 @@ async def bootstrap_train_release_worker(settings: Settings, *, run_once: bool) 
                         CandidateDeploymentService(
                             run_store=MLPipelineRunStore(session),
                             transition_manager=transition_manager,
-                            reload_client=ManagedEmbeddingModelReloadClient(
-                                base_url=settings.managed_embedding_endpoint_url,
-                                timeout_sec=settings.training_timeout_sec,
-                            ),
+                            reload_client=_build_embedding_model_reload(settings),
                             max_attempts=settings.candidate_deployment_max_attempts,
                         )
                     ),
@@ -249,9 +250,7 @@ async def bootstrap_rollback_worker(settings: Settings, *, run_once: bool) -> No
                 manager = RollbackTransitionManager(
                     release_store=ModelReleaseStore(session),
                     project_store=ProjectRollbackStore(session),
-                    target_readiness=ManagedEmbeddingReadinessClient(
-                        base_url=settings.managed_embedding_endpoint_url,
-                    ),
+                    target_readiness=_build_embedding_readiness(settings),
                     index_restore=CatalogSnapshotIndexRestore(session),
                     release_change_committer=SqlAlchemyReleaseChangeCommitter(session),
                     serving_target_reloader=_build_serving_target_reloader(settings),
@@ -280,7 +279,7 @@ async def bootstrap_reembedding_worker(settings: Settings, *, run_once: bool) ->
                 service = VideoReembedService(
                     session=session,
                     embedding_client=ManagedEmbeddingBatchClient(
-                        base_url=settings.managed_embedding_endpoint_url,
+                        base_url=settings.batch_embedding_endpoint_url,
                         timeout_sec=settings.training_timeout_sec,
                         default_model_version=settings.local_training_model_name,
                     ),
@@ -315,7 +314,7 @@ async def bootstrap_legacy_reindex_worker(settings: Settings, *, run_once: bool)
                     legacy_store=LegacyReindexStore(session),
                     catalog_store=VectorIndexCatalogStore(session),
                     embedding_client=ManagedEmbeddingBatchClient(
-                        base_url=settings.managed_embedding_endpoint_url,
+                        base_url=settings.batch_embedding_endpoint_url,
                         timeout_sec=settings.training_timeout_sec,
                         default_model_version=settings.local_training_model_name,
                     ),
@@ -410,9 +409,7 @@ class CandidateDeploymentRetryAdapter:
         transition_manager = ServingTransitionManager(
             run_store=run_store,
             release_store=ModelReleaseStore(self._session),
-            readiness=ManagedEmbeddingReadinessClient(
-                base_url=self._settings.managed_embedding_endpoint_url,
-            ),
+            readiness=_build_embedding_readiness(self._settings),
             legacy_reindex_gate=LegacyReindexStore(self._session),
             release_change_committer=SqlAlchemyReleaseChangeCommitter(self._session),
             serving_target_reloader=_build_serving_target_reloader(self._settings),
@@ -420,10 +417,7 @@ class CandidateDeploymentRetryAdapter:
         await CandidateDeploymentService(
             run_store=run_store,
             transition_manager=transition_manager,
-            reload_client=ManagedEmbeddingModelReloadClient(
-                base_url=self._settings.managed_embedding_endpoint_url,
-                timeout_sec=self._settings.training_timeout_sec,
-            ),
+            reload_client=_build_embedding_model_reload(self._settings),
             max_attempts=self._settings.candidate_deployment_max_attempts,
         ).attempt(run_id=run.id, trace_id=_new_trace_id())
         await self._session.commit()
@@ -433,6 +427,34 @@ def _build_serving_target_reloader(settings: Settings) -> ServingTargetReloader:
     if settings.search_service_url:
         return SearchServiceServingTargetReloader(base_url=settings.search_service_url)
     return NoopServingTargetReloader()
+
+
+def _build_embedding_readiness(
+    settings: Settings,
+) -> ManagedEmbeddingReadinessFanout:
+    return ManagedEmbeddingReadinessFanout(
+        batch_client=ManagedEmbeddingReadinessClient(
+            base_url=settings.batch_embedding_endpoint_url,
+        ),
+        search_client=ManagedEmbeddingReadinessClient(
+            base_url=settings.search_embedding_endpoint_url,
+        ),
+    )
+
+
+def _build_embedding_model_reload(
+    settings: Settings,
+) -> ManagedEmbeddingModelReloadFanout:
+    return ManagedEmbeddingModelReloadFanout(
+        batch_client=ManagedEmbeddingModelReloadClient(
+            base_url=settings.batch_embedding_endpoint_url,
+            timeout_sec=settings.training_timeout_sec,
+        ),
+        search_client=ManagedEmbeddingModelReloadClient(
+            base_url=settings.search_embedding_endpoint_url,
+            timeout_sec=settings.training_timeout_sec,
+        ),
+    )
 
 
 async def _run_consumer(

--- a/services/feedback-loop-pipeline/src/config/settings.py
+++ b/services/feedback-loop-pipeline/src/config/settings.py
@@ -41,7 +41,14 @@ class Settings(BaseSettings):
     gcs_ml_artifact_bucket_name: str | None = Field(default=None, alias="GCS_ML_ARTIFACT_BUCKET_NAME")
     local_artifact_root: str = Field(default="./tmp/feedback-loop-artifacts", alias="LOCAL_ARTIFACT_ROOT", min_length=1)
 
-    managed_embedding_endpoint_url: str = Field(alias="MANAGED_EMBEDDING_ENDPOINT_URL", min_length=1)
+    batch_embedding_endpoint_url: str = Field(
+        alias="BATCH_EMBEDDING_ENDPOINT_URL",
+        min_length=1,
+    )
+    search_embedding_endpoint_url: str = Field(
+        alias="SEARCH_EMBEDDING_ENDPOINT_URL",
+        min_length=1,
+    )
     search_service_url: str = Field(default="", alias="SEARCH_SERVICE_URL")
     local_training_model_name: str = Field(alias="LOCAL_TRAINING_MODEL_NAME", min_length=1)
     embedding_dimension: int = Field(alias="EMBEDDING_DIMENSION", ge=1)

--- a/services/feedback-loop-pipeline/src/release/model_reload.py
+++ b/services/feedback-loop-pipeline/src/release/model_reload.py
@@ -53,3 +53,46 @@ class ManagedEmbeddingModelReloadClient:
         if not isinstance(payload, dict):
             raise ModelReloadError("reload-models returned a non-object payload")
         return payload
+
+    @property
+    def base_url(self) -> str:
+        return self._base_url
+
+
+@dataclass(frozen=True)
+class ManagedEmbeddingModelReloadFanout:
+    batch_client: ManagedEmbeddingModelReloadClient
+    search_client: ManagedEmbeddingModelReloadClient
+
+    async def reload(self, *, trace_id: UUID) -> ModelReloadResult:
+        clients = self._unique_clients()
+        results = await asyncio.gather(
+            *(client.reload(trace_id=trace_id) for client in clients),
+            return_exceptions=True,
+        )
+        ready_version_sets = self._ready_version_sets(clients, results)
+        intersection = ready_version_sets[0]
+        for ready_versions in ready_version_sets[1:]:
+            intersection = intersection.intersection(ready_versions)
+        return ModelReloadResult(ready_model_versions=intersection)
+
+    def _unique_clients(self) -> tuple[ManagedEmbeddingModelReloadClient, ...]:
+        if self.batch_client.base_url == self.search_client.base_url:
+            return (self.batch_client,)
+        return self.batch_client, self.search_client
+
+    @staticmethod
+    def _ready_version_sets(
+        clients: tuple[ManagedEmbeddingModelReloadClient, ...],
+        results: list[ModelReloadResult | BaseException],
+    ) -> list[frozenset[str]]:
+        ready_version_sets: list[frozenset[str]] = []
+        for client, result in zip(clients, results, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, Exception):
+                raise ModelReloadError(
+                    f"managed embedding model reload failed: {client.base_url}"
+                ) from result
+            ready_version_sets.append(result.ready_model_versions)
+        return ready_version_sets

--- a/services/feedback-loop-pipeline/src/release/readiness.py
+++ b/services/feedback-loop-pipeline/src/release/readiness.py
@@ -1,3 +1,6 @@
+'''
+배포나 롤백을 실제로 실행하기 직전에, "새 모델이 진짜 임베딩 서버에 올라와 있나"를 확인
+'''
 from __future__ import annotations
 
 import asyncio
@@ -9,16 +12,18 @@ from urllib.request import Request, urlopen
 
 
 class CandidateReadinessError(RuntimeError):
-    pass
+    """준비 확인(readiness check) 과정에서 생긴 실패를 나타내는 전용 예외."""
 
 
 @dataclass(frozen=True)
 class ManagedEmbeddingReadinessClient:
+    """임베딩 VM 한 대에 /health를 호출해, 특정 모델 버전이 준비됐는지 확인한다."""
+
     base_url: str
     timeout_sec: float = 5.0
 
     async def is_candidate_ready(self, *, model_version: str) -> bool:
-        payload = await asyncio.to_thread(self._fetch_health)
+        payload = await asyncio.to_thread(self._fetch_health) #_fetch_health 메서드에서 쓰이는 urlopen() 함수가 동기함수라  asyncio.to_thread로 처리
         ready_versions = payload.get("ready_model_versions")
         if isinstance(ready_versions, list):
             return model_version in {str(version) for version in ready_versions}
@@ -39,9 +44,11 @@ class ManagedEmbeddingReadinessClient:
 
 @dataclass(frozen=True)
 class ManagedEmbeddingReadinessFanout:
+    """ManagedEmbeddingReadinessClient 두 개(배치·검색 VM)를 묶어, 둘 다 준비됐을 때만 True를 돌려준다."""
+
     batch_client: ManagedEmbeddingReadinessClient
     search_client: ManagedEmbeddingReadinessClient
-
+    # 배포시 체크
     async def is_candidate_ready(self, *, model_version: str) -> bool:
         clients = self._unique_clients()
         results = await asyncio.gather(
@@ -53,6 +60,7 @@ class ManagedEmbeddingReadinessFanout:
         )
         return self._all_ready(clients, results)
 
+    # 롤백시 체크
     async def is_ready(self, *, model_version: str) -> bool:
         clients = self._unique_clients()
         results = await asyncio.gather(

--- a/services/feedback-loop-pipeline/src/release/readiness.py
+++ b/services/feedback-loop-pipeline/src/release/readiness.py
@@ -35,3 +35,51 @@ class ManagedEmbeddingReadinessClient:
         except (HTTPError, URLError, TimeoutError) as exc:
             raise CandidateReadinessError("managed embedding endpoint health check failed") from exc
         return json.loads(body)
+
+
+@dataclass(frozen=True)
+class ManagedEmbeddingReadinessFanout:
+    batch_client: ManagedEmbeddingReadinessClient
+    search_client: ManagedEmbeddingReadinessClient
+
+    async def is_candidate_ready(self, *, model_version: str) -> bool:
+        clients = self._unique_clients()
+        results = await asyncio.gather(
+            *(
+                client.is_candidate_ready(model_version=model_version)
+                for client in clients
+            ),
+            return_exceptions=True,
+        )
+        return self._all_ready(clients, results)
+
+    async def is_ready(self, *, model_version: str) -> bool:
+        clients = self._unique_clients()
+        results = await asyncio.gather(
+            *(client.is_ready(model_version=model_version) for client in clients),
+            return_exceptions=True,
+        )
+        return self._all_ready(clients, results)
+
+    def _unique_clients(self) -> tuple[ManagedEmbeddingReadinessClient, ...]:
+        if self.batch_client.base_url.rstrip("/") == self.search_client.base_url.rstrip(
+            "/"
+        ):
+            return (self.batch_client,)
+        return self.batch_client, self.search_client
+
+    @staticmethod
+    def _all_ready(
+        clients: tuple[ManagedEmbeddingReadinessClient, ...],
+        results: list[bool | BaseException],
+    ) -> bool:
+        ready_results: list[bool] = []
+        for client, result in zip(clients, results, strict=True):
+            if isinstance(result, asyncio.CancelledError):
+                raise result
+            if isinstance(result, Exception):
+                raise CandidateReadinessError(
+                    f"managed embedding endpoint health check failed: {client.base_url}"
+                ) from result
+            ready_results.append(result)
+        return all(ready_results)

--- a/services/feedback-loop-pipeline/tests/unit/test_model_reload.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_model_reload.py
@@ -4,7 +4,11 @@ from uuid import uuid4
 
 import pytest
 
-from src.release.model_reload import ManagedEmbeddingModelReloadClient, ModelReloadError
+from src.release.model_reload import (
+    ManagedEmbeddingModelReloadClient,
+    ManagedEmbeddingModelReloadFanout,
+    ModelReloadError,
+)
 
 
 class _Response:
@@ -65,3 +69,95 @@ async def test_reload_client_raises_on_endpoint_failure() -> None:
             timeout_sec=2.5,
             urlopen_func=urlopen,
         ).reload(trace_id=uuid4())
+
+
+@pytest.mark.asyncio
+async def test_reload_fanout_calls_both_endpoints_and_returns_intersection() -> None:
+    calls: list[str] = []
+
+    def batch_urlopen(request, timeout):
+        calls.append(request.full_url)
+        return _Response({"ready_model_versions": ["active-v1", "candidate-v2"]})
+
+    def search_urlopen(request, timeout):
+        calls.append(request.full_url)
+        return _Response({"ready_model_versions": ["candidate-v2"]})
+
+    client = ManagedEmbeddingModelReloadFanout(
+        batch_client=ManagedEmbeddingModelReloadClient(
+            base_url="https://embedding-batch.local",
+            urlopen_func=batch_urlopen,
+        ),
+        search_client=ManagedEmbeddingModelReloadClient(
+            base_url="https://embedding-search.local",
+            urlopen_func=search_urlopen,
+        ),
+    )
+
+    result = await client.reload(trace_id=uuid4())
+
+    assert result.ready_model_versions == frozenset({"candidate-v2"})
+    assert set(calls) == {
+        "https://embedding-batch.local/internal/reload-models",
+        "https://embedding-search.local/internal/reload-models",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reload_fanout_identifies_failed_endpoint_after_calling_both() -> None:
+    calls: list[str] = []
+
+    def batch_urlopen(request, timeout):
+        calls.append(request.full_url)
+        raise URLError("batch endpoint down")
+
+    def search_urlopen(request, timeout):
+        calls.append(request.full_url)
+        return _Response({"ready_model_versions": ["candidate-v2"]})
+
+    client = ManagedEmbeddingModelReloadFanout(
+        batch_client=ManagedEmbeddingModelReloadClient(
+            base_url="https://embedding-batch.local",
+            urlopen_func=batch_urlopen,
+        ),
+        search_client=ManagedEmbeddingModelReloadClient(
+            base_url="https://embedding-search.local",
+            urlopen_func=search_urlopen,
+        ),
+    )
+
+    with pytest.raises(
+        ModelReloadError,
+        match="https://embedding-batch.local",
+    ):
+        await client.reload(trace_id=uuid4())
+
+    assert set(calls) == {
+        "https://embedding-batch.local/internal/reload-models",
+        "https://embedding-search.local/internal/reload-models",
+    }
+
+
+@pytest.mark.asyncio
+async def test_reload_fanout_calls_shared_endpoint_once() -> None:
+    calls: list[str] = []
+
+    def urlopen(request, timeout):
+        calls.append(request.full_url)
+        return _Response({"ready_model_versions": ["active-v1"]})
+
+    client = ManagedEmbeddingModelReloadFanout(
+        batch_client=ManagedEmbeddingModelReloadClient(
+            base_url="https://embedding-shared.local/",
+            urlopen_func=urlopen,
+        ),
+        search_client=ManagedEmbeddingModelReloadClient(
+            base_url="https://embedding-shared.local",
+            urlopen_func=urlopen,
+        ),
+    )
+
+    result = await client.reload(trace_id=uuid4())
+
+    assert result.ready_model_versions == frozenset({"active-v1"})
+    assert calls == ["https://embedding-shared.local/internal/reload-models"]

--- a/services/feedback-loop-pipeline/tests/unit/test_readiness.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_readiness.py
@@ -1,0 +1,78 @@
+from urllib.request import Request
+
+import pytest
+
+from src.release import readiness
+from src.release.readiness import (
+    ManagedEmbeddingReadinessClient,
+    ManagedEmbeddingReadinessFanout,
+)
+
+
+class _Response:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        return None
+
+    def read(self) -> bytes:
+        return self._payload
+
+
+@pytest.mark.asyncio
+async def test_readiness_fanout_requires_both_endpoints(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    ready_payloads = {
+        "https://embedding-batch.local/health": b'{"ready_model_versions":["candidate-v2"]}',
+        "https://embedding-search.local/health": b'{"ready_model_versions":["candidate-v2"]}',
+    }
+
+    def urlopen(request: Request, timeout: float) -> _Response:
+        return _Response(ready_payloads[request.full_url])
+
+    monkeypatch.setattr(readiness, "urlopen", urlopen)
+    client = ManagedEmbeddingReadinessFanout(
+        batch_client=ManagedEmbeddingReadinessClient(
+            base_url="https://embedding-batch.local"
+        ),
+        search_client=ManagedEmbeddingReadinessClient(
+            base_url="https://embedding-search.local"
+        ),
+    )
+
+    assert await client.is_candidate_ready(model_version="candidate-v2") is True
+
+    ready_payloads["https://embedding-search.local/health"] = (
+        b'{"ready_model_versions":[]}'
+    )
+
+    assert await client.is_ready(model_version="candidate-v2") is False
+
+
+@pytest.mark.asyncio
+async def test_readiness_fanout_checks_shared_endpoint_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    def urlopen(request: Request, timeout: float) -> _Response:
+        calls.append(request.full_url)
+        return _Response(b'{"ready_model_versions":["active-v1"]}')
+
+    monkeypatch.setattr(readiness, "urlopen", urlopen)
+    client = ManagedEmbeddingReadinessFanout(
+        batch_client=ManagedEmbeddingReadinessClient(
+            base_url="https://embedding-shared.local/"
+        ),
+        search_client=ManagedEmbeddingReadinessClient(
+            base_url="https://embedding-shared.local"
+        ),
+    )
+
+    assert await client.is_candidate_ready(model_version="active-v1") is True
+    assert calls == ["https://embedding-shared.local/health"]

--- a/services/feedback-loop-pipeline/tests/unit/test_settings.py
+++ b/services/feedback-loop-pipeline/tests/unit/test_settings.py
@@ -13,7 +13,8 @@ def _required_env() -> dict[str, str]:
         "MODEL_VERSION_PREFIX": "bge-m3",
         "SERVING_MODEL_ARTIFACT_PREFIX": "models",
         "EVALUATION_ARTIFACT_PREFIX": "feedback/evaluations",
-        "MANAGED_EMBEDDING_ENDPOINT_URL": "https://embedding.local",
+        "BATCH_EMBEDDING_ENDPOINT_URL": "https://embedding-batch.local",
+        "SEARCH_EMBEDDING_ENDPOINT_URL": "https://embedding-search.local",
         "LOCAL_TRAINING_MODEL_NAME": "BAAI/bge-small-en-v1.5",
         "EMBEDDING_DIMENSION": "384",
         "TRAINING_CONFIG_PATH": "configs/training/smoke.yaml",
@@ -35,6 +36,8 @@ def test_settings_load_required_feedback_loop_configuration(monkeypatch: pytest.
     assert settings.model_artifact_prefix == "model_artifacts/candidates"
     assert settings.model_version_prefix == "bge-m3"
     assert settings.serving_model_artifact_prefix == "models"
+    assert settings.batch_embedding_endpoint_url == "https://embedding-batch.local"
+    assert settings.search_embedding_endpoint_url == "https://embedding-search.local"
     assert settings.embedding_dimension == 384
     assert settings.worker_concurrency == 1
     assert settings.dataset_batch_size == 500

--- a/services/managed-embedding-endpoint/src/services/model_reloader.py
+++ b/services/managed-embedding-endpoint/src/services/model_reloader.py
@@ -1,3 +1,11 @@
+'''
+DB의 model_release에 적힌 버전대로, 이 VM 자신의 메모리 상태를 직접 맞추는 역할.
+
+- 이미 메모리에 있으면 다시 안 받고 그대로 재사용 (134~136행)
+- 없으면 GCS에서 받아서 새로 로드 (141~142행)
+- 더 이상 필요 없어진 옛 버전은 로드 다 끝난 뒤에 메모리에서 내림 (176~196행)
+'''
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 
@@ -51,7 +59,7 @@ class ModelRuntimeReloader:
     1. model_release 읽음
     2. active/previous/candidate target 목록 만듦
     3. 현재 runtime 목록 가져옴
-    4. target별로 materialize 후 기존 runtime 재사용 또는 새로 load
+    4. 별도 작업 스레드에서 target별로 materialize 후 기존 runtime 재사용 또는 새로 load
     5. RuntimeRegistry를 새 runtime 목록으로 교체
     6. ModelState ready_model_versions 갱신
     7. 더 이상 안 쓰는 runtime close
@@ -67,21 +75,12 @@ class ModelRuntimeReloader:
 
         targets = self._targets_from_release(release)
         current_runtimes = self._runtime_registry.snapshot()
-        new_runtimes: dict[str, EmbeddingRuntime] = {}
-        ready_versions: list[str] = []
-
-        for target in targets:
-            runtime = self._load_or_reuse_runtime(
-                target,
-                current_runtimes,
-                trace_id,
-            )
-            if runtime is None:
-                continue
-            if target.model_version in new_runtimes:
-                continue
-            new_runtimes[target.model_version] = runtime
-            ready_versions.append(target.model_version)
+        new_runtimes, ready_versions = await asyncio.to_thread(
+            self._load_target_runtimes,
+            targets,
+            current_runtimes,
+            trace_id,
+        )
 
         previous_runtimes = self._runtime_registry.replace(new_runtimes)
         self._model_state.replace_ready_versions(ready_versions)
@@ -93,6 +92,26 @@ class ModelRuntimeReloader:
             trace_id=trace_id,
         )
         return ReloadResult(ready_model_versions=ready_versions)
+
+    def _load_target_runtimes(
+        self,
+        targets: list[_ReloadTarget],
+        current_runtimes: dict[str, EmbeddingRuntime],
+        trace_id: str | None,
+    ) -> tuple[dict[str, EmbeddingRuntime], list[str]]:
+        new_runtimes: dict[str, EmbeddingRuntime] = {}
+        ready_versions: list[str] = []
+        for target in targets:
+            runtime = self._load_or_reuse_runtime(
+                target,
+                current_runtimes,
+                trace_id,
+            )
+            if runtime is None or target.model_version in new_runtimes:
+                continue
+            new_runtimes[target.model_version] = runtime
+            ready_versions.append(target.model_version)
+        return new_runtimes, ready_versions
 
     def _targets_from_release(
         self,

--- a/services/managed-embedding-endpoint/tests/unit/test_model_runtime_reloader.py
+++ b/services/managed-embedding-endpoint/tests/unit/test_model_runtime_reloader.py
@@ -1,6 +1,8 @@
+import asyncio
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
+from time import sleep
 
 import pytest
 
@@ -60,6 +62,15 @@ class _FakeMaterializer:
     def materialize(self, model_version: str) -> str:
         self.calls.append(model_version)
         return self._paths_by_version[model_version]
+
+
+class _SlowMaterializer:
+    def __init__(self, artifact_path: str) -> None:
+        self._artifact_path = artifact_path
+
+    def materialize(self, model_version: str) -> str:
+        sleep(0.05)
+        return self._artifact_path
 
 
 @dataclass(slots=True)
@@ -129,6 +140,43 @@ def _reloader_with_materializer(
 
 
 class TestModelRuntimeReloader:
+    async def test_keeps_existing_runtime_available_while_loading(
+        self,
+        tmp_path: Path,
+    ):
+        root = tmp_path / "models"
+        materialized_path = root / "active-v2"
+        settings = Settings(
+            MODEL_ARTIFACT_PATH=str(root / "active-v1"),
+            MODEL_ARTIFACT_ROOT=str(root),
+        )
+        state = ModelState()
+        state.replace_ready_versions(["active-v1"])
+        registry = RuntimeRegistry()
+        registry.replace({"active-v1": _StubRuntime(1.0)})
+        materializer = _SlowMaterializer(str(materialized_path))
+        reloader = ModelRuntimeReloader(
+            settings=settings,
+            model_state=state,
+            runtime_registry=registry,
+            release_repository=_FakeReleaseRepository(
+                ModelReleaseSnapshot(active_model_version="active-v2")
+            ),
+            loader_factory=_LoaderFactory({str(materialized_path): 2.0}, set()),
+            artifact_materializer=materializer,
+        )
+
+        reload_task = asyncio.create_task(reloader.reload(trace_id="trace-1"))
+        await asyncio.sleep(0.01)
+        assert registry.get("active-v1").encode(["x"]) == [[1.0]]
+        assert state.ready_model_versions == ["active-v1"]
+
+        result = await reload_task
+
+        assert result.ready_model_versions == ["active-v2"]
+        assert registry.get("active-v2").encode(["x"]) == [[2.0]]
+        assert registry.get("active-v1") is None
+
     async def test_materializes_model_version_before_loading(self, tmp_path: Path):
         snapshot = ModelReleaseSnapshot(active_model_version="active-v2")
         reloader, materializer = _reloader_with_materializer(

--- a/services/search-service/src/common/observability.py
+++ b/services/search-service/src/common/observability.py
@@ -1,0 +1,33 @@
+"""검색 로그에 매번 같이 붙는 ID 4개(trace_id, req_id, user_id, project_id) 모음.
+
+나중에 이 ID로 로그를 검색하면, 검색 한 건에 대한 모든 로그를 한 번에 모아볼 수 있다.
+검색 결과를 결정하는 데는 쓰지 않는다.
+"""
+
+from dataclasses import dataclass
+from time import perf_counter
+from uuid import UUID
+
+_MS_PER_SECOND = 1000
+_MS_DECIMALS = 1
+
+
+@dataclass(frozen=True, slots=True)
+class SearchRequestContext:
+    trace_id: str
+    req_id: UUID
+    user_id: UUID
+    project_id: UUID
+
+    def as_log_fields(self) -> dict[str, str]:
+        return {
+            "trace_id": self.trace_id,
+            "req_id": str(self.req_id),
+            "user_id": str(self.user_id),
+            "project_id": str(self.project_id),
+        }
+
+
+def elapsed_ms(started_at: float) -> float:
+    """Milliseconds since a `perf_counter()` reading, rounded for logging."""
+    return round((perf_counter() - started_at) * _MS_PER_SECOND, _MS_DECIMALS)

--- a/services/search-service/src/infra/db/search_repository.py
+++ b/services/search-service/src/infra/db/search_repository.py
@@ -5,12 +5,17 @@ Provides: corpus readiness check, FTS, ANN, SOT gate, SearchResponseSnapshot sin
 
 from dataclasses import dataclass
 from datetime import datetime
+from time import perf_counter
+from typing import Literal
 from uuid import UUID
 
 from sqlalchemy import exists, not_, select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 from sqlalchemy.orm import aliased
 
+from src.common.logging import info as log_info
+from src.common.logging import warning as log_warning
+from src.common.observability import SearchRequestContext, elapsed_ms
 from src.infra.db.models import (
     ChunkModel,
     ModelReleaseModel,
@@ -21,6 +26,63 @@ from src.infra.db.models import (
 )
 
 DEFAULT_VECTOR_INDEX_NAME = "default-index"
+
+DB_CONNECTION_ACQUIRE_LOG = "search.db_connection_acquire"
+
+DbOperation = Literal[
+    "readiness",
+    "fts",
+    "ann",
+    "sot_gate",
+    "snapshot",
+    "conversation",
+]
+
+
+async def _acquire_connection_for_observation(
+    session: AsyncSession,
+    *,
+    request_context: SearchRequestContext | None,
+    db_operation: DbOperation,
+    target_role: str | None = None,
+    model_version: str | None = None,
+    index_name: str | None = None,
+) -> None:
+    """Take the DB connection early so the wait can be timed on its own.
+
+    Without a request context this is a no-op, keeping the original lazy
+    connection behaviour for direct callers such as startup and tests.
+    The measured span covers pool queue wait plus `pool_pre_ping` and any
+    stale-connection reconnect, so it is not pure queue wait time.
+    """
+    if request_context is None:
+        return
+
+    fields: dict[str, object] = {
+        **request_context.as_log_fields(),
+        "db_operation": db_operation,
+        "target_role": target_role,
+        "model_version": model_version,
+        "index_name": index_name,
+    }
+    started_at = perf_counter()
+    try:
+        await session.connection()
+    except Exception as exc:
+        log_warning(
+            DB_CONNECTION_ACQUIRE_LOG,
+            **fields,
+            status="failed",
+            db_connection_acquire_ms=elapsed_ms(started_at),
+            error_type=type(exc).__name__,
+        )
+        raise
+    log_info(
+        DB_CONNECTION_ACQUIRE_LOG,
+        **fields,
+        status="success",
+        db_connection_acquire_ms=elapsed_ms(started_at),
+    )
 
 
 PROJECT_SERVING_GATE_SQL = """
@@ -168,7 +230,11 @@ class SearchRepository:
 
 
     async def check_corpus_readiness(
-        self, user_id: UUID, project_id: UUID
+        self,
+        user_id: UUID,
+        project_id: UUID,
+        *,
+        request_context: SearchRequestContext | None = None,
     ) -> CorpusReadiness:
         """Single-project readiness check: total video count + non-ready count."""
         async with self._session_factory() as session:
@@ -182,6 +248,11 @@ class SearchRepository:
                   AND v.project_id = :project_id
                   AND p.lifecycle_state = 'ACTIVE'
             """)
+            await _acquire_connection_for_observation(
+                session,
+                request_context=request_context,
+                db_operation="readiness",
+            )
             result = await session.execute(
                 stmt, {"user_id": user_id, "project_id": project_id}
             )
@@ -192,7 +263,13 @@ class SearchRepository:
             )
 
     async def fts_search(
-        self, user_id: UUID, project_id: UUID, query: str, *, top_k: int
+        self,
+        user_id: UUID,
+        project_id: UUID,
+        query: str,
+        *,
+        top_k: int,
+        request_context: SearchRequestContext | None = None,
     ) -> list[FTSCandidate]:
         """FTS keyword search on chunk text with user tenancy via video join.
 
@@ -223,6 +300,11 @@ class SearchRepository:
                 ORDER BY rank
                 LIMIT :top_k
             """)
+            await _acquire_connection_for_observation(
+                session,
+                request_context=request_context,
+                db_operation="fts",
+            )
             result = await session.execute(
                 stmt,
                 {
@@ -245,6 +327,9 @@ class SearchRepository:
         index_name: str = DEFAULT_VECTOR_INDEX_NAME,
         *,
         top_k: int,
+        request_context: SearchRequestContext | None = None,
+        target_role: str | None = None,
+        model_version: str | None = None,
     ) -> list[ANNCandidate]:
         """ANN vector search on vector_index_entry with READY video filter.
 
@@ -271,6 +356,14 @@ class SearchRepository:
                 ORDER BY vie.embedding_vector <=> CAST(:query_embedding AS vector)
                 LIMIT :top_k
             """)
+            await _acquire_connection_for_observation(
+                session,
+                request_context=request_context,
+                db_operation="ann",
+                target_role=target_role,
+                model_version=model_version,
+                index_name=index_name,
+            )
             result = await session.execute(
                 stmt,
                 {
@@ -287,7 +380,12 @@ class SearchRepository:
             ]
 
     async def sot_gate(
-        self, user_id: UUID, project_id: UUID, chunk_ids: list[UUID]
+        self,
+        user_id: UUID,
+        project_id: UUID,
+        chunk_ids: list[UUID],
+        *,
+        request_context: SearchRequestContext | None = None,
     ) -> list[ChunkRecord]:
         """SOT serving gate: verify chunks belong to a servable READY project.
 
@@ -325,6 +423,11 @@ class SearchRepository:
                     ),
                 )
             )
+            await _acquire_connection_for_observation(
+                session,
+                request_context=request_context,
+                db_operation="sot_gate",
+            )
             result = await session.execute(stmt)
             return [
                 ChunkRecord(
@@ -340,7 +443,10 @@ class SearchRepository:
             ]
 
     async def save_search_response_snapshot(
-        self, snapshot: SearchResponseSnapshotWrite
+        self,
+        snapshot: SearchResponseSnapshotWrite,
+        *,
+        request_context: SearchRequestContext | None = None,
     ) -> None:
         """Persist search response context for later feedback attribution."""
         async with self._session_factory() as session:
@@ -360,10 +466,18 @@ class SearchRepository:
                     expires_at=snapshot.expires_at,
                 )
             )
+            await _acquire_connection_for_observation(
+                session,
+                request_context=request_context,
+                db_operation="snapshot",
+            )
             await session.commit()
 
     async def save_conversation(
-        self, conversation: SearchConversationWrite
+        self,
+        conversation: SearchConversationWrite,
+        *,
+        request_context: SearchRequestContext | None = None,
     ) -> None:
         """Persist a frozen project search conversation turn."""
         async with self._session_factory() as session:
@@ -376,6 +490,11 @@ class SearchRepository:
                     answer=conversation.answer,
                     sources=conversation.sources,
                 )
+            )
+            await _acquire_connection_for_observation(
+                session,
+                request_context=request_context,
+                db_operation="conversation",
             )
             await session.commit()
 

--- a/services/search-service/src/services/search_observability.py
+++ b/services/search-service/src/services/search_observability.py
@@ -1,0 +1,114 @@
+"""검색 한 번의 단계별 시간을 기록한다.
+
+  `SearchOrchestrator.execute()` 한 번이 실행되는 동안 각 단계의 경과 시간을 모으고,
+  마지막에 `search.execute.timing` 로그를 정확히 한 건 남긴다.
+  `measure()`는 감싼 코드에서 발생한 예외를 기록한 뒤 그대로 다시 발생시키므로, 검색 결과나 기존 오류 처리에는 영향을 주지 않는다.
+"""
+
+from collections.abc import Generator
+from contextlib import contextmanager
+from time import perf_counter
+from typing import Literal
+
+from src.common.logging import info as log_info
+from src.common.observability import SearchRequestContext, elapsed_ms
+from src.middlewares.error_handler import ApiError
+
+EXECUTE_TIMING_LOG = "search.execute.timing"
+
+TimingStage = Literal[
+    "query_embedding",
+    "query_embedding_active",
+    "query_embedding_previous",
+    "fts",
+    "vector_search",
+    "vector_search_active",
+    "vector_search_previous",
+    "sot_gate",
+    "prompt_build",
+    "llm",
+    "snapshot_save",
+]
+
+SearchStatus = Literal["success", "empty", "failed"]
+
+QUERY_EMBEDDING_STAGES: dict[str, TimingStage] = {
+    "active": "query_embedding_active",
+    "previous": "query_embedding_previous",
+}
+
+VECTOR_SEARCH_STAGES: dict[str, TimingStage] = {
+    "active": "vector_search_active",
+    "previous": "vector_search_previous",
+}
+
+
+def _error_fields(error: BaseException) -> dict[str, str]:
+    """Stable error identity only. Exception messages are never logged."""
+    if isinstance(error, ApiError):
+        return {"error_code": error.code}
+    return {"error_type": type(error).__name__} # 예외가 들어왔을 때 해당 에러 클래스의 이름만 반환
+
+
+class SearchTimingRecorder:
+    def __init__(self, context: SearchRequestContext) -> None:
+        self._context = context
+        self._started_at = perf_counter() # 전체 시작 시간
+        self._stage_ms: dict[str, float] = {} #  # 단계별 시간 저장 목적
+        self._failed_stage: str | None = None
+        self._target_count: int | None = None # # active/previous 몇 개 쓰는지
+        self._logged = False
+
+    @contextmanager
+    def measure(self, stage: TimingStage) -> Generator[None, None, None]:
+        """Record elapsed time for `stage`, including on failure or cancel."""
+        stage_started_at = perf_counter()
+        try:
+            yield
+        except BaseException:
+            self._mark_failed_stage(stage)
+            raise
+        finally:
+            self._stage_ms[f"{stage}_ms"] = elapsed_ms(stage_started_at)
+
+    def set_target_count(self, target_count: int) -> None:
+        self._target_count = target_count
+
+    def log_success(self) -> None:
+        self._log("success")
+
+    def log_empty(self) -> None:
+        self._log("empty")
+
+    def log_failure(self, error: BaseException) -> None:
+        self._log("failed", error)
+
+    def _mark_failed_stage(self, stage: TimingStage) -> None:
+        """Keep the innermost stage that failed first."""
+        if self._failed_stage is None:
+            self._failed_stage = stage
+
+    def _log(self, status: SearchStatus, error: BaseException | None = None) -> None:
+        if self._logged:
+            return
+        self._logged = True
+        log_info(EXECUTE_TIMING_LOG, **self._log_fields(status, error))
+
+    def _log_fields(
+        self,
+        status: SearchStatus,
+        error: BaseException | None,
+    ) -> dict[str, object]:
+        fields: dict[str, object] = {
+            **self._context.as_log_fields(),
+            "status": status,
+        }
+        if error is not None:
+            fields.update(_error_fields(error))
+        if self._failed_stage is not None:
+            fields["failed_stage"] = self._failed_stage
+        if self._target_count is not None:
+            fields["target_count"] = self._target_count
+        fields.update(self._stage_ms)
+        fields["total_ms"] = elapsed_ms(self._started_at)
+        return fields

--- a/services/search-service/src/services/search_orchestrator.py
+++ b/services/search-service/src/services/search_orchestrator.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 from uuid import UUID, uuid4
 
 from src.common.logging import warning as log_warning
+from src.common.observability import SearchRequestContext
 from src.infra.db.search_repository import (
     ANNCandidate,
     ChunkRecord,
@@ -29,6 +30,11 @@ from src.services.prompt_builder import (
     build_user_prompt,
 )
 from src.services.rrf import RRFCandidate, rrf_merge
+from src.services.search_observability import (
+    QUERY_EMBEDDING_STAGES,
+    VECTOR_SEARCH_STAGES,
+    SearchTimingRecorder,
+)
 from src.services.serving_targets import ServingSearchTargetProvider
 from src.services.used_refs_parser import (
     count_answer_blocks,
@@ -47,8 +53,17 @@ class SearchResult:
 # Query embedding이 검색해야 할 model/index target
 @dataclass(frozen=True, slots=True)
 class _TargetQueryEmbedding:
+    role: str
     target: ServingSearchTarget
     embedding: list[float] # 질문쿼리
+
+
+# LLM 호출 입력과 ref 상한 계산에 쓰이는 context 개수
+@dataclass(frozen=True, slots=True)
+class _LLMPrompt:
+    system: str
+    user: str
+    context_count: int
 
 
 def _empty_result(req_id: UUID) -> SearchResult:
@@ -85,142 +100,207 @@ class SearchOrchestrator:
         query: str,
         trace_id: str,
     ) -> SearchResult:
-        req_id = uuid4()
-
-        readiness = await self._repo.check_corpus_readiness(user_id, project_id)
-        if readiness.total_videos == 0:
-            raise NoVideosUploadedError()
-        if readiness.non_ready_count > 0:
-            raise SearchNotReadyError()
-
-        targets, fts_results, ann_results = await self._retrieve_once(
+        context = SearchRequestContext(
+            trace_id=trace_id,
+            req_id=uuid4(),
             user_id=user_id,
             project_id=project_id,
-            query=query,
-            trace_id=trace_id,
         )
-
-        merged = self._merge(fts_results, ann_results)
-        if not merged:
-            return await self._empty_result_with_conversation(
-                req_id=req_id,
-                user_id=user_id,
-                project_id=project_id,
-                query=query,
-                trace_id=trace_id,
+        timings = SearchTimingRecorder(context)
+        try:
+            result = await self._execute_measured(
+                context=context, query=query, timings=timings
             )
+        except BaseException as exc:
+            timings.log_failure(exc)
+            raise
 
-        records = await self._sot_gate(user_id, project_id, merged)
-        if not records:
-            return await self._empty_result_with_conversation(
-                req_id=req_id,
-                user_id=user_id,
-                project_id=project_id,
-                query=query,
-                trace_id=trace_id,
-            )
-
-        ordered_records = self._order_records(merged, records)
-        chunks = self._build_chunks(ordered_records)
-
-        answer, used_refs = await self._generate_answer(
-            query=query,
-            ordered_records=ordered_records,
-            trace_id=trace_id,
-        )
-        chunks = self._apply_used_refs(chunks, used_refs)
-
-        await self._save_snapshot(
-            req_id=req_id,
-            user_id=user_id,
-            project_id=project_id,
-            query=query,
-            chunks=chunks,
-            targets=targets,
-            trace_id=trace_id,
-        )
-        await self._save_conversation(
-            req_id=req_id,
-            user_id=user_id,
-            project_id=project_id,
-            query=query,
-            answer=answer,
-            chunks=chunks,
-            trace_id=trace_id,
-        )
-
-        return SearchResult(req_id=req_id, answer=answer, chunks=chunks)
+        if result.chunks:
+            timings.log_success()
+        else:
+            timings.log_empty()
+        return result
 
     # ------------------------------------------------------------------
     # Private steps
     # ------------------------------------------------------------------
 
+    async def _execute_measured(
+        self,
+        *,
+        context: SearchRequestContext,
+        query: str,
+        timings: SearchTimingRecorder,
+    ) -> SearchResult:
+        await self._check_readiness(context)
+
+        targets, fts_results, ann_results = await self._retrieve_once(
+            context=context, query=query, timings=timings
+        )
+
+        merged = self._merge(fts_results, ann_results)
+        if not merged:
+            return await self._empty_result_with_conversation(context, query)
+
+        records = await self._sot_gate(context, merged, timings)
+        if not records:
+            return await self._empty_result_with_conversation(context, query)
+
+        ordered_records = self._order_records(merged, records)
+        chunks = self._build_chunks(ordered_records)
+
+        answer, used_refs = await self._generate_answer(
+            context=context,
+            query=query,
+            ordered_records=ordered_records,
+            timings=timings,
+        )
+        chunks = self._apply_used_refs(chunks, used_refs)
+
+        await self._save_snapshot(
+            context=context,
+            query=query,
+            chunks=chunks,
+            targets=targets,
+            timings=timings,
+        )
+        await self._save_conversation(
+            context=context,
+            query=query,
+            answer=answer,
+            chunks=chunks,
+        )
+
+        return SearchResult(req_id=context.req_id, answer=answer, chunks=chunks)
+
+    async def _check_readiness(self, context: SearchRequestContext) -> None:
+        readiness = await self._repo.check_corpus_readiness(
+            context.user_id,
+            context.project_id,
+            request_context=context,
+        )
+        if readiness.total_videos == 0:
+            raise NoVideosUploadedError()
+        if readiness.non_ready_count > 0:
+            raise SearchNotReadyError()
+
     async def _retrieve_once(
         self,
         *,
-        user_id: UUID,
-        project_id: UUID,
+        context: SearchRequestContext,
         query: str,
-        trace_id: str,
+        timings: SearchTimingRecorder,
     ) -> tuple[
         ServingSearchTargets,
         list[FTSCandidate],
         list[ANNCandidate],
     ]:
         targets = self._serving_target_provider.get()
-        target_embeddings = await self._embed_query_targets(query, trace_id, targets)
+        timings.set_target_count(len(targets.target_entries))
+        target_embeddings = await self._embed_query_targets(
+            context, query, targets, timings
+        )
         fts_results, ann_results = await self._retrieve(
-            user_id, project_id, query, target_embeddings
+            context, query, target_embeddings, timings
         )
         return targets, fts_results, ann_results
 
     async def _embed_query_targets(
         self,
+        context: SearchRequestContext,
         query: str,
-        trace_id: str,
         targets: ServingSearchTargets,
+        timings: SearchTimingRecorder,
     ) -> list[_TargetQueryEmbedding]:
-        target_entries = targets.target_entries
-        results = await asyncio.gather(
-            *(
-                self._embedding_client.embed_query(
-                    query,
-                    trace_id=trace_id,
-                    model_version=target.model_version,
+        with timings.measure("query_embedding"):
+            return await asyncio.gather(
+                *(
+                    self._embed_one_target(context, query, role, target, timings)
+                    for role, target in targets.target_entries
                 )
-                for _, target in target_entries
             )
+
+    async def _embed_one_target(
+        self,
+        context: SearchRequestContext,
+        query: str,
+        role: str,
+        target: ServingSearchTarget,
+        timings: SearchTimingRecorder,
+    ) -> _TargetQueryEmbedding:
+        with timings.measure(QUERY_EMBEDDING_STAGES[role]):
+            result = await self._embedding_client.embed_query(
+                query,
+                trace_id=context.trace_id,
+                model_version=target.model_version,
+            )
+        return _TargetQueryEmbedding(
+            role=role, target=target, embedding=result.embedding
         )
-        return [
-            _TargetQueryEmbedding(target=target, embedding=result.embedding)
-            for (_, target), result in zip(target_entries, results, strict=True)
-        ]
 
     async def _retrieve(
         self,
-        user_id: UUID,
-        project_id: UUID,
+        context: SearchRequestContext,
         query: str,
         target_embeddings: list[_TargetQueryEmbedding],
+        timings: SearchTimingRecorder,
     ) -> tuple[list[FTSCandidate], list[ANNCandidate]]:
-        fts_task = self._repo.fts_search(
-            user_id, project_id, query, top_k=self._search_top_k
+        return await asyncio.gather(
+            self._fts_search(context, query, timings),
+            self._vector_search(context, target_embeddings, timings),
         )
-        ann_tasks = [
-            self._repo.ann_search(
-                user_id,
-                project_id,
-                target_embedding.embedding,
-                target_embedding.target.index_name,
+
+    async def _fts_search(
+        self,
+        context: SearchRequestContext,
+        query: str,
+        timings: SearchTimingRecorder,
+    ) -> list[FTSCandidate]:
+        with timings.measure("fts"):
+            return await self._repo.fts_search(
+                context.user_id,
+                context.project_id,
+                query,
                 top_k=self._search_top_k,
+                request_context=context,
             )
-            for target_embedding in target_embeddings
-        ]
-        results = await asyncio.gather(fts_task, *ann_tasks)
+
+    async def _vector_search(
+        self,
+        context: SearchRequestContext,
+        target_embeddings: list[_TargetQueryEmbedding],
+        timings: SearchTimingRecorder,
+    ) -> list[ANNCandidate]:
+        with timings.measure("vector_search"):
+            per_target_results = await asyncio.gather(
+                *(
+                    self._ann_search_one_target(context, target_embedding, timings)
+                    for target_embedding in target_embeddings
+                )
+            )
         ann_results: list[ANNCandidate] = []
-        for result in results[1:]:
+        for result in per_target_results:
             ann_results.extend(result)
-        return results[0], ann_results
+        return ann_results
+
+    async def _ann_search_one_target(
+        self,
+        context: SearchRequestContext,
+        target_embedding: _TargetQueryEmbedding,
+        timings: SearchTimingRecorder,
+    ) -> list[ANNCandidate]:
+        target = target_embedding.target
+        with timings.measure(VECTOR_SEARCH_STAGES[target_embedding.role]):
+            return await self._repo.ann_search(
+                context.user_id,
+                context.project_id,
+                target_embedding.embedding,
+                target.index_name,
+                top_k=self._search_top_k,
+                request_context=context,
+                target_role=target_embedding.role,
+                model_version=target.model_version,
+            )
 
     def _merge(
         self,
@@ -233,12 +313,18 @@ class SearchOrchestrator:
 
     async def _sot_gate(
         self,
-        user_id: UUID,
-        project_id: UUID,
+        context: SearchRequestContext,
         merged: list[RRFCandidate],
+        timings: SearchTimingRecorder,
     ) -> list[ChunkRecord]:
         chunk_ids = [c.chunk_id for c in merged]
-        return await self._repo.sot_gate(user_id, project_id, chunk_ids)
+        with timings.measure("sot_gate"):
+            return await self._repo.sot_gate(
+                context.user_id,
+                context.project_id,
+                chunk_ids,
+                request_context=context,
+            )
 
     @staticmethod
     def _order_records(
@@ -270,31 +356,60 @@ class SearchOrchestrator:
     async def _generate_answer(
         self,
         *,
+        context: SearchRequestContext,
         query: str,
         ordered_records: list[ChunkRecord],
-        trace_id: str,
+        timings: SearchTimingRecorder,
     ) -> tuple[str, list[int]]:
-        contexts = build_context_blocks(ordered_records)
-        system_prompt = build_system_prompt()
-        user_prompt = build_user_prompt(query=query, contexts=contexts)
+        with timings.measure("prompt_build"):
+            prompt = self._build_prompt(query, ordered_records)
 
+        llm_text = await self._call_llm(prompt, context.trace_id, timings)
+        return self._parse_answer(llm_text, prompt.context_count, context.trace_id)
+
+    @staticmethod
+    def _build_prompt(
+        query: str,
+        ordered_records: list[ChunkRecord],
+    ) -> _LLMPrompt:
+        contexts = build_context_blocks(ordered_records)
+        return _LLMPrompt(
+            system=build_system_prompt(),
+            user=build_user_prompt(query=query, contexts=contexts),
+            context_count=len(contexts),
+        )
+
+    async def _call_llm(
+        self,
+        prompt: _LLMPrompt,
+        trace_id: str,
+        timings: SearchTimingRecorder,
+    ) -> str:
         try:
-            llm_result = await self._llm_adapter.generate(
-                system_prompt, user_prompt, trace_id=trace_id
-            )
+            with timings.measure("llm"):
+                llm_result = await self._llm_adapter.generate(
+                    prompt.system, prompt.user, trace_id=trace_id
+                )
         except LLMAdapterError as exc:
             if exc.retryable:
                 raise ServiceUnavailableError(exc.message) from exc
             raise ApiError(exc.message) from exc
+        return llm_result.text
 
-        self._log_answer_fallback_if_needed(llm_result.text, trace_id)
+    def _parse_answer(
+        self,
+        llm_text: str,
+        context_count: int,
+        trace_id: str,
+    ) -> tuple[str, list[int]]:
+        self._log_answer_fallback_if_needed(llm_text, trace_id)
 
         try:
-            answer = extract_answer(llm_result.text)
+            answer = extract_answer(llm_text)
         except ValueError as exc:
             raise ApiError(str(exc)) from exc
 
-        used_refs = parse_used_refs(llm_result.text, max_ref=len(contexts))
+        used_refs = parse_used_refs(llm_text, max_ref=context_count)
         return answer, used_refs
 
     @staticmethod
@@ -326,21 +441,40 @@ class SearchOrchestrator:
     async def _save_snapshot(
         self,
         *,
-        req_id: UUID,
-        user_id: UUID,
-        project_id: UUID,
+        context: SearchRequestContext,
         query: str,
         chunks: list[ChunkResponse],
         targets: ServingSearchTargets,
-        trace_id: str,
+        timings: SearchTimingRecorder,
     ) -> None:
         if not chunks:
             return
 
-        snapshot = SearchResponseSnapshotWrite(
-            req_id=req_id,
-            user_id=user_id,
-            project_id=project_id,
+        with timings.measure("snapshot_save"):
+            snapshot = self._build_snapshot(context, query, chunks, targets)
+            try:
+                await self._repo.save_search_response_snapshot(
+                    snapshot, request_context=context
+                )
+            except Exception as exc:
+                log_warning(
+                    "search.snapshot_write_failed",
+                    trace_id=context.trace_id,
+                    req_id=str(context.req_id),
+                    error=str(exc),
+                )
+
+    def _build_snapshot(
+        self,
+        context: SearchRequestContext,
+        query: str,
+        chunks: list[ChunkResponse],
+        targets: ServingSearchTargets,
+    ) -> SearchResponseSnapshotWrite:
+        return SearchResponseSnapshotWrite(
+            req_id=context.req_id,
+            user_id=context.user_id,
+            project_id=context.project_id,
             query_text=query,
             topk_chunk_ids=[str(chunk.chunk_id) for chunk in chunks],
             used_chunk_ids=[str(chunk.chunk_id) for chunk in chunks if chunk.used],
@@ -350,63 +484,44 @@ class SearchOrchestrator:
             project_serving_state="SERVABLE",
             expires_at=datetime.now(UTC) + timedelta(hours=self._snapshot_ttl_hours),
         )
-        try:
-            await self._repo.save_search_response_snapshot(snapshot)
-        except Exception as exc:
-            log_warning(
-                "search.snapshot_write_failed",
-                trace_id=trace_id,
-                req_id=str(req_id),
-                error=str(exc),
-            )
 
     async def _save_conversation(
         self,
         *,
-        req_id: UUID,
-        user_id: UUID,
-        project_id: UUID,
+        context: SearchRequestContext,
         query: str,
         answer: str,
         chunks: list[ChunkResponse],
-        trace_id: str,
     ) -> None:
         conversation = SearchConversationWrite(
-            req_id=req_id,
-            user_id=user_id,
-            project_id=project_id,
+            req_id=context.req_id,
+            user_id=context.user_id,
+            project_id=context.project_id,
             query=query,
             answer=answer,
             sources=self._conversation_sources(chunks),
         )
         try:
-            await self._repo.save_conversation(conversation)
+            await self._repo.save_conversation(conversation, request_context=context)
         except Exception as exc:
             log_warning(
                 "search.conversation_write_failed",
-                trace_id=trace_id,
-                req_id=str(req_id),
+                trace_id=context.trace_id,
+                req_id=str(context.req_id),
                 error=str(exc),
             )
 
     async def _empty_result_with_conversation(
         self,
-        *,
-        req_id: UUID,
-        user_id: UUID,
-        project_id: UUID,
+        context: SearchRequestContext,
         query: str,
-        trace_id: str,
     ) -> SearchResult:
-        result = _empty_result(req_id)
+        result = _empty_result(context.req_id)
         await self._save_conversation(
-            req_id=req_id,
-            user_id=user_id,
-            project_id=project_id,
+            context=context,
             query=query,
             answer=result.answer,
             chunks=result.chunks,
-            trace_id=trace_id,
         )
         return result
 

--- a/services/search-service/tests/unit/test_search_observability.py
+++ b/services/search-service/tests/unit/test_search_observability.py
@@ -1,0 +1,196 @@
+"""Unit tests for SearchTimingRecorder (stage timing + execute summary log).
+
+Covers: elapsed time on success/failure/cancel, first-failed-stage tracking,
+field contract of `search.execute.timing`, and single-log guarantee.
+"""
+
+import asyncio
+from unittest.mock import patch
+from uuid import uuid4
+
+import pytest
+
+from src.common.observability import SearchRequestContext, elapsed_ms
+from src.middlewares.error_handler import ServiceUnavailableError
+from src.services.search_observability import (
+    EXECUTE_TIMING_LOG,
+    SearchTimingRecorder,
+)
+
+TRACE_ID = str(uuid4())
+REQ_ID = uuid4()
+USER_ID = uuid4()
+PROJECT_ID = uuid4()
+
+
+def _context() -> SearchRequestContext:
+    return SearchRequestContext(
+        trace_id=TRACE_ID,
+        req_id=REQ_ID,
+        user_id=USER_ID,
+        project_id=PROJECT_ID,
+    )
+
+
+def _capture_log(recorder_call) -> dict:
+    with patch("src.services.search_observability.log_info") as log_info:
+        recorder_call()
+    assert log_info.call_args.args[0] == EXECUTE_TIMING_LOG
+    return log_info.call_args.kwargs
+
+
+class TestElapsedMs:
+    def test_returns_float_rounded_to_one_decimal(self) -> None:
+        with patch(
+            "src.common.observability.perf_counter",
+            side_effect=[1.0123456],
+        ):
+            value = elapsed_ms(1.0)
+
+        assert isinstance(value, float)
+        assert value == pytest.approx(12.3)
+
+    def test_is_not_a_formatted_string(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+        with recorder.measure("llm"):
+            pass
+
+        fields = _capture_log(recorder.log_success)
+        assert isinstance(fields["llm_ms"], float)
+        assert isinstance(fields["total_ms"], float)
+
+
+class TestMeasure:
+    def test_records_stage_on_success(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        with recorder.measure("prompt_build"):
+            pass
+
+        fields = _capture_log(recorder.log_success)
+        assert "prompt_build_ms" in fields
+        assert "failed_stage" not in fields
+
+    def test_records_stage_and_reraises_on_exception(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        with pytest.raises(RuntimeError, match="boom"), recorder.measure("fts"):
+            raise RuntimeError("boom")
+
+        fields = _capture_log(recorder.log_success)
+        assert "fts_ms" in fields
+        assert fields["failed_stage"] == "fts"
+
+    async def test_records_stage_and_reraises_on_cancel(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        async def cancelled_stage() -> None:
+            with recorder.measure("llm"):
+                await asyncio.sleep(10)
+
+        task = asyncio.create_task(cancelled_stage())
+        await asyncio.sleep(0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        fields = _capture_log(recorder.log_success)
+        assert "llm_ms" in fields
+        assert fields["failed_stage"] == "llm"
+
+    def test_keeps_innermost_failed_stage(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        with pytest.raises(RuntimeError), recorder.measure(
+            "query_embedding"
+        ), recorder.measure("query_embedding_active"):
+            raise RuntimeError("embedding down")
+
+        fields = _capture_log(recorder.log_success)
+        assert fields["failed_stage"] == "query_embedding_active"
+        assert "query_embedding_ms" in fields
+        assert "query_embedding_active_ms" in fields
+
+    def test_unrun_stages_are_omitted_not_zero(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        with recorder.measure("query_embedding_active"):
+            pass
+
+        fields = _capture_log(recorder.log_success)
+        assert "query_embedding_previous_ms" not in fields
+        assert "llm_ms" not in fields
+
+
+class TestExecuteSummaryLog:
+    def test_always_carries_correlation_and_status(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        fields = _capture_log(recorder.log_success)
+
+        assert fields["trace_id"] == TRACE_ID
+        assert fields["req_id"] == str(REQ_ID)
+        assert fields["user_id"] == str(USER_ID)
+        assert fields["project_id"] == str(PROJECT_ID)
+        assert fields["status"] == "success"
+        assert "total_ms" in fields
+
+    def test_empty_status(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        fields = _capture_log(recorder.log_empty)
+
+        assert fields["status"] == "empty"
+
+    def test_known_api_failure_uses_error_code(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+        error = ServiceUnavailableError("embedding endpoint down")
+
+        fields = _capture_log(lambda: recorder.log_failure(error))
+
+        assert fields["status"] == "failed"
+        assert fields["error_code"] == "SERVICE_UNAVAILABLE"
+        assert "error_type" not in fields
+
+    def test_unknown_failure_uses_error_type(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        fields = _capture_log(lambda: recorder.log_failure(ValueError("bad")))
+
+        assert fields["status"] == "failed"
+        assert fields["error_type"] == "ValueError"
+        assert "error_code" not in fields
+
+    def test_never_logs_exception_message(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+        error = ServiceUnavailableError("embedding endpoint down")
+
+        fields = _capture_log(lambda: recorder.log_failure(error))
+
+        assert "embedding endpoint down" not in str(fields)
+
+    def test_target_count_is_omitted_until_set(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        fields = _capture_log(recorder.log_success)
+
+        assert "target_count" not in fields
+
+    def test_target_count_is_reported_when_set(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+        recorder.set_target_count(2)
+
+        fields = _capture_log(recorder.log_success)
+
+        assert fields["target_count"] == 2
+
+    def test_logs_exactly_once_per_attempt(self) -> None:
+        recorder = SearchTimingRecorder(_context())
+
+        with patch("src.services.search_observability.log_info") as log_info:
+            recorder.log_success()
+            recorder.log_empty()
+            recorder.log_failure(ValueError("late"))
+
+        log_info.assert_called_once()
+        assert log_info.call_args.kwargs["status"] == "success"

--- a/services/search-service/tests/unit/test_search_orchestrator_empty.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_empty.py
@@ -12,6 +12,7 @@ from uuid import UUID, uuid4
 
 import pytest
 
+from src.common.observability import SearchRequestContext
 from src.infra.db.search_repository import (
     ANNCandidate,
     ChunkRecord,
@@ -92,6 +93,11 @@ def _make_orchestrator(
         rrf_k=rrf_k,
         snapshot_ttl_hours=snapshot_ttl_hours,
     )
+
+
+def _request_context_of(repo_method) -> SearchRequestContext:
+    """The SearchRequestContext a mocked repository method was called with."""
+    return repo_method.call_args.kwargs["request_context"]
 
 
 def _chunk_record(
@@ -211,18 +217,20 @@ class TestRetrievalFlow:
             fts_results=[FTSCandidate(chunk_id=chunk_id, rank=1)],
             sot_records=[],
         )
-        await orch.execute(
+        result = await orch.execute(
             user_id=USER_ID,
             project_id=PROJECT_ID,
             query="my query",
             trace_id=TRACE_ID,
         )
 
+        context = _request_context_of(orch._repo.fts_search)
+        assert context.req_id == result.req_id
         orch._repo.check_corpus_readiness.assert_called_once_with(
-            USER_ID, PROJECT_ID
+            USER_ID, PROJECT_ID, request_context=context
         )
         orch._repo.fts_search.assert_called_once_with(
-            USER_ID, PROJECT_ID, "my query", top_k=15
+            USER_ID, PROJECT_ID, "my query", top_k=15, request_context=context
         )
         orch._repo.ann_search.assert_called_once()
         ann_args = orch._repo.ann_search.call_args
@@ -243,7 +251,11 @@ class TestRetrievalFlow:
         )
 
         orch._repo.fts_search.assert_called_once_with(
-            USER_ID, PROJECT_ID, "my query", top_k=15
+            USER_ID,
+            PROJECT_ID,
+            "my query",
+            top_k=15,
+            request_context=_request_context_of(orch._repo.fts_search),
         )
         orch._repo.ann_search.assert_called_once()
         call_args = orch._repo.ann_search.call_args

--- a/services/search-service/tests/unit/test_search_orchestrator_observability.py
+++ b/services/search-service/tests/unit/test_search_orchestrator_observability.py
@@ -1,0 +1,389 @@
+"""Unit tests for SearchOrchestrator observability wiring.
+
+Covers: exactly one `search.execute.timing` per attempt, stage fields for
+success / empty / failure, active vs previous split, correlation reuse across
+every DB call, and preserved parallelism of FTS/ANN.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.common.observability import SearchRequestContext
+from src.infra.db.search_repository import (
+    ANNCandidate,
+    ChunkRecord,
+    CorpusReadiness,
+    FTSCandidate,
+    SearchRepository,
+    ServingSearchTarget,
+    ServingSearchTargets,
+)
+from src.infra.embedding.client import EmbeddingClient, EmbeddingResult
+from src.infra.llm.base import LLMAdapter, LLMAdapterError, LLMGenerationResult
+from src.middlewares.error_handler import (
+    ApiError,
+    SearchNotReadyError,
+    ServiceUnavailableError,
+)
+from src.services.search_observability import EXECUTE_TIMING_LOG
+from src.services.search_orchestrator import SearchOrchestrator
+from src.services.serving_targets import ServingSearchTargetProvider
+
+USER_ID = uuid4()
+PROJECT_ID = uuid4()
+TRACE_ID = str(uuid4())
+
+ANSWER_TEXT = (
+    "<ANSWER>mock answer</ANSWER>"
+    '<USED_REFS_JSON>{"used_refs":[1]}</USED_REFS_JSON>'
+)
+
+ACTIVE_ONLY = ServingSearchTargets(
+    active=ServingSearchTarget(
+        model_version="embedding-v2", index_name="active-index-v2"
+    )
+)
+
+ACTIVE_AND_PREVIOUS = ServingSearchTargets(
+    active=ServingSearchTarget(
+        model_version="embedding-v2", index_name="active-index-v2"
+    ),
+    previous=ServingSearchTarget(
+        model_version="embedding-v1", index_name="previous-index-v1"
+    ),
+)
+
+
+def _chunk_record(chunk_id=None) -> ChunkRecord:
+    return ChunkRecord(
+        chunk_id=chunk_id or uuid4(),
+        video_id=uuid4(),
+        title="Video",
+        text="text",
+        enriched_text="enriched",
+        start_ms=0,
+        end_ms=5000,
+    )
+
+
+def _make_orchestrator(
+    *,
+    total_videos: int = 1,
+    non_ready_count: int = 0,
+    fts_results: list[FTSCandidate] | None = None,
+    ann_results: list[ANNCandidate] | None = None,
+    sot_records: list[ChunkRecord] | None = None,
+    llm_text: str = ANSWER_TEXT,
+    llm_error: LLMAdapterError | None = None,
+    targets: ServingSearchTargets = ACTIVE_ONLY,
+) -> SearchOrchestrator:
+    repo = AsyncMock(spec=SearchRepository)
+    repo.check_corpus_readiness.return_value = CorpusReadiness(
+        total_videos=total_videos, non_ready_count=non_ready_count
+    )
+    repo.fts_search.return_value = fts_results or []
+    repo.ann_search.return_value = ann_results or []
+    repo.sot_gate.return_value = sot_records or []
+    repo.save_search_response_snapshot = AsyncMock()
+    repo.save_conversation = AsyncMock()
+
+    embedding_client = AsyncMock(spec=EmbeddingClient)
+    embedding_client.embed_query.return_value = EmbeddingResult(
+        embedding=[0.1, 0.2, 0.3]
+    )
+
+    llm_adapter = AsyncMock(spec=LLMAdapter)
+    if llm_error is not None:
+        llm_adapter.generate.side_effect = llm_error
+    else:
+        llm_adapter.generate.return_value = LLMGenerationResult(text=llm_text)
+
+    return SearchOrchestrator(
+        repo=repo,
+        serving_target_provider=ServingSearchTargetProvider(
+            repo, loaded_targets=targets
+        ),
+        embedding_client=embedding_client,
+        llm_adapter=llm_adapter,
+    )
+
+
+def _with_one_hit(**kwargs) -> SearchOrchestrator:
+    """Orchestrator whose pipeline reaches the LLM with a single chunk."""
+    chunk_id = uuid4()
+    return _make_orchestrator(
+        fts_results=[FTSCandidate(chunk_id=chunk_id, rank=1)],
+        sot_records=[_chunk_record(chunk_id=chunk_id)],
+        **kwargs,
+    )
+
+
+async def _run_and_capture(orch: SearchOrchestrator, *, expected_error=None) -> dict:
+    """Execute one search and return the `search.execute.timing` fields."""
+    with patch("src.services.search_observability.log_info") as log_info:
+        if expected_error is None:
+            await orch.execute(
+                user_id=USER_ID,
+                project_id=PROJECT_ID,
+                query="my query",
+                trace_id=TRACE_ID,
+            )
+        else:
+            with pytest.raises(expected_error):
+                await orch.execute(
+                    user_id=USER_ID,
+                    project_id=PROJECT_ID,
+                    query="my query",
+                    trace_id=TRACE_ID,
+                )
+
+    log_info.assert_called_once()
+    assert log_info.call_args.args[0] == EXECUTE_TIMING_LOG
+    return log_info.call_args.kwargs
+
+
+class TestSuccessTiming:
+    async def test_records_every_stage_of_a_successful_search(self) -> None:
+        fields = await _run_and_capture(_with_one_hit())
+
+        assert fields["status"] == "success"
+        assert fields["target_count"] == 1
+        for stage in (
+            "query_embedding_ms",
+            "query_embedding_active_ms",
+            "fts_ms",
+            "vector_search_ms",
+            "vector_search_active_ms",
+            "sot_gate_ms",
+            "prompt_build_ms",
+            "llm_ms",
+            "snapshot_save_ms",
+            "total_ms",
+        ):
+            assert isinstance(fields[stage], float), stage
+
+    async def test_active_only_omits_previous_fields(self) -> None:
+        fields = await _run_and_capture(_with_one_hit())
+
+        assert "query_embedding_previous_ms" not in fields
+        assert "vector_search_previous_ms" not in fields
+
+    async def test_previous_target_gets_its_own_fields(self) -> None:
+        fields = await _run_and_capture(_with_one_hit(targets=ACTIVE_AND_PREVIOUS))
+
+        assert fields["target_count"] == 2
+        assert isinstance(fields["query_embedding_previous_ms"], float)
+        assert isinstance(fields["vector_search_previous_ms"], float)
+
+
+class TestEmptyTiming:
+    async def test_no_candidates_logs_empty_without_llm_stages(self) -> None:
+        fields = await _run_and_capture(_make_orchestrator())
+
+        assert fields["status"] == "empty"
+        assert "fts_ms" in fields
+        assert "sot_gate_ms" not in fields
+        assert "llm_ms" not in fields
+
+
+class TestFailureTiming:
+    async def test_readiness_conflict_logs_failure_without_stage_fields(self) -> None:
+        orch = _make_orchestrator(non_ready_count=1)
+
+        fields = await _run_and_capture(orch, expected_error=SearchNotReadyError)
+
+        assert fields["status"] == "failed"
+        assert fields["error_code"] == "SEARCH_NOT_READY"
+        assert "failed_stage" not in fields
+        assert "query_embedding_ms" not in fields
+        assert isinstance(fields["total_ms"], float)
+
+    async def test_active_embedding_503_keeps_partial_timing(self) -> None:
+        orch = _make_orchestrator()
+        orch._embedding_client.embed_query.side_effect = ServiceUnavailableError(
+            "embedding endpoint down"
+        )
+
+        fields = await _run_and_capture(orch, expected_error=ServiceUnavailableError)
+
+        assert fields["status"] == "failed"
+        assert fields["error_code"] == "SERVICE_UNAVAILABLE"
+        assert fields["failed_stage"] == "query_embedding_active"
+        assert isinstance(fields["query_embedding_active_ms"], float)
+        assert isinstance(fields["query_embedding_ms"], float)
+        assert "fts_ms" not in fields
+
+    async def test_fts_failure_names_the_fts_stage(self) -> None:
+        orch = _make_orchestrator()
+        orch._repo.fts_search.side_effect = RuntimeError("fts down")
+
+        fields = await _run_and_capture(orch, expected_error=RuntimeError)
+
+        assert fields["status"] == "failed"
+        assert fields["error_type"] == "RuntimeError"
+        assert fields["failed_stage"] == "fts"
+
+    async def test_retryable_llm_failure_keeps_stages_before_llm(self) -> None:
+        orch = _with_one_hit(
+            llm_error=LLMAdapterError(
+                code="UNAVAILABLE", message="Gemini unavailable", retryable=True
+            )
+        )
+
+        fields = await _run_and_capture(orch, expected_error=ServiceUnavailableError)
+
+        assert fields["status"] == "failed"
+        assert fields["error_code"] == "SERVICE_UNAVAILABLE"
+        assert fields["failed_stage"] == "llm"
+        assert isinstance(fields["prompt_build_ms"], float)
+        assert isinstance(fields["llm_ms"], float)
+        assert "snapshot_save_ms" not in fields
+
+    async def test_missing_answer_block_logs_failure_after_llm(self) -> None:
+        orch = _with_one_hit(
+            llm_text='<USED_REFS_JSON>{"used_refs":[1]}</USED_REFS_JSON>'
+        )
+
+        fields = await _run_and_capture(orch, expected_error=ApiError)
+
+        assert fields["status"] == "failed"
+        assert fields["error_code"] == "INTERNAL_ERROR"
+        assert "failed_stage" not in fields
+        assert isinstance(fields["llm_ms"], float)
+
+
+class TestCorrelation:
+    async def test_every_db_call_shares_one_request_context(self) -> None:
+        orch = _with_one_hit()
+
+        result = await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="my query",
+            trace_id=TRACE_ID,
+        )
+
+        contexts = {
+            call.kwargs["request_context"]
+            for call in (
+                orch._repo.check_corpus_readiness.call_args,
+                orch._repo.fts_search.call_args,
+                orch._repo.ann_search.call_args,
+                orch._repo.sot_gate.call_args,
+                orch._repo.save_search_response_snapshot.call_args,
+                orch._repo.save_conversation.call_args,
+            )
+        }
+
+        assert contexts == {
+            SearchRequestContext(
+                trace_id=TRACE_ID,
+                req_id=result.req_id,
+                user_id=USER_ID,
+                project_id=PROJECT_ID,
+            )
+        }
+
+    async def test_ann_call_carries_target_role_and_model_version(self) -> None:
+        orch = _with_one_hit(targets=ACTIVE_AND_PREVIOUS)
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="my query",
+            trace_id=TRACE_ID,
+        )
+
+        roles = [
+            (call.kwargs["target_role"], call.kwargs["model_version"])
+            for call in orch._repo.ann_search.await_args_list
+        ]
+        assert roles == [("active", "embedding-v2"), ("previous", "embedding-v1")]
+
+
+class TestParallelismPreserved:
+    async def test_fts_and_ann_still_overlap(self) -> None:
+        orch = _make_orchestrator()
+        both_started = asyncio.Event()
+        started = 0
+
+        async def wait_for_sibling(*args, **kwargs):
+            del args, kwargs
+            nonlocal started
+            started += 1
+            if started == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=0.5)
+            return []
+
+        orch._repo.fts_search.side_effect = wait_for_sibling
+        orch._repo.ann_search.side_effect = wait_for_sibling
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="my query",
+            trace_id=TRACE_ID,
+        )
+
+        assert both_started.is_set()
+
+    async def test_active_and_previous_ann_still_overlap(self) -> None:
+        orch = _make_orchestrator(targets=ACTIVE_AND_PREVIOUS)
+        both_started = asyncio.Event()
+        started = 0
+
+        async def wait_for_sibling(*args, **kwargs):
+            del args, kwargs
+            nonlocal started
+            started += 1
+            if started == 2:
+                both_started.set()
+            await asyncio.wait_for(both_started.wait(), timeout=0.5)
+            return []
+
+        orch._repo.ann_search.side_effect = wait_for_sibling
+
+        await orch.execute(
+            user_id=USER_ID,
+            project_id=PROJECT_ID,
+            query="my query",
+            trace_id=TRACE_ID,
+        )
+
+        assert both_started.is_set()
+
+
+class TestNoSensitiveContent:
+    async def test_timing_log_excludes_query_prompt_answer_and_chunk_text(
+        self,
+    ) -> None:
+        chunk_id = uuid4()
+        orch = _make_orchestrator(
+            fts_results=[FTSCandidate(chunk_id=chunk_id, rank=1)],
+            sot_records=[_chunk_record(chunk_id=chunk_id)],
+            llm_text=(
+                "<ANSWER>secret answer body</ANSWER>"
+                '<USED_REFS_JSON>{"used_refs":[1]}</USED_REFS_JSON>'
+            ),
+        )
+        orch._embedding_client.embed_query.return_value = EmbeddingResult(
+            embedding=[8.675309]
+        )
+
+        with patch("src.services.search_observability.log_info") as log_info:
+            await orch.execute(
+                user_id=USER_ID,
+                project_id=PROJECT_ID,
+                query="a very private question",
+                trace_id=TRACE_ID,
+            )
+
+        logged = str(log_info.call_args.kwargs)
+        assert "a very private question" not in logged
+        assert "secret answer body" not in logged
+        assert "enriched" not in logged
+        assert "8.675309" not in logged

--- a/services/search-service/tests/unit/test_search_repository_observability.py
+++ b/services/search-service/tests/unit/test_search_repository_observability.py
@@ -1,0 +1,171 @@
+"""Unit tests for the SearchRepository DB connection acquire helper.
+
+Covers: no-op without request context, success/failure logs, exception
+propagation, ANN target metadata, and the measured span boundary.
+"""
+
+from unittest.mock import AsyncMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.common.observability import SearchRequestContext
+from src.infra.db.search_repository import (
+    DB_CONNECTION_ACQUIRE_LOG,
+    _acquire_connection_for_observation,
+)
+
+TRACE_ID = str(uuid4())
+REQ_ID = uuid4()
+USER_ID = uuid4()
+PROJECT_ID = uuid4()
+
+
+def _context() -> SearchRequestContext:
+    return SearchRequestContext(
+        trace_id=TRACE_ID,
+        req_id=REQ_ID,
+        user_id=USER_ID,
+        project_id=PROJECT_ID,
+    )
+
+
+class _FakeClock:
+    """Deterministic `perf_counter` stand-in measured in seconds."""
+
+    def __init__(self) -> None:
+        self._now = 100.0
+
+    def __call__(self) -> float:
+        return self._now
+
+    def advance(self, *, seconds: float) -> None:
+        self._now += seconds
+
+    def advancing_call(self, *, seconds: float):
+        async def _call() -> None:
+            self.advance(seconds=seconds)
+
+        return _call
+
+
+def _session(connection_error: Exception | None = None) -> AsyncMock:
+    session = AsyncMock()
+    if connection_error is not None:
+        session.connection.side_effect = connection_error
+    return session
+
+
+class TestWithoutRequestContext:
+    async def test_does_not_touch_the_connection(self) -> None:
+        session = _session()
+
+        with patch("src.infra.db.search_repository.log_info") as log_info:
+            await _acquire_connection_for_observation(
+                session, request_context=None, db_operation="fts"
+            )
+
+        session.connection.assert_not_awaited()
+        log_info.assert_not_called()
+
+
+class TestSuccess:
+    async def test_acquires_connection_and_logs_info(self) -> None:
+        session = _session()
+
+        with patch("src.infra.db.search_repository.log_info") as log_info:
+            await _acquire_connection_for_observation(
+                session, request_context=_context(), db_operation="readiness"
+            )
+
+        session.connection.assert_awaited_once()
+        assert log_info.call_args.args[0] == DB_CONNECTION_ACQUIRE_LOG
+        fields = log_info.call_args.kwargs
+        assert fields["trace_id"] == TRACE_ID
+        assert fields["req_id"] == str(REQ_ID)
+        assert fields["user_id"] == str(USER_ID)
+        assert fields["project_id"] == str(PROJECT_ID)
+        assert fields["status"] == "success"
+        assert fields["db_operation"] == "readiness"
+        assert isinstance(fields["db_connection_acquire_ms"], float)
+
+    async def test_non_ann_operations_omit_target_metadata(self) -> None:
+        session = _session()
+
+        with patch("src.infra.db.search_repository.log_info") as log_info:
+            await _acquire_connection_for_observation(
+                session, request_context=_context(), db_operation="sot_gate"
+            )
+
+        fields = log_info.call_args.kwargs
+        assert fields["target_role"] is None
+        assert fields["model_version"] is None
+        assert fields["index_name"] is None
+
+    async def test_ann_records_role_model_version_and_index_name(self) -> None:
+        session = _session()
+
+        with patch("src.infra.db.search_repository.log_info") as log_info:
+            await _acquire_connection_for_observation(
+                session,
+                request_context=_context(),
+                db_operation="ann",
+                target_role="previous",
+                model_version="v002",
+                index_name="candidate_v002",
+            )
+
+        fields = log_info.call_args.kwargs
+        assert fields["db_operation"] == "ann"
+        assert fields["target_role"] == "previous"
+        assert fields["model_version"] == "v002"
+        assert fields["index_name"] == "candidate_v002"
+
+    async def test_measures_only_the_connection_call(self) -> None:
+        """The span must cover session.connection() and nothing around it."""
+        clock = _FakeClock()
+        session = AsyncMock()
+        session.connection.side_effect = clock.advancing_call(seconds=0.25)
+
+        clock.advance(seconds=9.0)  # work before the helper must not count
+        with patch("src.common.observability.perf_counter", clock), patch(
+            "src.infra.db.search_repository.perf_counter", clock
+        ), patch("src.infra.db.search_repository.log_info") as log_info:
+            await _acquire_connection_for_observation(
+                session, request_context=_context(), db_operation="fts"
+            )
+
+        assert log_info.call_args.kwargs["db_connection_acquire_ms"] == pytest.approx(
+            250.0
+        )
+
+
+class TestFailure:
+    async def test_logs_warning_and_reraises_original_exception(self) -> None:
+        session = _session(TimeoutError("pool exhausted"))
+
+        with patch(
+            "src.infra.db.search_repository.log_warning"
+        ) as log_warning, pytest.raises(TimeoutError, match="pool exhausted"):
+            await _acquire_connection_for_observation(
+                session, request_context=_context(), db_operation="snapshot"
+            )
+
+        assert log_warning.call_args.args[0] == DB_CONNECTION_ACQUIRE_LOG
+        fields = log_warning.call_args.kwargs
+        assert fields["status"] == "failed"
+        assert fields["db_operation"] == "snapshot"
+        assert fields["error_type"] == "TimeoutError"
+        assert isinstance(fields["db_connection_acquire_ms"], float)
+
+    async def test_never_logs_the_exception_message(self) -> None:
+        session = _session(TimeoutError("pool exhausted"))
+
+        with patch(
+            "src.infra.db.search_repository.log_warning"
+        ) as log_warning, pytest.raises(TimeoutError):
+            await _acquire_connection_for_observation(
+                session, request_context=_context(), db_operation="conversation"
+            )
+
+        assert "pool exhausted" not in str(log_warning.call_args.kwargs)


### PR DESCRIPTION
## 요약

검색 지연이 어느 단계에서 발생하는지 특정할 수 없었고, 영상 임베딩이 검색과 같은
임베딩 서버를 점유해 검색이 503으로 실패하는 문제를 다룬다 (#103).

- base: `refactor/86-2nd-implementation`
- 이슈 #103의 마지막 항목(7/20 동일 조건 재실험)은 GCP 실측으로 완료했다. 결과는
  `2026-07-28-임베딩-VM-분리-재실험-원자료.md` 참고(로컬에만 존재)

## 주요 작업 단위

### 1. 검색 단계별 시간 계측

- search-service: `SearchOrchestrator.execute()` 한 번마다 query embedding(active/previous),
  FTS, vector search(active/previous), SOT gate, prompt build, LLM, snapshot save 단계의
  경과 시간을 모아 `search.execute.timing` 로그 한 건으로 남긴다
- 실패·취소 시에도 어느 단계에서 실패했는지(`failed_stage`)를 기록한다
- DB `session.connection()` 확보 시간도 별도 계측을 추가했다. 이 값은 순수 pool 대기가
  아니라 `pool_pre_ping`과 재접속 시간을 포함할 수 있어 그렇게 해석하지 않는다

### 2. 검색·배치 임베딩 실행 자원 분리

- infra: 기존 단일 임베딩 VM(`10.20.3.14`, 배치 전용)에 검색 전용 VM(`10.20.3.15`)을 추가.
  두 VM 모두 같은 모델(bge-m3)을 적재하고 실행 자원만 분리한다
- `search_embedding_cutover_enabled` 플래그로 검색 VM 생성과 서비스 주소 전환을 별도
  Terraform 적용으로 나눴다. 문제가 생기면 서비스 주소만 기존 배치 VM으로 되돌릴 수 있다
- search-service, feedback-loop-pipeline의 검색 경로 embedding 호출 주소를 검색 VM으로 전환
- feedback-loop-pipeline: 검색 VM 추가로 모델 배포·reload 요청 대상이 하나 늘어난 것을
  readiness 확인과 fan-out에 반영
- managed-embedding-endpoint: 모델 교체(reload) 중 기존 active 런타임을 그대로 서빙하도록
  유지하고, 새 버전 적재가 끝난 뒤에만 교체한다 (교체 중 요청 실패 방지)
- docs: 기존 단일 VM을 두 VM으로 나누는 최초 전환 절차(cutover flag false→true, 준비 확인
  순서)를 런북에 추가

## 측정 결과

gcp-perf에 배포해 7/20과 같은 조건(`CHUNK_MAX_TOKENS=300`, 영상 1건, 검색 8건·2초 간격)으로
재실험했다. 상세 원자료는 `2026-07-28-임베딩-VM-분리-재실험-원자료.md`.

| 항목 | 7/20 기준선 (분리 전) | 이번 실측 (분리 후) |
|---|---:|---:|
| 영상 임베딩 중 검색 503 | 8건 중 1건 | 8건 중 0건 |
| 영상 Pipeline total | 133.066초 | 121.045초 |
| 검색 query embedding inference | 0.414~0.443초 | 0.417~0.431초 |
| video batch inference | 약 20.0초 | 20.794초 |

- 배치 VM의 `video_preprocess` 추론 구간(약 20.8초) 안에 검색 2건이 검색 VM에서 실제로
  처리됐고, 두 건 모두 queue wait 0ms로 성공했다. 같은 구간 배치 VM에는 `lane=search` 0건,
  검색 VM에는 `lane=video_preprocess` 0건으로 실제 분리를 로그로 확인했다
- 검색 성공 응답의 클라이언트 평균은 15.952초로 기준선(3.907초)보다 늘었지만, query
  embedding은 기준선과 같은 범위였고 Search 전체 시간의 96.9%를 LLM 단계가 차지했다.
  이번 지연 악화는 임베딩 VM 경합이 아니라 동시 LLM 요청에서 발생한 것으로, 별도 관측
  대상으로 남긴다

## 검증

- managed-embedding-endpoint 123건
- feedback-loop-pipeline 171건
- search-service 211건
- Terraform validate, Docker Compose config 통과

## 남은 것

- 검색 VM도 슬롯 1개라 동시 검색 5건 이상이면 여전히 503이 날 수 있다. VM별 슬롯 수·
  대기 상한 조정은 부하테스트 결과를 보고 정한다(#104)
- `/health`가 active 버전이 아닌 아무 모델 하나만 ready여도 200을 반환하는 문제는 이번
  범위에 포함하지 않았다
- 우선순위 큐(lane 기반 대기 순서 선택) 로직은 두 VM 분리 후에는 각 VM에 요청이 한
  종류만 오므로 정상 배선에서는 발동하지 않는다. cutover 플래그로 단일 VM 상태로 되돌릴
  때만 의미가 있어 남겨뒀다

## 이슈

Closes #103 
